### PR TITLE
Add lineNumber and columnNumber to SyntaxErrors

### DIFF
--- a/src/syntax/errors.js
+++ b/src/syntax/errors.js
@@ -1,3 +1,10 @@
+export function error(ps, message) {
+  const err = new SyntaxError(message);
+  err.lineNumber = ps.getLineNumber();
+  err.columnNumber = ps.getColumnNumber();
+  return err;
+}
+
 export function getErrorSlice(source, start, end) {
   const len = source.length;
 

--- a/src/syntax/ftlstream.js
+++ b/src/syntax/ftlstream.js
@@ -1,6 +1,7 @@
 /* eslint no-magic-numbers: "off" */
 
 import { ParserStream } from './stream';
+import { error } from './errors.js';
 
 export class FTLParserStream extends ParserStream {
   peekLineWS() {
@@ -42,7 +43,7 @@ export class FTLParserStream extends ParserStream {
       return true;
     }
 
-    throw new Error(`ExpectedToken ${ch}`);
+    throw error(this, `Expected token ${ch}`);
   }
 
   takeCharIf(ch) {
@@ -132,7 +133,7 @@ export class FTLParserStream extends ParserStream {
       this.next();
       return ret;
     }
-    throw new Error('ExpectedCharRange');
+    throw error(this, 'Expected char range');
   }
 
   takeIDChar() {

--- a/src/syntax/parser.js
+++ b/src/syntax/parser.js
@@ -2,7 +2,7 @@
 
 import * as AST from './ast';
 import { FTLParserStream } from './ftlstream';
-import { getErrorSlice } from './errors';
+import { error, getErrorSlice } from './errors';
 
 export function parse(source) {
   const errors = [];
@@ -53,7 +53,7 @@ function getEntry(ps) {
   if (comment) {
     return comment;
   }
-  throw Error('ExpectedEntry');
+  throw error(ps, 'Expected entry');
 }
 
 function getComment(ps) {
@@ -121,7 +121,7 @@ function getMessage(ps, comment) {
   }
 
   if (pattern === undefined && attrs === undefined) {
-    throw new Error('MissingField');
+    throw error(ps, 'Missing field');
   }
 
   return new AST.Message(id, pattern, attrs, comment);
@@ -147,7 +147,7 @@ function getAttributes(ps) {
     const value = getPattern(ps);
 
     if (value === undefined) {
-      throw new Error('ExpectedField');
+      throw error(ps, 'Expected field');
     }
 
     attrs.push(new AST.Attribute(key, value));
@@ -176,7 +176,7 @@ function getVariantKey(ps) {
   const ch = ps.current();
 
   if (!ch) {
-    throw new Error('Expected VariantKey');
+    throw error(ps, 'Expected VariantKey');
   }
 
   const cc = ch.charCodeAt(0);
@@ -215,7 +215,7 @@ function getVariants(ps) {
     const value = getPattern(ps);
 
     if (!value) {
-      throw new Error('ExpectedField');
+      throw error(ps, 'Expected field');
     }
 
     variants.push(new AST.Variant(key, value, defaultIndex));
@@ -226,7 +226,7 @@ function getVariants(ps) {
   }
 
   if (!hasDefault) {
-    throw new Error('MissingDefaultVariant');
+    throw error(ps, 'Missing default variant');
   }
 
   return variants;
@@ -258,7 +258,7 @@ function getDigits(ps) {
   }
 
   if (num.length === 0) {
-    throw new Error('ExpectedCharRange');
+    throw error(ps, 'Expected char range');
   }
 
   return num;
@@ -300,7 +300,7 @@ function getPattern(ps) {
   while ((ch = ps.current())) {
     if (ch === '\n') {
       if (quoteDelimited) {
-        throw new Error('ExpectedToken');
+        throw error(ps, 'Expected roken');
       }
 
       if (firstLine && buffer.length !== 0) {
@@ -325,7 +325,7 @@ function getPattern(ps) {
         }
       } else {
         if (isIndented && !ps.takeCharIf(' ')) {
-          throw new Error('Generic');
+          throw error(ps, 'Generic');
         }
       }
 
@@ -402,7 +402,7 @@ function getExpression(ps) {
       const variants = getVariants(ps);
 
       if (variants.length === 0) {
-        throw new Error('MissingVariants');
+        throw error(ps, 'Missing variants');
       }
 
       ps.expectChar('\n');
@@ -469,7 +469,7 @@ function getCallArgs(ps) {
 
     if (ps.current() === ':') {
       if (exp.type !== 'MessageReference') {
-        throw new Error('ForbiddenKey');
+        throw error(ps, 'Forbidden key');
       }
 
       ps.next();
@@ -501,7 +501,7 @@ function getArgVal(ps) {
   } else if (ps.currentIs('"')) {
     return getString(ps);
   }
-  throw new Error('ExpectedField');
+  throw error(ps, 'Expected field');
 }
 
 function getString(ps) {
@@ -524,7 +524,7 @@ function getLiteral(ps) {
   const ch = ps.current();
 
   if (!ch) {
-    throw new Error('Expected literal');
+    throw error(ps, 'Expected literal');
   }
 
   if (ps.isNumberStart()) {

--- a/src/syntax/stream.js
+++ b/src/syntax/stream.js
@@ -1,5 +1,6 @@
 export class ParserStream {
   constructor(string) {
+    this.string = string;
     this.iter = string[Symbol.iterator]();
     this.buf = [];
     this.peekIndex = 0;
@@ -83,6 +84,14 @@ export class ParserStream {
 
   getIndex() {
     return this.index;
+  }
+
+  getLineNumber() {
+    return this.string.slice(1, this.index).split('\n').length;
+  }
+
+  getColumnNumber() {
+    return this.index - this.string.lastIndexOf('\n', this.index - 1);
   }
 
   getPeekIndex() {


### PR DESCRIPTION
This PR makes the AST parser produce `SyntaxErrors` annotated with the line and the column numbers. This is modelled after https://developer.mozilla.org/pl/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError#Properties_2.