### PR TITLE
Language Negotiation

### DIFF
--- a/fluent-langneg/.gitignore
+++ b/fluent-langneg/.gitignore
@@ -1,0 +1,2 @@
+fluent-langneg.js
+compat.js

--- a/fluent-langneg/.npmignore
+++ b/fluent-langneg/.npmignore
@@ -1,0 +1,3 @@
+docs
+test
+makefile

--- a/fluent-langneg/CHANGELOG.md
+++ b/fluent-langneg/CHANGELOG.md
@@ -6,6 +6,6 @@
 
 ## fluent-langneg 0.0.1
 
-  - (05d2487c) fluent-langneg 0.0.1
+  - Introduce Language Negotiation module for Fluent
 
     The initial release.

--- a/fluent-langneg/CHANGELOG.md
+++ b/fluent-langneg/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+  - …
+
+## fluent-langneg 0.0.1
+
+  - (05d2487c) fluent-langneg 0.0.1
+
+    The initial release.

--- a/fluent-langneg/README.md
+++ b/fluent-langneg/README.md
@@ -1,0 +1,104 @@
+# fluent-langneg
+
+`fluent-langneg` is an API for negotiating languages. It's part of
+Project Fluent, a localization framework designed to unleash 
+the expressive power of the natural language.
+
+## Installation
+
+`fluent-langneg` can be used both on the client-side and the server-side.
+You can install it from the npm registry or use it as a standalone script.
+
+    npm install fluent-langneg
+
+
+## How to use
+
+```javascript
+import negotiateLanguages from 'fluent-langneg';
+
+const supportedLocales = negotiateLanguages(
+  requestedLocales, availableLocales, defaultLocale
+);
+```
+
+The API reference is available at
+http://projectfluent.io/fluent.js/fluent-langneg.
+
+## Strategies
+
+The API supports three negotiation strategies:
+
+* filtering (defualt)
+
+In this strategy the algorithm will look for the best matching available
+locale for each requested locale.
+
+Example:
+
+requested: ['de-DE', 'fr-FR']
+available: ['it', 'de', 'en-US', 'fr-CA', 'de-DE', 'fr', 'de-AU']
+
+supported: ['de-DE', 'fr']
+
+* matching
+
+In this strategy the algorithm will try to match as many available locales
+as possible for each of the requested locale.
+
+Example:
+
+requested: ['de-DE', 'fr-FR']
+available: ['it', 'de', 'en-US', 'fr-CA', 'de-DE', 'fr', 'de-AU']
+
+supported: ['de-DE', 'de', 'fr', 'fr-CA']
+
+* lookup
+
+In this strategy the algorithm will try to find the single best locale
+for the requested locale list among the available locales.
+
+Example:
+
+requested: ['de-DE', 'fr-FR']
+available: ['it', 'de', 'en-US', 'fr-CA', 'de-DE', 'fr', 'de-AU']
+
+supported: ['de-DE']
+
+API use:
+
+```javascript
+let supported = negotiateLanguages(requested, available, {
+  strategy: 'matching',
+});
+```
+
+## Likely subtags
+
+Fluent Language Negotiation module carries its own minimal list of likely
+subtags data, which is useful in finding most likely available locales
+in case the requested locale is too generic.
+
+An example of that scenario is when the user requests `en` locale, and
+the application supportes `en-GB` and `en-US`.
+
+Unicode CLDR maintains a complete list of likely subtags that the
+user can load into `fluent-langneg` to replace the minimal version.
+
+```javascript
+let data = require('./data/likelySubtags.json');
+
+let supported = negotiateLanguages(requested, available, {
+  likelySubtags: data.supplemental.likelySubtags
+});
+```
+
+## Learn more
+
+Find out more about Project Fluent at [projectfluent.io][], including
+documentation of the Fluent file format ([FTL][]), links to other packages and
+implementations, and information about how to get involved.
+
+
+[projectfluent.io]: http://projectfluent.io
+[FTL]: http://projectfluent.io/fluent/guide/

--- a/fluent-langneg/README.md
+++ b/fluent-langneg/README.md
@@ -29,7 +29,7 @@ http://projectfluent.io/fluent.js/fluent-langneg.
 
 The API supports three negotiation strategies:
 
-* filtering (defualt)
+### filtering (default)
 
 In this strategy the algorithm will look for the best matching available
 locale for each requested locale.
@@ -41,7 +41,7 @@ available: ['it', 'de', 'en-US', 'fr-CA', 'de-DE', 'fr', 'de-AU']
 
 supported: ['de-DE', 'fr']
 
-* matching
+### matching
 
 In this strategy the algorithm will try to match as many available locales
 as possible for each of the requested locale.
@@ -53,7 +53,7 @@ available: ['it', 'de', 'en-US', 'fr-CA', 'de-DE', 'fr', 'de-AU']
 
 supported: ['de-DE', 'de', 'fr', 'fr-CA']
 
-* lookup
+### lookup
 
 In this strategy the algorithm will try to find the single best locale
 for the requested locale list among the available locales.
@@ -65,7 +65,7 @@ available: ['it', 'de', 'en-US', 'fr-CA', 'de-DE', 'fr', 'de-AU']
 
 supported: ['de-DE']
 
-API use:
+### API use:
 
 ```javascript
 let supported = negotiateLanguages(requested, available, {
@@ -86,7 +86,7 @@ Unicode CLDR maintains a complete list of likely subtags that the
 user can load into `fluent-langneg` to replace the minimal version.
 
 ```javascript
-let data = require('./data/likelySubtags.json');
+let data = require('cldr-core/supplemental/likelySubtags.json');
 
 let supported = negotiateLanguages(requested, available, {
   likelySubtags: data.supplemental.likelySubtags

--- a/fluent-langneg/makefile
+++ b/fluent-langneg/makefile
@@ -1,0 +1,23 @@
+PACKAGE := fluent-langneg
+GLOBAL  := FluentLangNeg
+
+include ../common.mk
+
+build: $(PACKAGE).js
+compat: compat.js
+
+$(PACKAGE).js: $(SOURCES)
+	@rollup $(CURDIR)/src/index.js \
+	    --format umd \
+	    --id $(PACKAGE) \
+	    --name $(GLOBAL) \
+	    --output $@
+	@echo -e " $(OK) $@ built"
+
+compat.js: $(PACKAGE).js
+	@babel --presets latest $< > $@
+	@echo -e " $(OK) $@ built"
+
+clean:
+	@rm -f $(PACKAGE).js compat.js
+	@echo -e " $(OK) clean"

--- a/fluent-langneg/package.json
+++ b/fluent-langneg/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "fluent-langneg",
+  "description": "Language Negotiation API for Fluent",
+  "version": "0.0.1",
+  "homepage": "http://projectfluent.io",
+  "author": "Mozilla <l10n-drivers@mozilla.org>",
+  "license": "Apache-2.0",
+  "contributors": [
+    {
+      "name": "Zibi Braniecki",
+      "email": "zbraniecki@mozilla.com"
+    },
+    {
+      "name": "Staś Małolepszy",
+      "email": "stas@mozilla.com"
+    }
+  ],
+  "directories": {
+    "lib": "./src"
+  },
+  "main": "./fluent-langneg.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/projectfluent/fluent.js.git"
+  },
+  "keywords": [
+    "localization",
+    "l10n"
+  ],
+  "engine": {
+    "node": ">=6"
+  }
+}

--- a/fluent-langneg/src/locale.js
+++ b/fluent-langneg/src/locale.js
@@ -1,0 +1,66 @@
+/* eslint no-magic-numbers: 0 */
+
+const languageCodeRe = '([a-z]{2,3}|\\*)';
+const scriptCodeRe = '(?:-([a-z]{4}|\\*))';
+const regionCodeRe = '(?:-([a-z]{2}|\\*))';
+const variantCodeRe = '(?:-([a-z]+|\\*))';
+
+/**
+ * Regular expression splitting locale id into four pieces:
+ *
+ * Example: `en-Latn-US-mac`
+ *
+ * language: en
+ * script:   Latn
+ * region:   US
+ * variant:  mac
+ *
+ * It can also accept a range `*` character on any position.
+ */
+const localeRe = new RegExp(
+`^${languageCodeRe}${scriptCodeRe}?${regionCodeRe}?${variantCodeRe}?$`, 'i');
+
+export const localeParts = ['language', 'script', 'region', 'variant'];
+
+export default class Locale {
+  /**
+   * Parses a locale id using the localeRe into an array with four elements.
+   *
+   * If the second argument `range` is set to true, it places range `*` char
+   * in place of any missing piece.
+   *
+   * It also allows skipping the script section of the id, so `en-US` is
+   * properly parsed as `en-*-US-*`.
+   */
+  constructor(locale, range = false) {
+    const result = localeRe.exec(locale);
+    if (!result) {
+      return;
+    }
+
+    const missing = range ? '*' : undefined;
+
+    const language = result[1] || missing;
+    const script = result[2] || missing;
+    const region = result[3] || missing;
+    const variant = result[4] || missing;
+
+    this.language = language;
+    this.script = script;
+    this.region = region;
+    this.variant = variant;
+  }
+
+  isEqual(locale) {
+    return localeParts.every(part => this[part] === locale[part]);
+  }
+
+  matches(locale) {
+    return localeParts.every(part => {
+      return this[part] === '*' || locale[part] === '*' ||
+        (this[part] === undefined && locale[part] === undefined) ||
+        (this[part] !== undefined && locale[part] !== undefined &&
+        this[part].toLowerCase() === locale[part].toLowerCase());
+    });
+  }
+}

--- a/fluent-langneg/src/matches.js
+++ b/fluent-langneg/src/matches.js
@@ -1,0 +1,210 @@
+/* eslint no-magic-numbers: 0 */
+/* eslint complexity: ["error", { "max": 22 }] */
+
+import Locale from './locale';
+import { getLikelySubtagsMin } from './subtags';
+
+/**
+ * Attempts to build a most likely maximum version of the locale id based
+ * on it's minimal version.
+ *
+ * If possible it uses the lookup table above. If this one is missing,
+ * it only attempts to place the language code in the region position.
+ */
+function getLikelySubtagsLocale(loc, likelySubtags) {
+  if (likelySubtags) {
+    for (const key of Object.keys(likelySubtags)) {
+      if (key.toLowerCase() === loc.toLowerCase()) {
+        return new Locale(likelySubtags[key]);
+      }
+    }
+    return null;
+  }
+  return getLikelySubtagsMin(loc);
+}
+
+/**
+ * Replaces the region position with a range to allow for matches
+ * with the same language/script but from different region.
+ */
+function regionRangeFor(locale) {
+  locale.region = '*';
+  return locale;
+}
+
+function variantRangeFor(locale) {
+  locale.variant = '*';
+  return locale;
+}
+
+function getOrParseLocaleRange(localeStr, cache) {
+  if (!cache.has(localeStr)) {
+    cache.set(localeStr, new Locale(localeStr, true));
+  }
+  return cache.get(localeStr);
+}
+/**
+ * Negotiates the languages between the list of requested locales against
+ * a list of available locales.
+ *
+ * The algorithm is based on the BCP4647 3.3.2 Extended Filtering algorithm,
+ * with several modifications:
+ *
+ *  1) available locales are treated as ranges
+ *
+ *    This change allows us to match a more specific request against
+ *    more generic available locale.
+ *
+ *    For example, if the available locale list provides locale `en`,
+ *    and the requested locale is `en-US`, we treat the available locale as
+ *    a locale that matches all possible english requests.
+ *
+ *    This means that we expect available locale ID to be as precize as
+ *    the matches they want to cover.
+ *
+ *    For example, if there is only `sr` available, it's ok to list
+ *    it in available locales. But once the available locales has both,
+ *    Cyrl and Latn variants, the locale IDs should be `sr-Cyrl` and `sr-Latn`
+ *    to avoid any `sr-*` request to match against whole `sr` range.
+ *
+ *    What it does ([requested] * [available] = [supported]):
+ *
+ *    ['en-US'] * ['en'] = ['en']
+ *
+ *  2) likely subtags from LDML 4.3 Likely Subtags has been added
+ *
+ *    The most obvious likely subtag that can be computed is a duplication
+ *    of the language field onto region field (`fr` => `fr-FR`).
+ *
+ *    On top of that, likely subtags may use a list of mappings, that
+ *    allow the algorithm to handle non-obvious matches.
+ *    For example, making sure that we match `en` to `en-US` or `sr` to
+ *    `sr-Cyrl`, while `sr-RU` to `sr-Latn-RU`.
+ *
+ *    This list can be taken directly from CLDR Supplemental Data.
+ *
+ *    What it does ([requested] * [available] = [supported]):
+ *
+ *    ['fr'] * ['fr-FR'] = ['fr-FR']
+ *    ['en'] * ['en-US'] = ['en-US']
+ *    ['sr'] * ['sr-Latn', 'sr-Cyrl'] = ['sr-Cyrl']
+ *
+ *  3) variant/region range check has been added
+ *
+ *    Lastly, the last form of check is against the requested locale ID
+ *    but with the variant/region field replaced with a `*` range.
+ *
+ *    The rationale here laid out in LDML 4.4 Language Matching:
+ *      "(...) normally the fall-off between the user's languages is
+ *      substantially greated than regional variants."
+ *
+ *    In other words, if we can't match for the given region, maybe
+ *    we can match for the same language/script but other region, and
+ *    it will in most cases be preferred over falling back on the next
+ *    language.
+ *
+ *    What it does ([requested] * [available] = [supported]):
+ *
+ *    ['en-AU'] * ['en-US'] = ['en-US']
+ *    ['sr-RU'] * ['sr-Latn-RO'] = ['sr-Latn-RO'] // sr-RU -> sr-Latn-RU
+ *
+ *    It works similarly to getParentLocales algo, except that we stop
+ *    after matching against variant/region ranges and don't try to match
+ *    ignoring script ranges. That means that `sr-Cyrl` will never match
+ *    against `sr-Latn`.
+ */
+export default function filterMatches(
+  requestedLocales, availableLocales, strategy, likelySubtags
+) {
+  const supportedLocales = new Set();
+
+  const availableLocalesCache = new Map();
+
+  outer:
+  for (const reqLocStr of requestedLocales) {
+    if (strategy === 'lookup' && supportedLocales.size > 0) {
+      return Array.from(supportedLocales);
+    }
+
+    const reqLocStrLC = reqLocStr.toLowerCase();
+
+    // Attempt to make an exact match
+    // Example: `en-US` === `en-US`
+    for (const availableLocale of availableLocales) {
+      if (reqLocStrLC === availableLocale.toLowerCase()) {
+        supportedLocales.add(availableLocale);
+        if (strategy !== 'matching') {
+          continue outer;
+        }
+      }
+    }
+
+    const requestedLocale = new Locale(reqLocStrLC);
+
+    // Attempt to match against the available range
+    // This turns `en` into `en-*-*-*` and `en-US` into `en-*-US-*`
+    // Example: ['en-US'] * ['en'] = ['en']
+    for (const availableLocale of availableLocales) {
+      if (requestedLocale.matches(
+        getOrParseLocaleRange(availableLocale, availableLocalesCache)
+      )) {
+        supportedLocales.add(availableLocale);
+        if (strategy !== 'matching') {
+          continue outer;
+        }
+      }
+    }
+
+    // Attempt to retrieve a maximal version of the requested locale ID
+    // If data is available, it'll expand `en` into `en-Latn-US` and
+    // `zh` into `zh-Hans-CN`.
+    // Example: ['en'] * ['en-GB', 'en-US'] = ['en-US']
+    const maxRequestedLocale =
+      getLikelySubtagsLocale(reqLocStrLC, likelySubtags);
+
+    if (maxRequestedLocale) {
+      for (const availableLocale of availableLocales) {
+        if (maxRequestedLocale.matches(
+          getOrParseLocaleRange(availableLocale, availableLocalesCache)
+        )) {
+          supportedLocales.add(availableLocale);
+          if (strategy !== 'matching') {
+            continue outer;
+          }
+        }
+      }
+    }
+
+    // Attempt to look up for a different variant for the same locale ID
+    // Example: ['en-US-mac'] * ['en-US-win'] = ['en-US-win']
+    const variantRange = variantRangeFor(maxRequestedLocale || requestedLocale);
+
+    for (const availableLocale of availableLocales) {
+      if (variantRange.matches(
+        getOrParseLocaleRange(availableLocale, availableLocalesCache)
+      )) {
+        supportedLocales.add(availableLocale);
+        if (strategy !== 'matching') {
+          continue outer;
+        }
+      }
+    }
+
+    // Attempt to look up for a different region for the same locale ID
+    // Example: ['en-US'] * ['en-AU'] = ['en-AU']
+    const regionRange = regionRangeFor(variantRange);
+
+    for (const availableLocale of availableLocales) {
+      if (regionRange.matches(
+        getOrParseLocaleRange(availableLocale, availableLocalesCache)
+      )) {
+        supportedLocales.add(availableLocale);
+        if (strategy !== 'matching') {
+          continue outer;
+        }
+      }
+    }
+  }
+
+  return Array.from(supportedLocales);
+}

--- a/fluent-langneg/src/subtags.js
+++ b/fluent-langneg/src/subtags.js
@@ -1,0 +1,62 @@
+import Locale from './locale';
+
+/**
+ * Below is a manually a list of likely subtags corresponding to Unicode
+ * CLDR likelySubtags list.
+ * This list is curated by the maintainers of Project Fluent and is
+ * intended to be used in place of the full likelySubtags list in use cases
+ * where full list cannot be (for example, due to the size).
+ *
+ * This version of the list is based on CLDR 30.0.3.
+ */
+const likelySubtagsMin = {
+  'ar': 'ar-arab-eg',
+  'az-arab': 'az-arab-ir',
+  'az-ir': 'az-arab-ir',
+  'be': 'be-cyrl-by',
+  'da': 'da-latn-dk',
+  'el': 'el-grek-gr',
+  'en': 'en-latn-us',
+  'fa': 'fa-arab-ir',
+  'ja': 'ja-jpan-jp',
+  'ko': 'ko-kore-kr',
+  'pt': 'pt-latn-br',
+  'sr': 'sr-cyrl-rs',
+  'sr-ru': 'sr-latn-ru',
+  'sv': 'sv-latn-se',
+  'ta': 'ta-taml-in',
+  'uk': 'uk-cyrl-ua',
+  'zh': 'zh-hans-cn',
+  'zh-gb': 'zh-hant-gb',
+  'zh-us': 'zh-hant-us',
+};
+
+const regionMatchingLangs = [
+  'az',
+  'bg',
+  'cs',
+  'de',
+  'es',
+  'fi',
+  'fr',
+  'hu',
+  'it',
+  'lt',
+  'lv',
+  'nl',
+  'pl',
+  'ro',
+  'ru',
+];
+
+export function getLikelySubtagsMin(loc) {
+  if (likelySubtagsMin.hasOwnProperty(loc)) {
+    return new Locale(likelySubtagsMin[loc]);
+  }
+  const locale = new Locale(loc);
+  if (regionMatchingLangs.includes(locale.language)) {
+    locale.region = locale.language;
+    return locale;
+  }
+  return null;
+}

--- a/fluent-langneg/test/langneg_filtering_test.js
+++ b/fluent-langneg/test/langneg_filtering_test.js
@@ -1,0 +1,153 @@
+import assert from 'assert';
+import negotiateLanguages from '../src/index';
+
+describe('Basic Language Negotiation without likelySubtags', () => {
+  const nl = negotiateLanguages;
+
+  it('exact match', () => {
+    assert.deepEqual(nl(['en'], ['en']), ['en']);
+
+    assert.deepEqual(nl(['en-US'], ['en-US']), ['en-US']);
+
+    assert.deepEqual(nl(['en-Latn-US'], ['en-Latn-US']), ['en-Latn-US']);
+
+    assert.deepEqual(
+      nl(['en-Latn-US-mac'], ['en-Latn-US-mac']), ['en-Latn-US-mac']
+    );
+
+    assert.deepEqual(nl(['fr-FR'], ['de', 'it', 'fr-FR']), ['fr-FR']);
+
+    assert.deepEqual(
+      nl(['fr', 'pl', 'de-DE'], ['pl', 'en-US', 'de-DE']),
+      ['pl', 'de-DE']);
+  });
+
+  it('available locale is treated as a range', () => {
+    assert.deepEqual(nl(['en-US'], ['en']), ['en']);
+
+    assert.deepEqual(nl(['en-Latn-US'], ['en-US']), ['en-US']);
+
+    assert.deepEqual(nl(['en-Latn-US-mac'], ['en-Latn-US']), ['en-Latn-US']);
+
+    assert.deepEqual(nl(['en-US-mac'], ['en-US']), ['en-US']);
+
+    assert.deepEqual(nl(['fr-CA', 'de-DE'], ['fr', 'it', 'de']), ['fr', 'de']);
+
+    assert.deepEqual(nl(['ja-JP-mac'], ['ja']), ['ja']);
+
+    assert.deepEqual(
+      nl(['en-Latn-GB', 'en-Latn-IN'], ['en-IN', 'en-GB']),
+      ['en-GB', 'en-IN']);
+  });
+
+  it('likely subtag', () => {
+    assert.deepEqual(
+      nl(['en'], ['en-GB', 'de', 'en-US']),
+      ['en-US']);
+
+    assert.deepEqual(
+      nl(['fr'], ['fr-CA', 'fr-FR']),
+      ['fr-FR']);
+
+    assert.deepEqual(
+      nl(['az-IR'], ['az-Latn', 'az-Arab']),
+      ['az-Arab']);
+
+    assert.deepEqual(
+      nl(['sr-RU'], ['sr-Cyrl', 'sr-Latn']),
+      ['sr-Latn']);
+
+    assert.deepEqual(
+      nl(['sr'], ['sr-Latn', 'sr-Cyrl']),
+      ['sr-Cyrl']);
+
+    assert.deepEqual(
+      nl(['zh-GB'], ['zh-Hans', 'zh-Hant']),
+      ['zh-Hant']);
+
+    assert.deepEqual(
+      nl(['sr', 'ru'], ['sr-Latn', 'ru']),
+      ['ru']);
+
+    assert.deepEqual(
+      nl(['sr-RU'], ['sr-Latn-RO', 'sr-Cyrl']),
+      ['sr-Latn-RO']);
+  });
+
+  it('requested locale as a range works', () => {
+    assert.deepEqual(nl(['en-*-US'], ['en-US']), ['en-US']);
+
+    assert.deepEqual(nl(['en-Latn-US-*'], ['en-Latn-US']), ['en-Latn-US']);
+
+    assert.deepEqual(nl(['en-*-US-*'], ['en-US']), ['en-US']);
+  });
+
+  it('we match cross-region', () => {
+    assert.deepEqual(nl(['en'], ['en-US']), ['en-US']);
+
+    assert.deepEqual(nl(['en-US'], ['en-GB']), ['en-GB']);
+
+    assert.deepEqual(nl(['en-Latn-US'], ['en-Latn-GB']), ['en-Latn-GB']);
+
+    assert.deepEqual(nl(['en-US-mac'], ['en-GB-mac']), ['en-GB-mac']);
+
+    // This is a cross-region check, because the requested Locale
+    // is really lang: en, script: *, region: undefined
+    assert.deepEqual(nl(['en-*'], ['en-US']), ['en-US']);
+  });
+
+  it('we match cross-variant', () => {
+    assert.deepEqual(nl(['en-US-mac'], ['en-US-win']), ['en-US-win']);
+  });
+
+  it('we prioritize properly', () => {
+    // exact match first
+    assert.deepEqual(nl(['en-US'], ['en-US-mac', 'en', 'en-US']), ['en-US']);
+
+    // available as range second
+    assert.deepEqual(nl(['en-Latn-US'], ['en-GB', 'en-US']), ['en-US']);
+
+    // we're skipping likelySubtags here
+
+    // variant range fourth
+    assert.deepEqual(
+      nl(['en-US-mac'], ['en-US-win', 'en-GB-mac']), ['en-US-win']
+    );
+
+    // regional range fourth
+    assert.deepEqual(
+      nl(['en-US-mac'], ['en-GB-win']), ['en-GB-win']
+    );
+
+  });
+
+  it('extra prioritization tests', () => {
+    // we pick generic range locale over other region first
+    assert.deepEqual(nl(['en-US'], ['en-GB', 'en']), ['en']);
+  });
+
+  it('default locale', () => {
+    assert.deepEqual(nl(['fr'], ['de', 'it']), []);
+
+    assert.deepEqual(nl(['fr'], ['de', 'it'], {
+      defaultLocale: 'en-US'
+    }), ['en-US']);
+
+    assert.deepEqual(nl(['fr'], ['de', 'en-US'], {
+      defaultLocale: 'en-US'
+    }), ['en-US']);
+
+    assert.deepEqual(
+      nl(['fr', 'de-DE'], ['de-DE', 'fr-CA'], {
+        defaultLocale: 'en-US'
+      }),
+      ['fr-CA', 'de-DE', 'en-US']);
+  });
+
+  it('all attempts on the first are higher than any on the second', () => {
+    assert.deepEqual(
+      nl(['fr-CA-mac', 'de-DE'], ['de-DE', 'fr-FR-win']),
+      ['fr-FR-win', 'de-DE']);
+  });
+
+});

--- a/fluent-langneg/test/langneg_lookup_test.js
+++ b/fluent-langneg/test/langneg_lookup_test.js
@@ -1,0 +1,41 @@
+import assert from 'assert';
+import negotiateLanguages from '../src/index';
+
+describe('Basic Language Lookup', () => {
+  let nl;
+  before(() => {
+    nl = function(requested, available, options = {}) {
+      const resolvedOptions = Object.assign(options, {
+        strategy: 'lookup',
+        defaultLocale: 'und'
+      });
+      return negotiateLanguages(requested, available, resolvedOptions);
+    };
+  });
+
+
+  it('exact match', () => {
+    assert.deepEqual(
+      nl(['en-US-mac', 'de'], ['de', 'en-US-win']), ['en-US-win']);
+  });
+
+  it('available locale is treated as a range', () => {
+    assert.deepEqual(
+      nl(['de-DE', 'fr'], ['fr', 'de']), ['de']);
+  });
+
+  it('requested locale as a range works', () => {
+    assert.deepEqual(
+      nl(['de-*', 'fr'], ['fr', 'de-DE']), ['de-DE']);
+  });
+
+  it('we match cross-region', () => {
+    assert.deepEqual(
+      nl(['de-DE', 'fr'], ['fr', 'de-AT']), ['de-AT']);
+  });
+
+  it('we match cross-variant', () => {
+    assert.deepEqual(
+      nl(['de-DE-mac', 'fr'], ['fr', 'de-DE-win']), ['de-DE-win']);
+  });
+});

--- a/fluent-langneg/test/langneg_matching_test.js
+++ b/fluent-langneg/test/langneg_matching_test.js
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import negotiateLanguages from '../src/index';
+
+describe('Basic Language Negotiation without likelySubtags', () => {
+  let nl;
+  before(() => {
+    nl = function(requested, available, options = {}) {
+      const resolvedOptions = Object.assign(options, {
+        strategy: 'matching'
+      });
+      return negotiateLanguages(requested, available, resolvedOptions);
+    };
+  });
+
+
+  it('exact match', () => {
+    assert.deepEqual(nl(['en-US'], ['en-US', 'en']), ['en-US', 'en']);
+
+    assert.deepEqual(
+      nl(['en-Latn-US'], ['en-Latn-US', 'en-US']), ['en-Latn-US', 'en-US']);
+  });
+});

--- a/fluent-langneg/test/locale_test.js
+++ b/fluent-langneg/test/locale_test.js
@@ -1,0 +1,135 @@
+import assert from 'assert';
+import Locale from '../src/locale';
+
+function isLocaleEqual(str, ref) {
+  const locale = new Locale(str);
+  return locale.isEqual(ref);
+}
+
+describe('Parses simple locales', () => {
+  it('language part', () => {
+    assert.ok(isLocaleEqual('en', {
+      language: 'en',
+    }));
+
+    assert.ok(isLocaleEqual('lij', {
+      language: 'lij',
+    }));
+  });
+
+  it('script part', () => {
+    assert.ok(isLocaleEqual('en-Latn', {
+      language: 'en',
+      script: 'Latn'
+    }));
+
+    assert.ok(isLocaleEqual('lij-Arab', {
+      language: 'lij',
+      script: 'Arab'
+    }));
+  });
+
+  it('region part', () => {
+    assert.ok(isLocaleEqual('en-Latn-US', {
+      language: 'en',
+      script: 'Latn',
+      region: 'US'
+    }));
+
+    assert.ok(isLocaleEqual('lij-Arab-FA', {
+      language: 'lij',
+      script: 'Arab',
+      region: 'FA'
+    }));
+  });
+
+  it('variant part', () => {
+    assert.ok(isLocaleEqual('en-Latn-US-mac', {
+      language: 'en',
+      script: 'Latn',
+      region: 'US',
+      variant: 'mac'
+    }));
+
+    assert.ok(isLocaleEqual('lij-Arab-FA-linux', {
+      language: 'lij',
+      script: 'Arab',
+      region: 'FA',
+      variant: 'linux'
+    }));
+  });
+
+  it('skipping script part', () => {
+    assert.ok(isLocaleEqual('en-US', {
+      language: 'en',
+      region: 'US',
+    }));
+
+    assert.ok(isLocaleEqual('lij-FA-linux', {
+      language: 'lij',
+      region: 'FA',
+      variant: 'linux'
+    }));
+  });
+
+  it('skipping variant part', () => {
+    assert.ok(isLocaleEqual('en-US', {
+      language: 'en',
+      region: 'US',
+    }));
+
+    assert.ok(isLocaleEqual('lij-FA-linux', {
+      language: 'lij',
+      region: 'FA',
+      variant: 'linux'
+    }));
+  });
+});
+
+describe('Parses locale ranges', () => {
+  it('language part', () => {
+    assert.ok(isLocaleEqual('*', {
+      language: '*',
+    }));
+
+    assert.ok(isLocaleEqual('*-Latn', {
+      language: '*',
+      script: 'Latn'
+    }));
+
+    assert.ok(isLocaleEqual('*-US', {
+      language: '*',
+      region: 'US'
+    }));
+  });
+
+  it('script part', () => {
+    assert.ok(isLocaleEqual('en-*', {
+      language: 'en',
+      script: '*'
+    }));
+
+    assert.ok(isLocaleEqual('en-*-US', {
+      language: 'en',
+      script: '*',
+      region: 'US'
+    }));
+  });
+
+  it('region part', () => {
+    assert.ok(isLocaleEqual('en-Latn-*', {
+      language: 'en',
+      script: 'Latn',
+      region: '*'
+    }));
+  });
+
+  it('variant part', () => {
+    assert.ok(isLocaleEqual('en-Latn-US-*', {
+      language: 'en',
+      script: 'Latn',
+      region: 'US',
+      variant: '*'
+    }));
+  });
+});

--- a/fluent-langneg/test/setup.js
+++ b/fluent-langneg/test/setup.js
@@ -1,0 +1,3 @@
+require('babel-register')({
+  plugins: ['transform-es2015-modules-commonjs']
+});


### PR DESCRIPTION
I'd like to start discussing our intended language negotiation strategy (I'd also like to share it between Fluent and Gecko).

I looked at rfc4647 and some of the ICU implementations, but I don't think that what they suggest (matching vs filtering) applies to us perfectly.

Thus, I started working on my own algorithm and the JS implementation is imho a good starting point to discuss it.

The patch here is not finalized but it uses two data-driven algorithms:
 - getParent - which in simplest form cuts off last part ("en-US" -> "en") but eventually will have some exceptions to prevent things like  "zh-Hant" -> "zh", and hopefully will land in ECMA402 (see https://github.com/tc39/ecma402/issues/87)
 - getBestSubtags does not have a good equivalent in ICU so will likely stay curated by us. It allows us to easily go up from more generic to more detailed subtags

The algorithm currently has four parts. It tries, in order:
 - exact match at weight `1.0`
 - likely subtags (tests "en-US" for "en") at weight `0.9`
 - parents (tests "en" for "en-US") at weight `0.8`
 - siblings (tests "en-GB" for "en-US") at weight `0.6`

It stops on the best match for the candidate.

I'd like to get feedback and any suggestions at this point from @Pike and @stasm.