### PR TITLE
Add spans to Entries and Annotations to Resource

### DIFF
--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -19,7 +19,7 @@ can install it from the npm registry or use it as a standalone script (as the
 ```javascript
 import { parse, Resource } from 'fluent-syntax';
 
-const [res, errors] = parse(`
+const res = parse(`
 brand-name = Foo 3000
 welcome    = Welcome, { $name }, to { brand-name }!
 `);

--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -3,11 +3,12 @@ class Node {
 }
 
 export class Resource extends Node {
-  constructor(body = [], comment = null) {
-    super(body, comment);
+  constructor(body = [], comment = null, source = '') {
+    super();
     this.type = 'Resource';
     this.body = body;
     this.comment = comment;
+    this.source = source;
   }
 }
 
@@ -15,6 +16,15 @@ export class Entry extends Node {
   constructor() {
     super();
     this.type = 'Entry';
+    this.annotations = [];
+  }
+
+  addSpan(from, to) {
+    this.span = { from, to };
+  }
+
+  addAnnotation(annot) {
+    this.annotations.push(annot);
   }
 }
 
@@ -179,10 +189,10 @@ export class Function extends Identifier {
   }
 }
 
-export class JunkEntry extends Entry {
+export class Junk extends Entry {
   constructor(content) {
     super();
-    this.type = 'JunkEntry';
+    this.type = 'Junk';
     this.content = content;
   }
 }

--- a/fluent-syntax/src/errors.js
+++ b/fluent-syntax/src/errors.js
@@ -1,26 +1,18 @@
-export function error(ps, message) {
-  const err = new SyntaxError(message);
-  err.lineNumber = ps.getLineNumber();
-  err.columnNumber = ps.getColumnNumber();
-  return err;
+class Annotation {
+  constructor(message) {
+    this.message = message;
+  }
 }
 
-export function getErrorSlice(source, start, end) {
-  const len = source.length;
-
-  let startPos;
-  let sliceLen = end - start;
-
-  if (len < sliceLen) {
-    startPos = 0;
-    sliceLen = len;
-  } else if (start + sliceLen >= len) {
-    startPos = len - sliceLen - 1;
-  } else {
-    startPos = start;
+export class ParseError extends Annotation {
+  constructor(message) {
+    super(message);
+    this.name = 'ParseError';
   }
+}
 
-  return startPos > 0 ?
-    source.substr(startPos - 1, sliceLen) :
-    source.substr(0, sliceLen);
+export function error(ps, message) {
+  const err = new ParseError(message);
+  err.pos = ps.getIndex();
+  return err;
 }

--- a/fluent-syntax/src/index.js
+++ b/fluent-syntax/src/index.js
@@ -1,2 +1,15 @@
 export * from './ast';
-export { parse } from './parser';
+export * from './parser';
+
+export function lineOffset(source, pos) {
+  // Substract 1 to get the offset.
+  return source.substring(0, pos).split('\n').length - 1;
+}
+
+export function columnOffset(source, pos) {
+  const lastLineBreak = source.lastIndexOf('\n', pos);
+  return lastLineBreak === -1
+    ? pos
+    // Substracting two offsets gives length; substract 1 to get the offset.
+    : pos - lastLineBreak - 1;
+}

--- a/fluent-syntax/src/stream.js
+++ b/fluent-syntax/src/stream.js
@@ -86,14 +86,6 @@ export class ParserStream {
     return this.index;
   }
 
-  getLineNumber() {
-    return this.string.slice(1, this.index).split('\n').length;
-  }
-
-  getColumnNumber() {
-    return this.index - this.string.lastIndexOf('\n', this.index - 1);
-  }
-
   getPeekIndex() {
     return this.peekIndex;
   }

--- a/tools/parse.js
+++ b/tools/parse.js
@@ -2,12 +2,14 @@
 
 'use strict';
 
-var fs = require('fs');
-var program = require('commander');
+const fs = require('fs');
+const program = require('commander');
 
 require('babel-register')({
   plugins: ['transform-es2015-modules-commonjs']
 });
+
+const FluentSyntax = require('../fluent-syntax/src');
 
 program
   .version('0.0.1')
@@ -16,26 +18,69 @@ program
   .option('-s, --silent', 'Silence syntax errors')
   .parse(process.argv);
 
-const parse = program.runtime
-  ? require('../fluent/src/parser').default
-  : require('../fluent-syntax/src/parser').parse;
+if (program.args.length) {
+  fs.readFile(program.args[0], print);
+} else {
+  process.stdin.resume();
+  process.stdin.on('data', print);
+}
 
 function print(err, data) {
   if (err) {
     return console.error('File not found: ' + err.path);
   }
 
-  const [result, errors] = parse(data.toString());
-  console.log(JSON.stringify(result, null, 2));
+  (program.runtime
+    ? printRuntime
+    : printResource
+  )(data);
+}
 
-  if (errors.length && !program.silent) {
+function printRuntime(data) {
+  const parse = require('../fluent/src/parser').default;
+  const [res, errors] = parse(data.toString());
+  console.log(JSON.stringify(res, null, 2));
+
+  if (!program.silent) {
     errors.map(e => console.error(e.message));
   }
 }
 
-if (program.args.length) {
-  fs.readFile(program.args[0], print);
-} else {
-  process.stdin.resume();
-  process.stdin.on('data', print);
+function printResource(data) {
+  const res = FluentSyntax.parse(data.toString());
+  const source = res.source;
+  delete res.source;
+  console.log(JSON.stringify(res, null, 2));
+
+  if (!program.silent) {
+    res.body.map(entry => printAnnotations(source, entry));
+  }
+}
+
+function printAnnotations(source, entry) {
+  const { span, annotations } = entry;
+  for (const annot of annotations) {
+    printAnnotation(source, span, annot);
+  }
+}
+
+function printAnnotation(source, span, annot) {
+  const { name, message, pos } = annot;
+  const slice = source.substring(span.from, span.to).trimRight();
+  const lineNumber = FluentSyntax.lineOffset(source, pos) + 1;
+  const columnOffset = FluentSyntax.columnOffset(source, pos);
+  const showLines = lineNumber - FluentSyntax.lineOffset(source, span.from);
+  const lines = slice.split('\n');
+  const head = lines.slice(0, showLines);
+  const tail = lines.slice(showLines);
+
+  console.log();
+  console.log(`! ${name} on line ${lineNumber}:`);
+  console.log(head.map(line => `  | ${line}`).join('\n'));
+  console.log(`  … ${indent(columnOffset)}^----- ${message}`);
+  console.log(tail.map(line => `  | ${line}`).join('\n'));
+}
+
+function indent(spaces) {
+  return new Array(spaces + 1).join(' ');
 }


### PR DESCRIPTION
This change allows consumers of the fluent-syntax API to display nice error
messages.

`Entry` instances now have a `span: { from, to, lineno }` field. `from` and
`to` are positions relative to the start of the file. `lineno` is the 0-based
line number in which the entry starts.  Two examples follow.

```json
{
    "type": "Message",
	"id": {
	    "type": "Identifier",
	    "name": "hello-world"
	},
	"value": {
	    "type": "Pattern",
	    "elements": [
	    {
		"type": "StringExpression",
		"value": "Hello, world!"
	    }
	    ],
	    "quoted": false
	},
	"attributes": null,
	"comment": null,
	"span": {
	    "from": 38,
	    "to": 65,
	    "lineno": 2
	}
},
```

```json
{
    "type": "Junk",
	"content": "hello-world Hello, world!\n\n",
	"span": {
	    "from": 44,
	    "to": 71,
	    "lineno": 4
	}
},
```

Parsing errors are now collected into the `annotations` field of `Resource`
instances.  In the future, we can add warnings and notes there, too.  Each
annotation holds a reference to an `Entry` instance which created the
annotation.  This allows the consumers of the API to build their own formatting
rules for annotations.

```json
{
    "name": "SyntaxError",
    "message": "Missing field",
    "lineNumber": 4,
    "columnNumber": 13,
    "entry": {
        "type": "Junk",
        "content": "hello-world Hello, world!\n\n",
        "span": {
            "from": 44,
            "to": 71,
            "lineno": 4
        }
    }
},
```

As per [Error-reporting][], in the future we may considering adding `labels` to
annotations to provide explanation of the error and suggested ways of fixing
it.

[Error-reporting]: https://github.com/projectfluent/fluent/wiki/Error-reporting

Lastly, the `tools/parse` script now prints the following output for errors.
I didn't use any colors at this point because I didn't want to make the patch
too complicated.

    ! SyntaxError on line 3:
      | @xxx
      … ^----- Expected entry

    ! SyntaxError on line 5:
      | hello-world Hello, world!
      …             ^----- Missing field

    ! SyntaxError on line 7:
      | shared-photos = { $user_name { $photo_count ->
      …                              ^----- Expected token }
      |     [0] hasn't added any photos yet
      |     [one] added a new photo
      |    *[other] added { $photo_count } new photos
      | }.

    ! SyntaxError on line 17:
      | liked-comment = { $user_name } liked your comment on { $user_gender ->
      |     [male] his
      |     [female] her
      |     [other] their
      | } post.
      …                  ^----- Missing default variant

The last example shows a case where the `lineNumber` and `columnNumber` of the
error are wrong.  I'll fix this later in the parser.