### PR TITLE
fluent-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ be installed independently of each other.
   - [fluent-intl-polyfill](https://github.com/projectfluent/fluent.js/tree/master/fluent-intl-polyfill)
   - [fluent-langneg](https://github.com/projectfluent/fluent.js/tree/master/fluent-langneg)
   - [fluent-react](https://github.com/projectfluent/fluent.js/tree/master/fluent-react)
+  - [fluent-merge](https://github.com/projectfluent/fluent.js/tree/master/fluent-merge)
 
 
 Learn the FTL syntax

--- a/fluent-merge/.gitignore
+++ b/fluent-merge/.gitignore
@@ -1,0 +1,2 @@
+fluent-merge.js
+compat.js

--- a/fluent-merge/.npmignore
+++ b/fluent-merge/.npmignore
@@ -1,0 +1,3 @@
+docs
+test
+makefile

--- a/fluent-merge/CHANGELOG.md
+++ b/fluent-merge/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+  - …
+
+## fluent-merge 0.0.1
+
+  - Command Line Tool for merging localization files.
+
+    The initial release.

--- a/fluent-merge/README.md
+++ b/fluent-merge/README.md
@@ -1,0 +1,52 @@
+# fluent-merge
+
+`fluent-merge` is a command line utility for merging localization files.  It's
+part of Project Fluent, a localization framework designed to unleash the
+expressive power of the natural language.
+
+
+## Installation
+
+    npm install -g fluent-merge
+
+
+## Usage
+
+    $ fluent-merge en-US.ftl de.ftl
+
+
+## API
+
+`fluent-merge` can be used both on the client-side and the server-side.
+You can install it from the npm registry or use it as a standalone script.
+
+    npm install fluent-merge
+
+Two functions are available: `mergeFiles` for merging text files and
+`mergeResources` for merging AST trees.
+
+```javascript
+import { mergeFiles } from 'fluent-merge';
+
+async function merge(paths) {
+  const buffers = await Promise.all(
+    program.args.map(
+      path => readFile(path)
+    )
+  );
+
+  const files = buffers.map(buffer => buffer.toString());
+  return mergeFiles(...files);
+}
+```
+
+
+## Learn more
+
+Find out more about Project Fluent at [projectfluent.io][], including
+documentation of the Fluent file format ([FTL][]), links to other packages and
+implementations, and information about how to get involved.
+
+
+[projectfluent.io]: http://projectfluent.io
+[FTL]: http://projectfluent.io/fluent/guide/

--- a/fluent-merge/bin/fs.js
+++ b/fluent-merge/bin/fs.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const fs = require('fs');
+
+exports.readFile = function readFile(filename) {
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filename, function(err, buffer) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(buffer);
+      }
+    });
+  });
+};

--- a/fluent-merge/bin/index.js
+++ b/fluent-merge/bin/index.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const program = require('commander');
+const { readFile } = require('./fs');
+
+require('babel-register')({
+  plugins: ['transform-es2015-modules-commonjs']
+});
+
+const { mergeFiles } = require('../src');
+
+program
+  .version('0.0.1')
+  .usage('[options] [files]')
+  .parse(process.argv);
+
+if (program.args.length === 0) {
+  process.exit(1);
+}
+
+Promise.all(
+  program.args.map(
+    path => readFile(path)
+  )
+).then(buffers => {
+  const files = buffers.map(buffer => buffer.toString());
+  const merged = mergeFiles(...files);
+  console.log(merged);
+}).catch(console.error);

--- a/fluent-merge/makefile
+++ b/fluent-merge/makefile
@@ -1,0 +1,25 @@
+PACKAGE := fluent-merge
+GLOBAL  := FluentMerge
+DEPS    := fluent-syntax:FluentSyntax
+
+include ../common.mk
+
+build: $(PACKAGE).js
+compat: compat.js
+
+$(PACKAGE).js: $(SOURCES)
+	@rollup $(CURDIR)/src/index.js \
+	    --format umd \
+	    --id $(PACKAGE) \
+	    --name $(GLOBAL) \
+	    --globals $(DEPS) \
+	    --output $@
+	@echo -e " $(OK) $@ built"
+
+compat.js: $(PACKAGE).js
+	@babel --presets latest $< > $@
+	@echo -e " $(OK) $@ built"
+
+clean:
+	@rm -f $(PACKAGE).js compat.js
+	@echo -e " $(OK) clean"

--- a/fluent-merge/package.json
+++ b/fluent-merge/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "fluent-merge",
+  "description": "Merge Fluent localization resources",
+  "version": "0.0.1",
+  "homepage": "http://projectfluent.io",
+  "author": "Mozilla <l10n-drivers@mozilla.org>",
+  "license": "Apache-2.0",
+  "contributors": [
+    {
+      "name": "Zibi Braniecki",
+      "email": "zbraniecki@mozilla.com"
+    },
+    {
+      "name": "Staś Małolepszy",
+      "email": "stas@mozilla.com"
+    }
+  ],
+  "directories": {
+    "lib": "./src"
+  },
+  "main": "./fluent-merge.js",
+  "bin": {
+    "fluent-merge": "./bin/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/projectfluent/fluent.js.git"
+  },
+  "keywords": [
+    "localization",
+    "l10n"
+  ],
+  "engine": {
+    "node": ">=6"
+  },
+  "dependencies": {
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+    "babel-register": "^6.23.0",
+    "fluent-syntax": "^0.2.0"
+  }
+}

--- a/fluent-merge/src/index.js
+++ b/fluent-merge/src/index.js
@@ -1,0 +1,66 @@
+import { Resource, parse, serialize } from 'fluent-syntax';
+
+/*
+ * Merge text files into one file.
+ */
+export function mergeFiles(...files) {
+  const resources = files.map(parse);
+  const merged = resources.reduce(merge);
+  return serialize(merged);
+}
+
+/*
+ * Merge AST trees into one tree.
+ */
+export function mergeResources(...resources) {
+  const merged = resources.reduce(merge);
+  return merged;
+}
+
+/*
+ * Merge messages of two resources.
+ *
+ * The first resource is treated as the reference. Sections and Junk entries
+ * are ignored.
+ */
+function merge(res1, res2) {
+  const body = [];
+
+  for (const message of messages(res1)) {
+    const other = findMessage(res2, message.id.name);
+    if (other) {
+      body.push(other);
+    } else {
+      body.push(message);
+    }
+  }
+
+  const merged = new Resource(body, res1.comment);
+  merged.source = serialize(merged);
+
+  return merged;
+}
+
+/*
+ * Find a message in `res` by its `id`.
+ */
+function findMessage(res, id) {
+  for (const message of messages(res)) {
+    if (message.id.name === id) {
+      return message;
+    }
+  }
+
+  return null;
+}
+
+/*
+ * Create an iterator over Resource's messages.
+ */
+function* messages(res) {
+  for (const entry of res.body) {
+    if (entry.type === 'Message') {
+      yield entry;
+    }
+  }
+}

--- a/fluent-merge/test/merge_files_test.js
+++ b/fluent-merge/test/merge_files_test.js
@@ -1,0 +1,41 @@
+import assert from 'assert';
+
+import { ftl } from './util';
+import { mergeFiles } from '../src';
+
+suite('mergeFiles', function() {
+  test('overwrite existing messages', function() {
+    const res1 = ftl`
+      foo = Foo
+      bar = Bar
+    `;
+
+    const res2 = ftl`
+      foo = FOO
+    `;
+
+    const merged = mergeFiles(res1, res2);
+
+    assert.equal(merged, ftl`
+      foo = FOO
+      bar = Bar
+    `);
+  });
+
+  test('ignore obsolete messages', function() {
+    const res1 = ftl`
+      foo = Foo
+    `;
+
+    const res2 = ftl`
+      foo = FOO
+      bar = BAR
+    `;
+
+    const merged = mergeFiles(res1, res2);
+
+    assert.equal(merged, ftl`
+      foo = FOO
+    `);
+  });
+});

--- a/fluent-merge/test/setup.js
+++ b/fluent-merge/test/setup.js
@@ -1,0 +1,3 @@
+require('babel-register')({
+  plugins: ['transform-es2015-modules-commonjs']
+});

--- a/fluent-merge/test/util.js
+++ b/fluent-merge/test/util.js
@@ -1,0 +1,22 @@
+'use strict';
+
+function nonBlank(line) {
+  return !/^\s*$/.test(line);
+}
+
+function countIndent(line) {
+  const [indent] = line.match(/^\s*/);
+  return indent.length;
+}
+
+export function ftl(strings) {
+  const [code] = strings;
+  const lines = code.split('\n').slice(1, -1);
+  const indents = lines.filter(nonBlank).map(countIndent);
+  const common = Math.min(...indents);
+  const indent = new RegExp(`^\\s{${common}}`);
+
+  return lines.map(
+    line => line.replace(indent, '')
+  ).join('\n');
+}


### PR DESCRIPTION
`fluent-merge` is a simple command line utility for merging localization files. It uses the first resource as the reference. Messages from other resources which don't exist in the first resource are ignored.

In the future we can change the exact merging logic. For instance, we could follow the logic of `Object.assign` in ECMAScript, or additionally merge any messages referenced by other merged messages.