### PR TITLE
Use the TDD interface for tests

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -18,7 +18,7 @@ lint:
 	@echo -e " $(OK) $@"
 
 test:
-	@mocha --recursive --require ./test/setup
+	@mocha --ui tdd --recursive --require ./test/setup
 
 html: $(SOURCES)
 	@jsdoc -c $(ROOT)/.jsdoc.json -R README.md \

--- a/fluent-intl-polyfill/test/plural_rules_test.js
+++ b/fluent-intl-polyfill/test/plural_rules_test.js
@@ -3,22 +3,22 @@
 import assert from 'assert';
 import '../src/index';
 
-describe('Polyfill', function() {
+suite('Polyfill', function() {
 
-  it('Intl.PluralRules exists', function() {
+  test('Intl.PluralRules exists', function() {
     assert.strictEqual(typeof Intl.PluralRules, 'function');
   });
 
-  it('select method exists', function() {
+  test('select method exists', function() {
     const pr = new Intl.PluralRules('fr');
     assert.strictEqual(typeof pr.select, 'function');
   });
 
 });
 
-describe('Plural rules', function() {
+suite('Plural rules', function() {
 
-  it('known language: en', function() {
+  test('known language: en', function() {
     const pr = new Intl.PluralRules('en');
     assert.strictEqual(pr.select(0), 'other');
     assert.strictEqual(pr.select(1), 'one');
@@ -28,7 +28,7 @@ describe('Plural rules', function() {
     assert.strictEqual(pr.select(22), 'other');
   });
 
-  it('known language: pl', function() {
+  test('known language: pl', function() {
     const pr = new Intl.PluralRules('pl');
     assert.strictEqual(pr.select(0), 'many');
     assert.strictEqual(pr.select(1), 'one');
@@ -38,7 +38,7 @@ describe('Plural rules', function() {
     assert.strictEqual(pr.select(22), 'few');
   });
 
-  it('unknown languages uses en-US', function() {
+  test('unknown languages uses en-US', function() {
     const pr = new Intl.PluralRules('xxx');
     assert.strictEqual(pr.select(0), 'other');
     assert.strictEqual(pr.select(1), 'one');

--- a/fluent-langneg/test/langneg_filtering_test.js
+++ b/fluent-langneg/test/langneg_filtering_test.js
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import negotiateLanguages from '../src/index';
 
-describe('Basic Language Negotiation', () => {
+suite('Basic Language Negotiation', () => {
   const nl = negotiateLanguages;
 
-  it('should match on an exact match', () => {
+  test('exact match', () => {
     assert.deepEqual(nl(['en'], ['en']), ['en']);
 
     assert.deepEqual(nl(['en-US'], ['en-US']), ['en-US']);
@@ -22,7 +22,7 @@ describe('Basic Language Negotiation', () => {
       ['pl', 'de-DE']);
   });
 
-  it('should match on available locale treated as a range', () => {
+  test('available locale is treated as a range', () => {
     assert.deepEqual(nl(['en-US'], ['en']), ['en']);
 
     assert.deepEqual(nl(['en-Latn-US'], ['en-US']), ['en-US']);
@@ -40,7 +40,7 @@ describe('Basic Language Negotiation', () => {
       ['en-GB', 'en-IN']);
   });
 
-  it('should match on a likely subtag', () => {
+  test('likely subtag', () => {
     assert.deepEqual(
       nl(['en'], ['en-GB', 'de', 'en-US']),
       ['en-US']);
@@ -74,7 +74,7 @@ describe('Basic Language Negotiation', () => {
       ['sr-Latn-RO']);
   });
 
-  it('should match on a requested locale as a range', () => {
+  test('requested locale as a range', () => {
     assert.deepEqual(nl(['en-*-US'], ['en-US']), ['en-US']);
 
     assert.deepEqual(nl(['en-Latn-US-*'], ['en-Latn-US']), ['en-Latn-US']);
@@ -82,7 +82,7 @@ describe('Basic Language Negotiation', () => {
     assert.deepEqual(nl(['en-*-US-*'], ['en-US']), ['en-US']);
   });
 
-  it('should match cross-region', () => {
+  test('match cross-region', () => {
     assert.deepEqual(nl(['en'], ['en-US']), ['en-US']);
 
     assert.deepEqual(nl(['en-US'], ['en-GB']), ['en-GB']);
@@ -96,11 +96,11 @@ describe('Basic Language Negotiation', () => {
     assert.deepEqual(nl(['en-*'], ['en-US']), ['en-US']);
   });
 
-  it('should match cross-variant', () => {
+  test('match cross-variant', () => {
     assert.deepEqual(nl(['en-US-mac'], ['en-US-win']), ['en-US-win']);
   });
 
-  it('should prioritize properly', () => {
+  test('prioritize properly', () => {
     // exact match first
     assert.deepEqual(nl(['en-US'], ['en-US-mac', 'en', 'en-US']), ['en-US']);
 
@@ -121,12 +121,12 @@ describe('Basic Language Negotiation', () => {
 
   });
 
-  it('should prioritiz properly (extra tests)', () => {
+  test('prioritize properly (extra tests)', () => {
     // we pick generic range locale over other region first
     assert.deepEqual(nl(['en-US'], ['en-GB', 'en']), ['en']);
   });
 
-  it('should handle default locale properly', () => {
+  test('default locale', () => {
     assert.deepEqual(nl(['fr'], ['de', 'it']), []);
 
     assert.deepEqual(nl(['fr'], ['de', 'it'], {
@@ -144,7 +144,7 @@ describe('Basic Language Negotiation', () => {
       ['fr-CA', 'de-DE', 'en-US']);
   });
 
-  it('should handle all matches on the 1st higher than any on the 2nd', () => {
+  test('all attempts on the first are higher than any on the second', () => {
     assert.deepEqual(
       nl(['fr-CA-mac', 'de-DE'], ['de-DE', 'fr-FR-win']),
       ['fr-FR-win', 'de-DE']);

--- a/fluent-langneg/test/langneg_lookup_test.js
+++ b/fluent-langneg/test/langneg_lookup_test.js
@@ -1,9 +1,9 @@
 import assert from 'assert';
 import negotiateLanguages from '../src/index';
 
-describe('Basic Language Lookup', () => {
+suite('Basic Language Lookup', () => {
   let nl;
-  before(() => {
+  suiteSetup(() => {
     nl = function(requested, available, options = {}) {
       const resolvedOptions = Object.assign(options, {
         strategy: 'lookup',
@@ -14,27 +14,27 @@ describe('Basic Language Lookup', () => {
   });
 
 
-  it('exact match', () => {
+  test('exact match', () => {
     assert.deepEqual(
       nl(['en-US-mac', 'de'], ['de', 'en-US-win']), ['en-US-win']);
   });
 
-  it('available locale is treated as a range', () => {
+  test('available locale is treated as a range', () => {
     assert.deepEqual(
       nl(['de-DE', 'fr'], ['fr', 'de']), ['de']);
   });
 
-  it('requested locale as a range works', () => {
+  test('requested locale as a range works', () => {
     assert.deepEqual(
       nl(['de-*', 'fr'], ['fr', 'de-DE']), ['de-DE']);
   });
 
-  it('we match cross-region', () => {
+  test('we match cross-region', () => {
     assert.deepEqual(
       nl(['de-DE', 'fr'], ['fr', 'de-AT']), ['de-AT']);
   });
 
-  it('we match cross-variant', () => {
+  test('we match cross-variant', () => {
     assert.deepEqual(
       nl(['de-DE-mac', 'fr'], ['fr', 'de-DE-win']), ['de-DE-win']);
   });

--- a/fluent-langneg/test/langneg_matching_test.js
+++ b/fluent-langneg/test/langneg_matching_test.js
@@ -1,9 +1,9 @@
 import assert from 'assert';
 import negotiateLanguages from '../src/index';
 
-describe('Basic Language Negotiation without likelySubtags', () => {
+suite('Basic Language Negotiation without likelySubtags', () => {
   let nl;
-  before(() => {
+  suiteSetup(() => {
     nl = function(requested, available, options = {}) {
       const resolvedOptions = Object.assign(options, {
         strategy: 'matching'
@@ -13,7 +13,7 @@ describe('Basic Language Negotiation without likelySubtags', () => {
   });
 
 
-  it('exact match', () => {
+  test('exact match', () => {
     assert.deepEqual(nl(['en-US'], ['en-US', 'en']), ['en-US', 'en']);
 
     assert.deepEqual(

--- a/fluent-langneg/test/locale_test.js
+++ b/fluent-langneg/test/locale_test.js
@@ -6,8 +6,8 @@ function isLocaleEqual(str, ref) {
   return locale.isEqual(ref);
 }
 
-describe('Parses simple locales', () => {
-  it('language part', () => {
+suite('Parses simple locales', () => {
+  test('language part', () => {
     assert.ok(isLocaleEqual('en', {
       language: 'en',
     }));
@@ -17,7 +17,7 @@ describe('Parses simple locales', () => {
     }));
   });
 
-  it('script part', () => {
+  test('script part', () => {
     assert.ok(isLocaleEqual('en-Latn', {
       language: 'en',
       script: 'Latn'
@@ -29,7 +29,7 @@ describe('Parses simple locales', () => {
     }));
   });
 
-  it('region part', () => {
+  test('region part', () => {
     assert.ok(isLocaleEqual('en-Latn-US', {
       language: 'en',
       script: 'Latn',
@@ -43,7 +43,7 @@ describe('Parses simple locales', () => {
     }));
   });
 
-  it('variant part', () => {
+  test('variant part', () => {
     assert.ok(isLocaleEqual('en-Latn-US-mac', {
       language: 'en',
       script: 'Latn',
@@ -59,7 +59,7 @@ describe('Parses simple locales', () => {
     }));
   });
 
-  it('skipping script part', () => {
+  test('skipping script part', () => {
     assert.ok(isLocaleEqual('en-US', {
       language: 'en',
       region: 'US',
@@ -72,7 +72,7 @@ describe('Parses simple locales', () => {
     }));
   });
 
-  it('skipping variant part', () => {
+  test('skipping variant part', () => {
     assert.ok(isLocaleEqual('en-US', {
       language: 'en',
       region: 'US',
@@ -86,8 +86,8 @@ describe('Parses simple locales', () => {
   });
 });
 
-describe('Parses locale ranges', () => {
-  it('language part', () => {
+suite('Parses locale ranges', () => {
+  test('language part', () => {
     assert.ok(isLocaleEqual('*', {
       language: '*',
     }));
@@ -103,7 +103,7 @@ describe('Parses locale ranges', () => {
     }));
   });
 
-  it('script part', () => {
+  test('script part', () => {
     assert.ok(isLocaleEqual('en-*', {
       language: 'en',
       script: '*'
@@ -116,7 +116,7 @@ describe('Parses locale ranges', () => {
     }));
   });
 
-  it('region part', () => {
+  test('region part', () => {
     assert.ok(isLocaleEqual('en-Latn-*', {
       language: 'en',
       script: 'Latn',
@@ -124,7 +124,7 @@ describe('Parses locale ranges', () => {
     }));
   });
 
-  it('variant part', () => {
+  test('variant part', () => {
     assert.ok(isLocaleEqual('en-Latn-US-*', {
       language: 'en',
       script: 'Latn',

--- a/fluent-syntax/test/stream_test.js
+++ b/fluent-syntax/test/stream_test.js
@@ -3,8 +3,8 @@
 import assert from 'assert';
 import { ParserStream } from '../src/stream';
 
-describe('ParserStream', function() {
-  it('next', function() {
+suite('ParserStream', function() {
+  test('next', function() {
     let ps = new ParserStream("abcd");
 
     assert.strictEqual('a', ps.current());
@@ -27,7 +27,7 @@ describe('ParserStream', function() {
     assert.strictEqual(4, ps.getIndex());
   });
 
-  it('peek', function() {
+  test('peek', function() {
     let ps = new ParserStream("abcd");
 
     assert.strictEqual('a', ps.currentPeek());
@@ -50,7 +50,7 @@ describe('ParserStream', function() {
     assert.strictEqual(4, ps.getPeekIndex());
   });
 
-  it('peek_and_next', function() {
+  test('peek_and_next', function() {
     let ps = new ParserStream("abcd");
 
     assert.strictEqual('b', ps.peek());
@@ -96,7 +96,7 @@ describe('ParserStream', function() {
     assert.strictEqual(4, ps.getIndex());
   });
 
-  it('skip_to_peek', function() {
+  test('skip_to_peek', function() {
     let ps = new ParserStream("abcd");
 
     ps.peek();
@@ -124,7 +124,7 @@ describe('ParserStream', function() {
     assert.strictEqual(3, ps.getIndex());
   });
 
-  it('reset_peek', function() {
+  test('reset_peek', function() {
     let ps = new ParserStream("abcd");
 
     ps.next();
@@ -164,7 +164,7 @@ describe('ParserStream', function() {
     assert.strictEqual(undefined, ps.peek());
   });
 
-  it('peek_char_is', function() {
+  test('peek_char_is', function() {
     let ps = new ParserStream("abcd");
 
     ps.next();

--- a/fluent/test/arguments_test.js
+++ b/fluent/test/arguments_test.js
@@ -5,15 +5,15 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('External arguments', function() {
+suite('External arguments', function() {
   let ctx, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('in values', function(){
-    before(function() {
+  suite('in values', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo { $num }
@@ -26,28 +26,28 @@ describe('External arguments', function() {
       `);
     });
 
-    it('can be used in the message value', function() {
+    test('can be used in the message value', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Foo 3');
       assert.equal(errs.length, 0);
     });
 
-    it('can be used in the message value which is referenced', function() {
+    test('can be used in the message value which is referenced', function() {
       const msg = ctx.messages.get('bar');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Foo 3');
       assert.equal(errs.length, 0);
     });
 
-    it('can be used in an attribute', function() {
+    test('can be used in an attribute', function() {
       const msg = ctx.messages.get('baz').attrs.attr;
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Baz Attribute 3');
       assert.equal(errs.length, 0);
     });
 
-    it('can be used in a variant', function() {
+    test('can be used in a variant', function() {
       const msg = ctx.messages.get('qux');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Baz Variant A 3');
@@ -55,8 +55,8 @@ describe('External arguments', function() {
     });
   });
 
-  describe('in selectors', function(){
-    before(function() {
+  suite('in selectors', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { $num -> 
@@ -65,7 +65,7 @@ describe('External arguments', function() {
       `);
     });
 
-    it('can be used as a selector', function() {
+    test('can be used as a selector', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Foo');
@@ -73,8 +73,8 @@ describe('External arguments', function() {
     });
   });
 
-  describe('in function calls', function(){
-    before(function() {
+  suite('in function calls', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { NUMBER($num) }
@@ -82,14 +82,14 @@ describe('External arguments', function() {
       `);
     });
 
-    it('can be a positional argument', function() {
+    test('can be a positional argument', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, '3');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a named argument', function() {
+    test('can be a named argument', function() {
       const msg = ctx.messages.get('bar');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, '1.000');
@@ -97,57 +97,57 @@ describe('External arguments', function() {
     });
   });
 
-  describe('simple errors', function(){
-    before(function() {
+  suite('simple errors', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { $arg }
       `);
     });
 
-    it('falls back to argument\'s name if it\'s missing', function() {
+    test('falls back to argument\'s name if it\'s missing', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, {}, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof ReferenceError); // unknown external
     });
 
-    it('cannot be arrays', function() {
+    test('cannot be arrays', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { arg: [1, 2, 3] }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
-    it('cannot be a dict-like object', function() {
+    test('cannot be a dict-like object', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { arg: { prop: 1 } }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
-    it('cannot be a boolean', function() {
+    test('cannot be a boolean', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { arg: true }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
-    it('cannot be undefined', function() {
+    test('cannot be undefined', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { arg: undefined }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
-    it('cannot be null', function() {
+    test('cannot be null', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { arg: null }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
-    it('cannot be a function', function() {
+    test('cannot be a function', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { arg: () => null }, errs);
       assert.equal(val, 'arg');
@@ -155,10 +155,10 @@ describe('External arguments', function() {
     });
   });
 
-  describe('and strings', function(){
+  suite('and strings', function(){
     let args;
 
-    before(function() {
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { $arg }
@@ -168,7 +168,7 @@ describe('External arguments', function() {
       };
     });
 
-    it('can be a string', function(){
+    test('can be a string', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Argument');
@@ -176,10 +176,10 @@ describe('External arguments', function() {
     });
   });
 
-  describe('and numbers', function(){
+  suite('and numbers', function(){
     let args;
 
-    before(function() {
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { $arg }
@@ -189,7 +189,7 @@ describe('External arguments', function() {
       };
     });
 
-    it('can be a number', function(){
+    test('can be a number', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
@@ -197,10 +197,10 @@ describe('External arguments', function() {
     });
   });
 
-  describe('and dates', function(){
+  suite('and dates', function(){
     let args, dtf;
 
-    before(function() {
+    suiteSetup(function() {
       dtf = new Intl.DateTimeFormat('en-US');
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
@@ -211,7 +211,7 @@ describe('External arguments', function() {
       };
     });
 
-    it('can be a date', function(){
+    test('can be a date', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       // format the date argument to account for the testrunner's timezone

--- a/fluent/test/attributes_test.js
+++ b/fluent/test/attributes_test.js
@@ -5,15 +5,15 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Attributes', function() {
+suite('Attributes', function() {
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('missing', function(){
-    before(function() {
+  suite('missing', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
@@ -30,7 +30,7 @@ describe('Attributes', function() {
       `);
     });
 
-    it('falls back gracefully for entities with string values and no attributes', function() {
+    test('falls back gracefully for entities with string values and no attributes', function() {
       const msg = ctx.messages.get('ref-foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo');
@@ -38,7 +38,7 @@ describe('Attributes', function() {
       assert(errs[0] instanceof ReferenceError); // unknown attribute
     });
 
-    it('falls back gracefully for entities with string values and other attributes', function() {
+    test('falls back gracefully for entities with string values and other attributes', function() {
       const msg = ctx.messages.get('ref-bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar');
@@ -46,7 +46,7 @@ describe('Attributes', function() {
       assert(errs[0] instanceof ReferenceError); // unknown attribute
     });
 
-    it('falls back gracefully for entities with pattern values and no attributes', function() {
+    test('falls back gracefully for entities with pattern values and no attributes', function() {
       const msg = ctx.messages.get('ref-baz');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Baz');
@@ -54,7 +54,7 @@ describe('Attributes', function() {
       assert(errs[0] instanceof ReferenceError); // unknown attribute
     });
 
-    it('falls back gracefully for entities with pattern values and other attributes', function() {
+    test('falls back gracefully for entities with pattern values and other attributes', function() {
       const msg = ctx.messages.get('ref-qux');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Qux');
@@ -63,8 +63,8 @@ describe('Attributes', function() {
     });
   });
 
-  describe('with string values', function(){
-    before(function() {
+  suite('with string values', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
@@ -77,28 +77,28 @@ describe('Attributes', function() {
       `);
     });
 
-    it('can be referenced for entities with string values', function() {
+    test('can be referenced for entities with string values', function() {
       const msg = ctx.messages.get('ref-foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be formatted directly for entities with string values', function() {
+    test('can be formatted directly for entities with string values', function() {
       const msg = ctx.messages.get('foo').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be referenced for entities with pattern values', function() {
+    test('can be referenced for entities with pattern values', function() {
       const msg = ctx.messages.get('ref-bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be formatted directly for entities with pattern values', function() {
+    test('can be formatted directly for entities with pattern values', function() {
       const msg = ctx.messages.get('bar').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar Attribute');
@@ -106,8 +106,8 @@ describe('Attributes', function() {
     });
   });
 
-  describe('with simple pattern values', function(){
-    before(function() {
+  suite('with simple pattern values', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
@@ -124,42 +124,42 @@ describe('Attributes', function() {
       `);
     });
 
-    it('can be referenced for entities with string values', function() {
+    test('can be referenced for entities with string values', function() {
       const msg = ctx.messages.get('ref-bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be formatted directly for entities with string values', function() {
+    test('can be formatted directly for entities with string values', function() {
       const msg = ctx.messages.get('bar').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be referenced for entities with simple pattern values', function() {
+    test('can be referenced for entities with simple pattern values', function() {
       const msg = ctx.messages.get('ref-baz');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be formatted directly for entities with simple pattern values', function() {
+    test('can be formatted directly for entities with simple pattern values', function() {
       const msg = ctx.messages.get('baz').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('works with self-references', function() {
+    test('works with self-references', function() {
       const msg = ctx.messages.get('ref-qux');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Qux Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be formatted directly when it uses a self-reference', function() {
+    test('can be formatted directly when it uses a self-reference', function() {
       const msg = ctx.messages.get('qux').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Qux Attribute');
@@ -167,8 +167,8 @@ describe('Attributes', function() {
     });
   });
 
-  describe('with values with select expressions', function(){
-    before(function() {
+  suite('with values with select expressions', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
@@ -181,14 +181,14 @@ describe('Attributes', function() {
       `);
     });
 
-    it('can be referenced', function() {
+    test('can be referenced', function() {
       const msg = ctx.messages.get('ref-foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
       assert.equal(errs.length, 0);
     });
 
-    it('can be formatted directly', function() {
+    test('can be formatted directly', function() {
       const msg = ctx.messages.get('foo').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');

--- a/fluent/test/bomb_test.js
+++ b/fluent/test/bomb_test.js
@@ -5,15 +5,15 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Reference bombs', function() {
+suite('Reference bombs', function() {
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('Billion Laughs', function(){
-    before(function() {
+  suite('Billion Laughs', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         lol0 = LOL

--- a/fluent/test/context_test.js
+++ b/fluent/test/context_test.js
@@ -5,15 +5,15 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Context', function() {
+suite('Context', function() {
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('addMessages', function(){
-    before(function() {
+  suite('addMessages', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
@@ -21,7 +21,7 @@ describe('Context', function() {
       `);
     });
 
-    it('preserves existing messages when new are added', function() {
+    test('preserves existing messages when new are added', function() {
       ctx.addMessages(ftl`
         baz = Baz
       `);
@@ -30,7 +30,7 @@ describe('Context', function() {
       assert(ctx.messages.has('baz'));
     });
 
-    it('overwrites existing messages if the ids are the same', function() {
+    test('overwrites existing messages if the ids are the same', function() {
       ctx.addMessages(ftl`
         foo = New Foo
       `);

--- a/fluent/test/format_parts_test.js
+++ b/fluent/test/format_parts_test.js
@@ -31,22 +31,22 @@ function assert_partsEqual(actual, expected) {
   }
 }
 
-describe('formatToParts', function(){
+suite('formatToParts', function(){
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('Simple value', function(){
-    before(function() {
+  suite('Simple value', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
       `);
     });
 
-    it('returns the parts', function(){
+    test('returns the parts', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo']);
@@ -54,8 +54,8 @@ describe('formatToParts', function(){
     });
   });
 
-  describe('Complex value', function(){
-    before(function() {
+  suite('Complex value', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
@@ -65,21 +65,21 @@ describe('formatToParts', function(){
       `);
     });
 
-    it('returns the parts', function(){
+    test('returns the parts', function(){
       const msg = ctx.messages.get('bar');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo', ' Bar']);
       assert.equal(errs.length, 0);
     });
 
-    it('returns FluentNone', function(){
+    test('returns FluentNone', function(){
       const msg = ctx.messages.get('baz');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, [new FluentNone('missing')]);
       assert.ok(errs[0] instanceof ReferenceError); // unknown message
     });
 
-    it('returns FluentNumber', function(){
+    test('returns FluentNumber', function(){
       const msg = ctx.messages.get('qux');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, [new FluentNumber(1)]);
@@ -87,8 +87,8 @@ describe('formatToParts', function(){
     });
   });
 
-  describe('Complex value referencing a null message', function(){
-    before(function() {
+  suite('Complex value referencing a null message', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo
@@ -97,21 +97,21 @@ describe('formatToParts', function(){
       `);
     });
 
-    it('returns null', function(){
+    test('returns null', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, null);
       assert.equal(errs.length, 0);
     });
 
-    it('returns the parts of the attribute', function(){
+    test('returns the parts of the attribute', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.formatToParts(msg.attrs.attr, args, errs);
       assert_partsEqual(val, ['Foo Attr']);
       assert.equal(errs.length, 0);
     });
 
-    it('returns FluentNone', function(){
+    test('returns FluentNone', function(){
       const msg = ctx.messages.get('bar');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, [new FluentNone(), ' Bar']);
@@ -119,8 +119,8 @@ describe('formatToParts', function(){
     });
   });
 
-  describe('Nested complex values', function(){
-    before(function() {
+  suite('Nested complex values', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo { 1 }
@@ -129,21 +129,21 @@ describe('formatToParts', function(){
       `);
     });
 
-    it('returns parts of foo', function(){
+    test('returns parts of foo', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo', new FluentNumber(1)]);
       assert.equal(errs.length, 0);
     });
 
-    it('returns flattened parts of bar', function(){
+    test('returns flattened parts of bar', function(){
       const msg = ctx.messages.get('bar');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo', new FluentNumber(1), 'Bar']);
       assert.equal(errs.length, 0);
     });
 
-    it('returns flattened parts of baz', function(){
+    test('returns flattened parts of baz', function(){
       const msg = ctx.messages.get('baz');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo', new FluentNumber(1), ' Bar', ' Baz']);

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -5,22 +5,22 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Built-in functions', function() {
+suite('Built-in functions', function() {
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('NUMBER', function(){
-    before(function() {
+  suite('NUMBER', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { NUMBER(1) }
       `);
     });
 
-    it('formats the number', function() {
+    test('formats the number', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
@@ -28,10 +28,10 @@ describe('Built-in functions', function() {
     });
   });
 
-  describe('DATETIME', function(){
+  suite('DATETIME', function(){
     let dtf;
 
-    before(function() {
+    suiteSetup(function() {
       dtf = new Intl.DateTimeFormat('en-US');
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
@@ -39,7 +39,7 @@ describe('Built-in functions', function() {
       `);
     });
 
-    it('formats the date', function() {
+    test('formats the date', function() {
       const date = new Date('2016-09-29');
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, { date }, errs);

--- a/fluent/test/functions_runtime_test.js
+++ b/fluent/test/functions_runtime_test.js
@@ -5,15 +5,15 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Runtime-specific functions', function() {
+suite('Runtime-specific functions', function() {
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('passing into the constructor', function(){
-    before(function() {
+  suite('passing into the constructor', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', {
         useIsolating: false,
         functions: {
@@ -27,7 +27,7 @@ describe('Runtime-specific functions', function() {
       `);
     });
 
-    it('works for strings', function() {
+    test('works for strings', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'FooBar');

--- a/fluent/test/functions_test.js
+++ b/fluent/test/functions_test.js
@@ -5,22 +5,22 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Functions', function() {
+suite('Functions', function() {
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('missing', function(){
-    before(function() {
+  suite('missing', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { MISSING("Foo") }
       `);
     });
 
-    it('falls back to the name of the function', function() {
+    test('falls back to the name of the function', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'MISSING()');
@@ -29,8 +29,8 @@ describe('Functions', function() {
     });
   });
 
-  describe('arguments', function(){
-    before(function() {
+  suite('arguments', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', {
         useIsolating: false,
         functions: {
@@ -60,21 +60,21 @@ describe('Functions', function() {
       assert(errs[0] instanceof RangeError); // wrong argument type
     });
 
-    it('accepts strings', function() {
+    test('accepts strings', function() {
       const msg = ctx.messages.get('pass-string');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'a');
       assert.equal(errs.length, 0);
     });
 
-    it('accepts numbers', function() {
+    test('accepts numbers', function() {
       const msg = ctx.messages.get('pass-number');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
       assert.equal(errs.length, 0);
     });
 
-    it('accepts entities', function() {
+    test('accepts entities', function() {
       const msg = ctx.messages.get('pass-message');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo');
@@ -90,14 +90,14 @@ describe('Functions', function() {
       assert.equal(errs.length, 0);
     });
 
-    it('accepts externals', function() {
+    test('accepts externals', function() {
       const msg = ctx.messages.get('pass-external');
       const val = ctx.format(msg, { ext: "Ext" }, errs);
       assert.equal(val, 'Ext');
       assert.equal(errs.length, 0);
     });
 
-    it('accepts function calls', function() {
+    test('accepts function calls', function() {
       const msg = ctx.messages.get('pass-function-call');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');

--- a/fluent/test/isolating_test.js
+++ b/fluent/test/isolating_test.js
@@ -9,10 +9,10 @@ import { ftl } from './util';
 const FSI = '\u2068';
 const PDI = '\u2069';
 
-describe('Isolating interpolations', function(){
+suite('Isolating interpolations', function(){
   let ctx, args, errs;
 
-  before(function() {
+  suiteSetup(function() {
     ctx = new MessageContext('en-US');
     ctx.addMessages(ftl`
       foo = Foo
@@ -22,32 +22,32 @@ describe('Isolating interpolations', function(){
     `);
   });
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  it('isolates interpolated message references', function(){
+  test('isolates interpolated message references', function(){
     const msg = ctx.messages.get('bar');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, `${FSI}Foo${PDI} Bar`);
     assert.equal(errs.length, 0);
   });
 
-  it('isolates interpolated string-typed external arguments', function(){
+  test('isolates interpolated string-typed external arguments', function(){
     const msg = ctx.messages.get('baz');
     const val = ctx.format(msg, {arg: 'Arg'}, errs);
     assert.equal(val, `${FSI}Arg${PDI} Baz`);
     assert.equal(errs.length, 0);
   });
 
-  it('isolates interpolated number-typed external arguments', function(){
+  test('isolates interpolated number-typed external arguments', function(){
     const msg = ctx.messages.get('baz');
     const val = ctx.format(msg, {arg: 1}, errs);
     assert.equal(val, `${FSI}1${PDI} Baz`);
     assert.equal(errs.length, 0);
   });
 
-  it('isolates interpolated date-typed external arguments', function(){
+  test('isolates interpolated date-typed external arguments', function(){
     const dtf = new Intl.DateTimeFormat('en-US');
     const arg = new Date('2016-09-29');
 
@@ -58,7 +58,7 @@ describe('Isolating interpolations', function(){
     assert.equal(errs.length, 0);
   });
 
-  it('isolates complex interpolations', function(){
+  test('isolates complex interpolations', function(){
     const msg = ctx.messages.get('qux');
     const val = ctx.format(msg, {arg: 'Arg'}, errs);
 

--- a/fluent/test/patterns_test.js
+++ b/fluent/test/patterns_test.js
@@ -5,22 +5,22 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Patterns', function(){
+suite('Patterns', function(){
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('Simple string value', function(){
-    before(function() {
+  suite('Simple string value', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
       `);
     });
 
-    it('returns the value', function(){
+    test('returns the value', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo');
@@ -28,8 +28,8 @@ describe('Patterns', function(){
     });
   });
 
-  describe('Complex string value', function(){
-    before(function() {
+  suite('Complex string value', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = Foo
@@ -39,14 +39,14 @@ describe('Patterns', function(){
       `);
     });
 
-    it('returns the value', function(){
+    test('returns the value', function(){
       const msg = ctx.messages.get('bar');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'Foo Bar');
       assert.equal(errs.length, 0);
     });
 
-    it('returns the raw string if the referenced message is ' +
+    test('returns the raw string if the referenced message is ' +
        'not found', function(){
       const msg = ctx.messages.get('baz');
       const val = ctx.format(msg, args, errs);
@@ -55,8 +55,8 @@ describe('Patterns', function(){
     });
   });
 
-  describe('Complex string referencing a message with null value', function(){
-    before(function() {
+  suite('Complex string referencing a message with null value', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo
@@ -65,21 +65,21 @@ describe('Patterns', function(){
       `);
     });
 
-    it('returns the null value', function(){
+    test('returns the null value', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, null);
       assert.equal(errs.length, 0);
     });
 
-    it('formats the attribute', function(){
+    test('formats the attribute', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg.attrs.attr, args, errs);
       assert.strictEqual(val, 'Foo Attr');
       assert.equal(errs.length, 0);
     });
 
-    it('formats ??? when the referenced message has no value and no default',
+    test('formats ??? when the referenced message has no value and no default',
        function(){
       const msg = ctx.messages.get('bar');
       const val = ctx.format(msg, args, errs);
@@ -88,8 +88,8 @@ describe('Patterns', function(){
     });
   });
 
-  describe('Cyclic reference', function(){
-    before(function() {
+  suite('Cyclic reference', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { bar }
@@ -97,7 +97,7 @@ describe('Patterns', function(){
       `);
     });
 
-    it('returns ???', function(){
+    test('returns ???', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, '???');
@@ -105,15 +105,15 @@ describe('Patterns', function(){
     });
   });
 
-  describe('Cyclic self-reference', function(){
-    before(function() {
+  suite('Cyclic self-reference', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { foo }
       `);
     });
 
-    it('returns the raw string', function(){
+    test('returns the raw string', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, '???');
@@ -121,8 +121,8 @@ describe('Patterns', function(){
     });
   });
 
-  describe('Cyclic self-reference in a member', function(){
-    before(function() {
+  suite('Cyclic self-reference in a member', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { $sel ->
@@ -133,14 +133,14 @@ describe('Patterns', function(){
       `);
     });
 
-    it('returns ???', function(){
+    test('returns ???', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, {sel: 'a'}, errs);
       assert.strictEqual(val, '???');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
     });
 
-    it('returns the other member if requested', function(){
+    test('returns the other member if requested', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, {sel: 'b'}, errs);
       assert.strictEqual(val, 'Bar');
@@ -148,8 +148,8 @@ describe('Patterns', function(){
     });
   });
 
-  describe('Cyclic reference in a selector', function(){
-    before(function() {
+  suite('Cyclic reference in a selector', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { ref-foo ->
@@ -160,7 +160,7 @@ describe('Patterns', function(){
       `);
     });
 
-    it('returns the default variant', function(){
+    test('returns the default variant', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'Foo');
@@ -168,8 +168,8 @@ describe('Patterns', function(){
     });
   });
 
-  describe('Cyclic self-reference in a selector', function(){
-    before(function() {
+  suite('Cyclic self-reference in a selector', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { foo ->
@@ -183,14 +183,14 @@ describe('Patterns', function(){
       `);
     });
 
-    it('returns the default variant', function(){
+    test('returns the default variant', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'Foo');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
     });
 
-    it('can reference an attribute', function(){
+    test('can reference an attribute', function(){
       const msg = ctx.messages.get('bar');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'Bar');

--- a/fluent/test/primitives_test.js
+++ b/fluent/test/primitives_test.js
@@ -5,15 +5,15 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Primitives', function() {
+suite('Primitives', function() {
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('Numbers', function(){
-    before(function() {
+  suite('Numbers', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         one     = { 1 }
@@ -24,14 +24,14 @@ describe('Primitives', function() {
       `);
     });
 
-    it('can be used in a placeable', function(){
+    test('can be used in a placeable', function(){
       const msg = ctx.messages.get('one');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
       assert.equal(errs.length, 0);
     });
 
-    it('can be used as a selector', function(){
+    test('can be used as a selector', function(){
       const msg = ctx.messages.get('select');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'One');
@@ -39,8 +39,8 @@ describe('Primitives', function() {
     });
   });
 
-  describe('Simple string value', function(){
-    before(function() {
+  suite('Simple string value', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo               = Foo
@@ -66,61 +66,61 @@ describe('Primitives', function() {
       `);
     });
 
-    it('can be used as a value', function(){
+    test('can be used as a value', function(){
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo');
       assert.equal(errs.length, 0);
     });
 
-    it('is detected to be non-complex', function(){
+    test('is detected to be non-complex', function(){
       const msg = ctx.messages.get('foo');
       assert.equal(typeof msg, 'string');
     });
 
-    it('can be used in a placeable', function(){
+    test('can be used in a placeable', function(){
       const msg = ctx.messages.get('placeable-literal');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a value of a message referenced in a placeable', function(){
+    test('can be a value of a message referenced in a placeable', function(){
       const msg = ctx.messages.get('placeable-message');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a selector', function(){
+    test('can be a selector', function(){
       const msg = ctx.messages.get('selector-literal');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Member 1');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a value of a message used as a selector', function(){
+    test('can be a value of a message used as a selector', function(){
       const msg = ctx.messages.get('selector-message');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Member 2');
       assert.equal(errs.length, 0);
     });
 
-    it('can be used as an attribute value', function(){
+    test('can be used as an attribute value', function(){
       const msg = ctx.messages.get('bar').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a value of an attribute used in a placeable', function(){
+    test('can be a value of an attribute used in a placeable', function(){
       const msg = ctx.messages.get('placeable-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a value of an attribute used as a selector', function(){
+    test('can be a value of an attribute used as a selector', function(){
       const msg = ctx.messages.get('selector-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Member 3');
@@ -128,8 +128,8 @@ describe('Primitives', function() {
     });
   });
 
-  describe('Complex string value', function(){
-    before(function() {
+  suite('Complex string value', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo               = Foo
@@ -156,62 +156,62 @@ describe('Primitives', function() {
       `);
     });
 
-    it('can be used as a value', function(){
+    test('can be used as a value', function(){
       const msg = ctx.messages.get('bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar');
       assert.equal(errs.length, 0);
     });
 
-    it('is detected to be complex', function(){
+    test('is detected to be complex', function(){
       const msg = ctx.messages.get('bar');
       assert.equal(typeof msg, 'object');
       assert(Array.isArray(msg.val));
     });
 
-    it('can be used in a placeable', function(){
+    test('can be used in a placeable', function(){
       const msg = ctx.messages.get('placeable-literal');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar Baz');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a value of a message referenced in a placeable', function(){
+    test('can be a value of a message referenced in a placeable', function(){
       const msg = ctx.messages.get('placeable-message');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar Baz');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a selector', function(){
+    test('can be a selector', function(){
       const msg = ctx.messages.get('selector-literal');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Member 1');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a value of a message used as a selector', function(){
+    test('can be a value of a message used as a selector', function(){
       const msg = ctx.messages.get('selector-message');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Member 2');
       assert.equal(errs.length, 0);
     });
 
-    it('can be used as an attribute value', function(){
+    test('can be used as an attribute value', function(){
       const msg = ctx.messages.get('baz').attrs.attr
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar Baz Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a value of an attribute used in a placeable', function(){
+    test('can be a value of an attribute used in a placeable', function(){
       const msg = ctx.messages.get('placeable-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar Baz Attribute');
       assert.equal(errs.length, 0);
     });
 
-    it('can be a value of an attribute used as a selector', function(){
+    test('can be a value of an attribute used as a selector', function(){
       const msg = ctx.messages.get('selector-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Member 3');

--- a/fluent/test/select_expressions_test.js
+++ b/fluent/test/select_expressions_test.js
@@ -5,15 +5,15 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Select expressions', function() {
+suite('Select expressions', function() {
   let ctx, args, errs;
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  describe('with a matching selector', function(){
-    before(function() {
+  suite('with a matching selector', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { "a" ->
@@ -23,7 +23,7 @@ describe('Select expressions', function() {
       `);
     });
 
-    it('selects the variant matching the selector', function() {
+    test('selects the variant matching the selector', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
@@ -31,8 +31,8 @@ describe('Select expressions', function() {
     });
   });
 
-  describe('with a valid non-matching selector', function(){
-    before(function() {
+  suite('with a valid non-matching selector', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { "c" ->
@@ -42,7 +42,7 @@ describe('Select expressions', function() {
       `);
     });
 
-    it('selects the default variant', function() {
+    test('selects the default variant', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
@@ -50,8 +50,8 @@ describe('Select expressions', function() {
     });
   });
 
-  describe('with an invalid selector', function(){
-    before(function() {
+  suite('with an invalid selector', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { bar ->
@@ -61,7 +61,7 @@ describe('Select expressions', function() {
       `);
     });
 
-    it('selects the default variant', function() {
+    test('selects the default variant', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
@@ -70,8 +70,8 @@ describe('Select expressions', function() {
     });
   });
 
-  describe('with a number selector', function(){
-    before(function() {
+  suite('with a number selector', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { 1 ->
@@ -86,21 +86,21 @@ describe('Select expressions', function() {
       `);
     });
 
-    it('selects the right variant', function() {
+    test('selects the right variant', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'B');
     });
 
-    it('selects the default variant', function() {
+    test('selects the default variant', function() {
       const msg = ctx.messages.get('bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
     });
   });
 
-  describe('with a number selector and plural categories', function(){
-    before(function() {
+  suite('with a number selector and plural categories', function(){
+    suiteSetup(function() {
       ctx = new MessageContext('en-US', { useIsolating: false });
       ctx.addMessages(ftl`
         foo = { 1 ->
@@ -115,13 +115,13 @@ describe('Select expressions', function() {
       `);
     });
 
-    it('selects the right category', function() {
+    test('selects the right category', function() {
       const msg = ctx.messages.get('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
     });
 
-    it('selects the exact match', function() {
+    test('selects the exact match', function() {
       const msg = ctx.messages.get('bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');

--- a/fluent/test/values_format_test.js
+++ b/fluent/test/values_format_test.js
@@ -5,10 +5,10 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Formatting values', function(){
+suite('Formatting values', function(){
   let ctx, args, errs;
 
-  before(function() {
+  suiteSetup(function() {
     ctx = new MessageContext('en-US', { useIsolating: false });
     ctx.addMessages(ftl`
       key1 = Value 1
@@ -27,46 +27,46 @@ describe('Formatting values', function(){
     `);
   });
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  it('returns the value', function(){
+  test('returns the value', function(){
     const msg = ctx.messages.get('key1');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Value 1');
     assert.equal(errs.length, 0);
   });
 
-  it('returns the default variant', function(){
+  test('returns the default variant', function(){
     const msg = ctx.messages.get('key2');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'B2');
     assert.equal(errs.length, 0);
   });
 
-  it('returns the value if it is a pattern', function(){
+  test('returns the value if it is a pattern', function(){
     const msg = ctx.messages.get('key3');
     const val = ctx.format(msg, args, errs)
     assert.strictEqual(val, 'Value 3');
     assert.equal(errs.length, 0);
   });
 
-  it('returns the default variant if it is a pattern', function(){
+  test('returns the default variant if it is a pattern', function(){
     const msg = ctx.messages.get('key4');
     const val = ctx.format(msg, args, errs)
     assert.strictEqual(val, 'B4');
     assert.equal(errs.length, 0);
   });
 
-  it('returns null if there is no value', function(){
+  test('returns null if there is no value', function(){
     const msg = ctx.messages.get('key5');
     const val = ctx.format(msg, args, errs);
     assert.strictEqual(val, null);
     assert.equal(errs.length, 0);
   });
 
-  it('allows to pass traits directly to ctx.format', function(){
+  test('allows to pass traits directly to ctx.format', function(){
     const msg = ctx.messages.get('key5');
     assert.strictEqual(ctx.format(msg.attrs.a, args, errs), 'A5');
     assert.strictEqual(ctx.format(msg.attrs.b, args, errs), 'B5');

--- a/fluent/test/values_ref_test.js
+++ b/fluent/test/values_ref_test.js
@@ -5,10 +5,10 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-describe('Referencing values', function(){
+suite('Referencing values', function(){
   let ctx, args, errs;
 
-  before(function() {
+  suiteSetup(function() {
     ctx = new MessageContext('en-US', { useIsolating: false });
     ctx.addMessages(ftl`
       key1 = Value 1
@@ -42,46 +42,46 @@ describe('Referencing values', function(){
     `);
   });
 
-  beforeEach(function() {
+  setup(function() {
     errs = [];
   });
 
-  it('references the value', function(){
+  test('references the value', function(){
     const msg = ctx.messages.get('ref1');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Value 1');
     assert.equal(errs.length, 0);
   });
 
-  it('references the default variant', function(){
+  test('references the default variant', function(){
     const msg = ctx.messages.get('ref2');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'B2');
     assert.equal(errs.length, 0);
   });
 
-  it('references the value if it is a pattern', function(){
+  test('references the value if it is a pattern', function(){
     const msg = ctx.messages.get('ref3');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Value 3');
     assert.equal(errs.length, 0);
   });
 
-  it('references the default variant if it is a pattern', function(){
+  test('references the default variant if it is a pattern', function(){
     const msg = ctx.messages.get('ref4');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'B4');
     assert.equal(errs.length, 0);
   });
 
-  it('uses ??? if there is no value', function(){
+  test('uses ??? if there is no value', function(){
     const msg = ctx.messages.get('ref5');
     const val = ctx.format(msg, args, errs);
     assert.strictEqual(val, '???');
     assert.ok(errs[0] instanceof RangeError); // no default
   });
 
-  it('references the variants', function(){
+  test('references the variants', function(){
     const msg_a = ctx.messages.get('ref6');
     const msg_b = ctx.messages.get('ref7');
     const val_a = ctx.format(msg_a, args, errs)
@@ -91,7 +91,7 @@ describe('Referencing values', function(){
     assert.equal(errs.length, 0);
   });
 
-  it('references the variants which are patterns', function(){
+  test('references the variants which are patterns', function(){
     const msg_a = ctx.messages.get('ref8');
     const msg_b = ctx.messages.get('ref9');
     const val_a = ctx.format(msg_a, args, errs)
@@ -101,7 +101,7 @@ describe('Referencing values', function(){
     assert.equal(errs.length, 0);
   });
 
-  it('references the attributes', function(){
+  test('references the attributes', function(){
     const msg_a = ctx.messages.get('ref10');
     const msg_b = ctx.messages.get('ref11');
     const val_a = ctx.format(msg_a, args, errs)


### PR DESCRIPTION
It looks like we've naturally gravitated towards using the TDD in our test descriptions. The exception are some of the resolver tests; I'll fix them progressively.

Let's switch to using TDD in the whole project so that writing new tests feels easier.