### PR TITLE
Add hasMessage, getMessage and the messages iterator to MessageContext

### DIFF
--- a/fluent-react/src/localization.js
+++ b/fluent-react/src/localization.js
@@ -48,7 +48,7 @@ export default class Localization {
    */
   getMessageContext(id) {
     for (const context of this.contexts) {
-      if (context.messages.has(id)) {
+      if (context.hasMessage(id)) {
         return context;
       }
     }

--- a/fluent-react/src/localized.js
+++ b/fluent-react/src/localized.js
@@ -139,7 +139,7 @@ export default class Localized extends Component {
       return elem;
     }
 
-    const msg = mcx.messages.get(id);
+    const msg = mcx.getMessage(id);
     const args = withElements(this.props);
     const parts = mcx.formatToParts(msg, args) || [];
 

--- a/fluent-react/test/localized_change_test.js
+++ b/fluent-react/test/localized_change_test.js
@@ -24,7 +24,7 @@ suite('Localized - change messages', function() {
     ));
 
     const mcx2 = new MessageContext();
-    sinon.stub(mcx2.messages, 'get').returns('BAR');
+    sinon.stub(mcx2, 'getMessage').returns('BAR');
     l10n.setMessages([mcx2]);
 
     assert.equal(wrapper.state('mcx'), mcx2);

--- a/fluent-react/test/localized_fallback_test.js
+++ b/fluent-react/test/localized_fallback_test.js
@@ -26,7 +26,7 @@ suite('Localized - fallback', function() {
 
   test('message id in the second context', function() {
     const mcx1 = new MessageContext();
-    sinon.stub(mcx1.messages, 'has').returns(false);
+    sinon.stub(mcx1, 'hasMessage').returns(false);
     const mcx2 = new MessageContext();
     const l10n = new Localization([mcx1, mcx2]);
 
@@ -45,7 +45,7 @@ suite('Localized - fallback', function() {
 
   test('missing message', function() {
     const mcx1 = new MessageContext();
-    sinon.stub(mcx1.messages, 'has').returns(false);
+    sinon.stub(mcx1, 'hasMessage').returns(false);
     const l10n = new Localization([mcx1]);
 
     const wrapper = shallow(

--- a/fluent-react/test/localized_render_test.js
+++ b/fluent-react/test/localized_render_test.js
@@ -25,7 +25,7 @@ suite('Localized - rendering', function() {
 
   test('rendering the attributes', function() {
     const mcx = new MessageContext();
-    sinon.stub(mcx.messages, 'get').returns({
+    sinon.stub(mcx, 'getMessage').returns({
       value: null,
       attrs: { attr: 'ATTR' }
     });
@@ -46,7 +46,7 @@ suite('Localized - rendering', function() {
 
   test('preserves existing attributes', function() {
     const mcx = new MessageContext();
-    sinon.stub(mcx.messages, 'get').returns({
+    sinon.stub(mcx, 'getMessage').returns({
       value: null,
       attrs: { attr: 'ATTR' }
     });
@@ -83,7 +83,7 @@ suite('Localized - rendering', function() {
 
   test('$arg is passed to format the attributes', function() {
     const mcx = new MessageContext();
-    sinon.stub(mcx.messages, 'get').returns({
+    sinon.stub(mcx, 'getMessage').returns({
       value: null,
       attrs: { attr: 'ATTR' }
     });

--- a/fluent-react/test/message_context_stub.js
+++ b/fluent-react/test/message_context_stub.js
@@ -1,13 +1,10 @@
 export default class MessageContext {
-  constructor() {
-    this.messages = {
-      has(id) {
-        return true;
-      },
-      get(id) {
-        return id.toUpperCase();
-      },
-    };
+  hasMessage(id) {
+    return true;
+  }
+
+  getMessage(id) {
+    return id.toUpperCase();
   }
 
   format(msg) {

--- a/fluent/CHANGELOG.md
+++ b/fluent/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+  - Added MessageContext.hasMessage and MessageContext.getMessage methods.
+
+    Using the MessageContext.messages map for getting raw messages is
+    deprecated now.  Instead, use the two dedicated methods: hasMessage and
+    getMessage.
+
+    Before:
+
+        const msg = ctx.messages.get(id);
+        const txt = ctx.format(msg);
+
+    Now:
+
+        const msg = ctx.getMessage(id);
+        const txt = ctx.format(msg);
+
   - The compat build is now transpiled using rollup-plugin-babel.
 
     This ensures that the "use strict" pragma is scoped to the UMD wrapper.  It

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -32,7 +32,7 @@ if (errors.length) {
   // syntax errors are per-message and don't break the whole resource
 }
 
-const welcome = ctx.messages.get('welcome');
+const welcome = ctx.getMessage('welcome');
 
 ctx.format(welcome, { name: 'Anna' });
 // → 'Welcome, Anna, to Foo 3000!'

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -85,7 +85,7 @@ function DefaultMember(env, members, def) {
  */
 function MessageReference(env, {name}) {
   const { ctx, errors } = env;
-  const message = ctx.messages.get(name);
+  const message = ctx.getMessage(name);
 
   if (!message) {
     errors.push(new ReferenceError(`Unknown message: ${name}`));
@@ -102,7 +102,7 @@ function MessageReference(env, {name}) {
  */
 function Tags(env, {name}) {
   const { ctx, errors } = env;
-  const message = ctx.messages.get(name);
+  const message = ctx.getMessage(name);
 
   if (!message) {
     errors.push(new ReferenceError(`Unknown message: ${name}`));
@@ -330,8 +330,8 @@ function ExternalArgument(env, {name}) {
 function FunctionReference(env, {name}) {
   // Some functions are built-in.  Others may be provided by the runtime via
   // the `MessageContext` constructor.
-  const { ctx: { functions }, errors } = env;
-  const func = functions[name] || builtins[name];
+  const { ctx: { _functions }, errors } = env;
+  const func = _functions[name] || builtins[name];
 
   if (!func) {
     errors.push(new ReferenceError(`Unknown function: ${name}()`));
@@ -398,7 +398,7 @@ function Pattern(env, ptn) {
 
     const part = Type(env, elem);
 
-    if (ctx.useIsolating) {
+    if (ctx._useIsolating) {
       result.push(FSI);
     }
 
@@ -420,7 +420,7 @@ function Pattern(env, ptn) {
       result.push(part);
     }
 
-    if (ctx.useIsolating) {
+    if (ctx._useIsolating) {
       result.push(PDI);
     }
   }

--- a/fluent/test/arguments_test.js
+++ b/fluent/test/arguments_test.js
@@ -27,28 +27,28 @@ suite('External arguments', function() {
     });
 
     test('can be used in the message value', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Foo 3');
       assert.equal(errs.length, 0);
     });
 
     test('can be used in the message value which is referenced', function() {
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Foo 3');
       assert.equal(errs.length, 0);
     });
 
     test('can be used in an attribute', function() {
-      const msg = ctx.messages.get('baz').attrs.attr;
+      const msg = ctx.getMessage('baz').attrs.attr;
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Baz Attribute 3');
       assert.equal(errs.length, 0);
     });
 
     test('can be used in a variant', function() {
-      const msg = ctx.messages.get('qux');
+      const msg = ctx.getMessage('qux');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Baz Variant A 3');
       assert.equal(errs.length, 0);
@@ -66,7 +66,7 @@ suite('External arguments', function() {
     });
 
     test('can be used as a selector', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, 'Foo');
       assert.equal(errs.length, 0);
@@ -82,7 +82,7 @@ suite('External arguments', function() {
     });
 
     test('can be a positional argument', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { num: 3 }, errs);
       assert.equal(val, '3');
       assert.equal(errs.length, 0);
@@ -98,49 +98,49 @@ suite('External arguments', function() {
     });
 
     test('falls back to argument\'s name if it\'s missing', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, {}, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof ReferenceError); // unknown external
     });
 
     test('cannot be arrays', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { arg: [1, 2, 3] }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
     test('cannot be a dict-like object', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { arg: { prop: 1 } }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
     test('cannot be a boolean', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { arg: true }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
     test('cannot be undefined', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { arg: undefined }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
     test('cannot be null', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { arg: null }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
     });
 
     test('cannot be a function', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { arg: () => null }, errs);
       assert.equal(val, 'arg');
       assert(errs[0] instanceof TypeError); // unsupported external type
@@ -161,7 +161,7 @@ suite('External arguments', function() {
     });
 
     test('can be a string', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Argument');
       assert.equal(errs.length, 0);
@@ -182,7 +182,7 @@ suite('External arguments', function() {
     });
 
     test('can be a number', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
       assert.equal(errs.length, 0);
@@ -204,7 +204,7 @@ suite('External arguments', function() {
     });
 
     test('can be a date', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       // format the date argument to account for the testrunner's timezone
       assert.equal(val, dtf.format(args.arg));

--- a/fluent/test/attributes_test.js
+++ b/fluent/test/attributes_test.js
@@ -31,7 +31,7 @@ suite('Attributes', function() {
     });
 
     test('falls back gracefully for entities with string values and no attributes', function() {
-      const msg = ctx.messages.get('ref-foo');
+      const msg = ctx.getMessage('ref-foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo');
       assert.equal(errs.length, 1);
@@ -39,7 +39,7 @@ suite('Attributes', function() {
     });
 
     test('falls back gracefully for entities with string values and other attributes', function() {
-      const msg = ctx.messages.get('ref-bar');
+      const msg = ctx.getMessage('ref-bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar');
       assert.equal(errs.length, 1);
@@ -47,7 +47,7 @@ suite('Attributes', function() {
     });
 
     test('falls back gracefully for entities with pattern values and no attributes', function() {
-      const msg = ctx.messages.get('ref-baz');
+      const msg = ctx.getMessage('ref-baz');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Baz');
       assert.equal(errs.length, 1);
@@ -55,7 +55,7 @@ suite('Attributes', function() {
     });
 
     test('falls back gracefully for entities with pattern values and other attributes', function() {
-      const msg = ctx.messages.get('ref-qux');
+      const msg = ctx.getMessage('ref-qux');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Qux');
       assert.equal(errs.length, 1);
@@ -78,28 +78,28 @@ suite('Attributes', function() {
     });
 
     test('can be referenced for entities with string values', function() {
-      const msg = ctx.messages.get('ref-foo');
+      const msg = ctx.getMessage('ref-foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be formatted directly for entities with string values', function() {
-      const msg = ctx.messages.get('foo').attrs.attr;
+      const msg = ctx.getMessage('foo').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be referenced for entities with pattern values', function() {
-      const msg = ctx.messages.get('ref-bar');
+      const msg = ctx.getMessage('ref-bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be formatted directly for entities with pattern values', function() {
-      const msg = ctx.messages.get('bar').attrs.attr;
+      const msg = ctx.getMessage('bar').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar Attribute');
       assert.equal(errs.length, 0);
@@ -125,42 +125,42 @@ suite('Attributes', function() {
     });
 
     test('can be referenced for entities with string values', function() {
-      const msg = ctx.messages.get('ref-bar');
+      const msg = ctx.getMessage('ref-bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be formatted directly for entities with string values', function() {
-      const msg = ctx.messages.get('bar').attrs.attr;
+      const msg = ctx.getMessage('bar').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be referenced for entities with simple pattern values', function() {
-      const msg = ctx.messages.get('ref-baz');
+      const msg = ctx.getMessage('ref-baz');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be formatted directly for entities with simple pattern values', function() {
-      const msg = ctx.messages.get('baz').attrs.attr;
+      const msg = ctx.getMessage('baz').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('works with self-references', function() {
-      const msg = ctx.messages.get('ref-qux');
+      const msg = ctx.getMessage('ref-qux');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Qux Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be formatted directly when it uses a self-reference', function() {
-      const msg = ctx.messages.get('qux').attrs.attr;
+      const msg = ctx.getMessage('qux').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Qux Attribute');
       assert.equal(errs.length, 0);
@@ -182,14 +182,14 @@ suite('Attributes', function() {
     });
 
     test('can be referenced', function() {
-      const msg = ctx.messages.get('ref-foo');
+      const msg = ctx.getMessage('ref-foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
       assert.equal(errs.length, 0);
     });
 
     test('can be formatted directly', function() {
-      const msg = ctx.messages.get('foo').attrs.attr;
+      const msg = ctx.getMessage('foo').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
       assert.equal(errs.length, 0);

--- a/fluent/test/bomb_test.js
+++ b/fluent/test/bomb_test.js
@@ -33,7 +33,7 @@ suite('Reference bombs', function() {
     // XXX Protect the FTL Resolver against the billion laughs attack
     // https://bugzil.la/1307126
     it.skip('does not expand all placeables', function() {
-      const msg = ctx.messages.get('lolz');
+      const msg = ctx.getMessage('lolz');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '???');
       assert.equal(errs.length, 1);

--- a/fluent/test/constructor_test.js
+++ b/fluent/test/constructor_test.js
@@ -22,7 +22,7 @@ suite('MessageContext constructor', function() {
       foo = Foo { 1 }
     `);
 
-    const msg = ctx.messages.get('foo');
+    const msg = ctx.getMessage('foo');
     const val = ctx.format(msg, null, errs);
 
     assert.equal(val, 'Foo 1');
@@ -39,7 +39,7 @@ suite('MessageContext constructor', function() {
       foo = Foo { 1 }
     `);
 
-    const msg = ctx.messages.get('foo');
+    const msg = ctx.getMessage('foo');
     const val = ctx.format(msg, null, errs);
 
     assert.equal(val, 'Foo 1');

--- a/fluent/test/context_test.js
+++ b/fluent/test/context_test.js
@@ -25,21 +25,21 @@ suite('Context', function() {
       ctx.addMessages(ftl`
         baz = Baz
       `);
-      assert(ctx.messages.has('foo'));
-      assert(ctx.messages.has('bar'));
-      assert(ctx.messages.has('baz'));
+      assert(ctx.hasMessage('foo'));
+      assert(ctx.hasMessage('bar'));
+      assert(ctx.hasMessage('baz'));
     });
 
     test('overwrites existing messages if the ids are the same', function() {
       ctx.addMessages(ftl`
         foo = New Foo
       `);
-      assert(ctx.messages.has('foo'));
-      assert(ctx.messages.has('bar'));
-      assert(ctx.messages.has('baz'));
-      assert.equal(ctx.messages.size, 3);
+      assert(ctx.hasMessage('foo'));
+      assert(ctx.hasMessage('bar'));
+      assert(ctx.hasMessage('baz'));
+      assert.equal(ctx._messages.size, 3);
 
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'New Foo');
       assert.equal(errs.length, 0);

--- a/fluent/test/format_parts_test.js
+++ b/fluent/test/format_parts_test.js
@@ -47,7 +47,7 @@ suite('formatToParts', function(){
     });
 
     test('returns the parts', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo']);
       assert.equal(errs.length, 0);
@@ -66,21 +66,21 @@ suite('formatToParts', function(){
     });
 
     test('returns the parts', function(){
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo', ' Bar']);
       assert.equal(errs.length, 0);
     });
 
     test('returns FluentNone', function(){
-      const msg = ctx.messages.get('baz');
+      const msg = ctx.getMessage('baz');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, [new FluentNone('missing')]);
       assert.ok(errs[0] instanceof ReferenceError); // unknown message
     });
 
     test('returns FluentNumber', function(){
-      const msg = ctx.messages.get('qux');
+      const msg = ctx.getMessage('qux');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, [new FluentNumber(1)]);
       assert.equal(errs.length, 0);
@@ -98,21 +98,21 @@ suite('formatToParts', function(){
     });
 
     test('returns null', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, null);
       assert.equal(errs.length, 0);
     });
 
     test('returns the parts of the attribute', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.formatToParts(msg.attrs.attr, args, errs);
       assert_partsEqual(val, ['Foo Attr']);
       assert.equal(errs.length, 0);
     });
 
     test('returns FluentNone', function(){
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, [new FluentNone(), ' Bar']);
       assert.ok(errs[0] instanceof RangeError); // no default
@@ -130,21 +130,21 @@ suite('formatToParts', function(){
     });
 
     test('returns parts of foo', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo', new FluentNumber(1)]);
       assert.equal(errs.length, 0);
     });
 
     test('returns flattened parts of bar', function(){
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo', new FluentNumber(1), 'Bar']);
       assert.equal(errs.length, 0);
     });
 
     test('returns flattened parts of baz', function(){
-      const msg = ctx.messages.get('baz');
+      const msg = ctx.getMessage('baz');
       const val = ctx.formatToParts(msg, args, errs);
       assert_partsEqual(val, ['Foo', new FluentNumber(1), ' Bar', ' Baz']);
       assert.equal(errs.length, 0);

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -21,7 +21,7 @@ suite('Built-in functions', function() {
     });
 
     test('formats the number', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
       assert.equal(errs.length, 0);
@@ -41,7 +41,7 @@ suite('Built-in functions', function() {
 
     test('formats the date', function() {
       const date = new Date('2016-09-29');
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, { date }, errs);
       // format the date argument to account for the testrunner's timezone
       assert.equal(val, dtf.format(date));

--- a/fluent/test/functions_runtime_test.js
+++ b/fluent/test/functions_runtime_test.js
@@ -28,7 +28,7 @@ suite('Runtime-specific functions', function() {
     });
 
     test('works for strings', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'FooBar');
       assert.equal(errs.length, 0);
@@ -37,7 +37,7 @@ suite('Runtime-specific functions', function() {
     // XXX When passed as external args, convert JS types to FTL types
     // https://bugzil.la/1307116
     it.skip('works for numbers', function() {
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '3');
       assert.equal(errs.length, 0);

--- a/fluent/test/functions_test.js
+++ b/fluent/test/functions_test.js
@@ -21,7 +21,7 @@ suite('Functions', function() {
     });
 
     test('falls back to the name of the function', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'MISSING()');
       assert.equal(errs.length, 1);
@@ -53,7 +53,7 @@ suite('Functions', function() {
     // XXX Gracefully handle wrong argument types passed into FTL Functions
     // https://bugzil.la/1307124
     it.skip('falls back when arguments don\'t match the arity', function() {
-      const msg = ctx.messages.get('pass-nothing');
+      const msg = ctx.getMessage('pass-nothing');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'IDENTITY()');
       assert.equal(errs.length, 1);
@@ -61,21 +61,21 @@ suite('Functions', function() {
     });
 
     test('accepts strings', function() {
-      const msg = ctx.messages.get('pass-string');
+      const msg = ctx.getMessage('pass-string');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'a');
       assert.equal(errs.length, 0);
     });
 
     test('accepts numbers', function() {
-      const msg = ctx.messages.get('pass-number');
+      const msg = ctx.getMessage('pass-number');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
       assert.equal(errs.length, 0);
     });
 
     test('accepts entities', function() {
-      const msg = ctx.messages.get('pass-message');
+      const msg = ctx.getMessage('pass-message');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo');
       assert.equal(errs.length, 0);
@@ -84,21 +84,21 @@ suite('Functions', function() {
     // XXX Accept complex types (e.g. attributes) as arguments to FTL Functions
     // https://bugzil.la/1307120
     it.skip('accepts attributes', function() {
-      const msg = ctx.messages.get('pass-attr');
+      const msg = ctx.getMessage('pass-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('accepts externals', function() {
-      const msg = ctx.messages.get('pass-external');
+      const msg = ctx.getMessage('pass-external');
       const val = ctx.format(msg, { ext: "Ext" }, errs);
       assert.equal(val, 'Ext');
       assert.equal(errs.length, 0);
     });
 
     test('accepts function calls', function() {
-      const msg = ctx.messages.get('pass-function-call');
+      const msg = ctx.getMessage('pass-function-call');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
       assert.equal(errs.length, 0);

--- a/fluent/test/isolating_test.js
+++ b/fluent/test/isolating_test.js
@@ -27,21 +27,21 @@ suite('Isolating interpolations', function(){
   });
 
   test('isolates interpolated message references', function(){
-    const msg = ctx.messages.get('bar');
+    const msg = ctx.getMessage('bar');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, `${FSI}Foo${PDI} Bar`);
     assert.equal(errs.length, 0);
   });
 
   test('isolates interpolated string-typed external arguments', function(){
-    const msg = ctx.messages.get('baz');
+    const msg = ctx.getMessage('baz');
     const val = ctx.format(msg, {arg: 'Arg'}, errs);
     assert.equal(val, `${FSI}Arg${PDI} Baz`);
     assert.equal(errs.length, 0);
   });
 
   test('isolates interpolated number-typed external arguments', function(){
-    const msg = ctx.messages.get('baz');
+    const msg = ctx.getMessage('baz');
     const val = ctx.format(msg, {arg: 1}, errs);
     assert.equal(val, `${FSI}1${PDI} Baz`);
     assert.equal(errs.length, 0);
@@ -51,7 +51,7 @@ suite('Isolating interpolations', function(){
     const dtf = new Intl.DateTimeFormat('en-US');
     const arg = new Date('2016-09-29');
 
-    const msg = ctx.messages.get('baz');
+    const msg = ctx.getMessage('baz');
     const val = ctx.format(msg, {arg}, errs);
     // format the date argument to account for the testrunner's timezone
     assert.equal(val, `${FSI}${dtf.format(arg)}${PDI} Baz`);
@@ -59,7 +59,7 @@ suite('Isolating interpolations', function(){
   });
 
   test('isolates complex interpolations', function(){
-    const msg = ctx.messages.get('qux');
+    const msg = ctx.getMessage('qux');
     const val = ctx.format(msg, {arg: 'Arg'}, errs);
 
     const expected_bar = `${FSI}${FSI}Foo${PDI} Bar${PDI}`;

--- a/fluent/test/patterns_test.js
+++ b/fluent/test/patterns_test.js
@@ -21,7 +21,7 @@ suite('Patterns', function(){
     });
 
     test('returns the value', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo');
       assert.equal(errs.length, 0);
@@ -40,7 +40,7 @@ suite('Patterns', function(){
     });
 
     test('returns the value', function(){
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'Foo Bar');
       assert.equal(errs.length, 0);
@@ -48,7 +48,7 @@ suite('Patterns', function(){
 
     test('returns the raw string if the referenced message is ' +
        'not found', function(){
-      const msg = ctx.messages.get('baz');
+      const msg = ctx.getMessage('baz');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'missing');
       assert.ok(errs[0] instanceof ReferenceError); // unknown message
@@ -66,14 +66,14 @@ suite('Patterns', function(){
     });
 
     test('returns the null value', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, null);
       assert.equal(errs.length, 0);
     });
 
     test('formats the attribute', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg.attrs.attr, args, errs);
       assert.strictEqual(val, 'Foo Attr');
       assert.equal(errs.length, 0);
@@ -81,7 +81,7 @@ suite('Patterns', function(){
 
     test('formats ??? when the referenced message has no value and no default',
        function(){
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, '??? Bar');
       assert.ok(errs[0] instanceof RangeError); // no default
@@ -98,7 +98,7 @@ suite('Patterns', function(){
     });
 
     test('returns ???', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, '???');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
@@ -114,7 +114,7 @@ suite('Patterns', function(){
     });
 
     test('returns the raw string', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, '???');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
@@ -134,14 +134,14 @@ suite('Patterns', function(){
     });
 
     test('returns ???', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, {sel: 'a'}, errs);
       assert.strictEqual(val, '???');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
     });
 
     test('returns the other member if requested', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, {sel: 'b'}, errs);
       assert.strictEqual(val, 'Bar');
       assert.equal(errs.length, 0);
@@ -161,7 +161,7 @@ suite('Patterns', function(){
     });
 
     test('returns the default variant', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'Foo');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
@@ -184,14 +184,14 @@ suite('Patterns', function(){
     });
 
     test('returns the default variant', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'Foo');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
     });
 
     test('can reference an attribute', function(){
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.format(msg, args, errs);
       assert.strictEqual(val, 'Bar');
       assert.equal(errs.length, 0);

--- a/fluent/test/primitives_test.js
+++ b/fluent/test/primitives_test.js
@@ -25,14 +25,14 @@ suite('Primitives', function() {
     });
 
     test('can be used in a placeable', function(){
-      const msg = ctx.messages.get('one');
+      const msg = ctx.getMessage('one');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, '1');
       assert.equal(errs.length, 0);
     });
 
     test('can be used as a selector', function(){
-      const msg = ctx.messages.get('select');
+      const msg = ctx.getMessage('select');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'One');
       assert.equal(errs.length, 0);
@@ -64,54 +64,54 @@ suite('Primitives', function() {
     });
 
     test('can be used as a value', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo');
       assert.equal(errs.length, 0);
     });
 
     test('is detected to be non-complex', function(){
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       assert.equal(typeof msg, 'string');
     });
 
     test('can be used in a placeable', function(){
-      const msg = ctx.messages.get('placeable-literal');
+      const msg = ctx.getMessage('placeable-literal');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar');
       assert.equal(errs.length, 0);
     });
 
     test('can be a value of a message referenced in a placeable', function(){
-      const msg = ctx.messages.get('placeable-message');
+      const msg = ctx.getMessage('placeable-message');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar');
       assert.equal(errs.length, 0);
     });
 
     test('can be a selector', function(){
-      const msg = ctx.messages.get('selector-literal');
+      const msg = ctx.getMessage('selector-literal');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Member 1');
       assert.equal(errs.length, 0);
     });
 
     test('can be used as an attribute value', function(){
-      const msg = ctx.messages.get('bar').attrs.attr;
+      const msg = ctx.getMessage('bar').attrs.attr;
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be a value of an attribute used in a placeable', function(){
-      const msg = ctx.messages.get('placeable-attr');
+      const msg = ctx.getMessage('placeable-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Bar Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be a value of an attribute used as a selector', function(){
-      const msg = ctx.messages.get('selector-attr');
+      const msg = ctx.getMessage('selector-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Member 3');
       assert.equal(errs.length, 0);
@@ -140,41 +140,41 @@ suite('Primitives', function() {
     });
 
     test('can be used as a value', function(){
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar');
       assert.equal(errs.length, 0);
     });
 
     test('is detected to be complex', function(){
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       assert.equal(typeof msg, 'object');
       assert(Array.isArray(msg.val));
     });
 
     test('can be a value of a message referenced in a placeable', function(){
-      const msg = ctx.messages.get('placeable-message');
+      const msg = ctx.getMessage('placeable-message');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar Baz');
       assert.equal(errs.length, 0);
     });
 
     test('can be used as an attribute value', function(){
-      const msg = ctx.messages.get('baz').attrs.attr
+      const msg = ctx.getMessage('baz').attrs.attr
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar Baz Attribute');
       assert.equal(errs.length, 0);
     });
 
     test('can be a value of an attribute used in a placeable', function(){
-      const msg = ctx.messages.get('placeable-attr');
+      const msg = ctx.getMessage('placeable-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Foo Bar Baz Attribute');
       assert.equal(errs.length, 0);
     });
 
     test.skip('can be a value of an attribute used as a selector', function(){
-      const msg = ctx.messages.get('selector-attr');
+      const msg = ctx.getMessage('selector-attr');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'Variant 2');
       assert.equal(errs.length, 0);

--- a/fluent/test/select_expressions_test.js
+++ b/fluent/test/select_expressions_test.js
@@ -24,7 +24,7 @@ suite('Select expressions', function() {
     });
 
     test('selects the variant matching the selector', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
       assert.equal(errs.length, 0);
@@ -43,7 +43,7 @@ suite('Select expressions', function() {
     });
 
     test('selects the default variant', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
       assert.equal(errs.length, 0);
@@ -62,7 +62,7 @@ suite('Select expressions', function() {
     });
 
     test('selects the default variant', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
       assert.equal(errs.length, 1);
@@ -87,13 +87,13 @@ suite('Select expressions', function() {
     });
 
     test('selects the right variant', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'B');
     });
 
     test('selects the default variant', function() {
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
     });
@@ -116,13 +116,13 @@ suite('Select expressions', function() {
     });
 
     test('selects the right category', function() {
-      const msg = ctx.messages.get('foo');
+      const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
     });
 
     test('selects the exact match', function() {
-      const msg = ctx.messages.get('bar');
+      const msg = ctx.getMessage('bar');
       const val = ctx.format(msg, args, errs);
       assert.equal(val, 'A');
     });

--- a/fluent/test/tags_test.js
+++ b/fluent/test/tags_test.js
@@ -52,28 +52,28 @@ suite('Tags', function() {
   });
 
   test('match in a message', function() {
-    const msg = ctx.messages.get('ref-foo');
+    const msg = ctx.getMessage('ref-foo');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Foo Tag');
     assert.equal(errs.length, 0);
   });
 
   test('match one of two', function() {
-    const msg = ctx.messages.get('ref-bar-1');
+    const msg = ctx.getMessage('ref-bar-1');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Bar Tag 1');
     assert.equal(errs.length, 0);
   });
 
   test('match in order of variants', function() {
-    const msg = ctx.messages.get('ref-bar-2');
+    const msg = ctx.getMessage('ref-bar-2');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Bar Tag 2');
     assert.equal(errs.length, 0);
   });
 
   test('fallback when tag is missing', function() {
-    const msg = ctx.messages.get('ref-baz');
+    const msg = ctx.getMessage('ref-baz');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Other');
     assert.equal(errs.length, 1);

--- a/fluent/test/values_format_test.js
+++ b/fluent/test/values_format_test.js
@@ -32,42 +32,42 @@ suite('Formatting values', function(){
   });
 
   test('returns the value', function(){
-    const msg = ctx.messages.get('key1');
+    const msg = ctx.getMessage('key1');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Value 1');
     assert.equal(errs.length, 0);
   });
 
   test('returns the default variant', function(){
-    const msg = ctx.messages.get('key2');
+    const msg = ctx.getMessage('key2');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'B2');
     assert.equal(errs.length, 0);
   });
 
   test('returns the value if it is a pattern', function(){
-    const msg = ctx.messages.get('key3');
+    const msg = ctx.getMessage('key3');
     const val = ctx.format(msg, args, errs)
     assert.strictEqual(val, 'Value 3');
     assert.equal(errs.length, 0);
   });
 
   test('returns the default variant if it is a pattern', function(){
-    const msg = ctx.messages.get('key4');
+    const msg = ctx.getMessage('key4');
     const val = ctx.format(msg, args, errs)
     assert.strictEqual(val, 'B4');
     assert.equal(errs.length, 0);
   });
 
   test('returns null if there is no value', function(){
-    const msg = ctx.messages.get('key5');
+    const msg = ctx.getMessage('key5');
     const val = ctx.format(msg, args, errs);
     assert.strictEqual(val, null);
     assert.equal(errs.length, 0);
   });
 
   test('allows to pass traits directly to ctx.format', function(){
-    const msg = ctx.messages.get('key5');
+    const msg = ctx.getMessage('key5');
     assert.strictEqual(ctx.format(msg.attrs.a, args, errs), 'A5');
     assert.strictEqual(ctx.format(msg.attrs.b, args, errs), 'B5');
     assert.equal(errs.length, 0);

--- a/fluent/test/values_ref_test.js
+++ b/fluent/test/values_ref_test.js
@@ -47,43 +47,43 @@ suite('Referencing values', function(){
   });
 
   test('references the value', function(){
-    const msg = ctx.messages.get('ref1');
+    const msg = ctx.getMessage('ref1');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Value 1');
     assert.equal(errs.length, 0);
   });
 
   test('references the default variant', function(){
-    const msg = ctx.messages.get('ref2');
+    const msg = ctx.getMessage('ref2');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'B2');
     assert.equal(errs.length, 0);
   });
 
   test('references the value if it is a pattern', function(){
-    const msg = ctx.messages.get('ref3');
+    const msg = ctx.getMessage('ref3');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'Value 3');
     assert.equal(errs.length, 0);
   });
 
   test('references the default variant if it is a pattern', function(){
-    const msg = ctx.messages.get('ref4');
+    const msg = ctx.getMessage('ref4');
     const val = ctx.format(msg, args, errs);
     assert.equal(val, 'B4');
     assert.equal(errs.length, 0);
   });
 
   test('uses ??? if there is no value', function(){
-    const msg = ctx.messages.get('ref5');
+    const msg = ctx.getMessage('ref5');
     const val = ctx.format(msg, args, errs);
     assert.strictEqual(val, '???');
     assert.ok(errs[0] instanceof RangeError); // no default
   });
 
   test('references the variants', function(){
-    const msg_a = ctx.messages.get('ref6');
-    const msg_b = ctx.messages.get('ref7');
+    const msg_a = ctx.getMessage('ref6');
+    const msg_b = ctx.getMessage('ref7');
     const val_a = ctx.format(msg_a, args, errs)
     const val_b = ctx.format(msg_b, args, errs)
     assert.strictEqual(val_a, 'A2');
@@ -92,8 +92,8 @@ suite('Referencing values', function(){
   });
 
   test('references the variants which are patterns', function(){
-    const msg_a = ctx.messages.get('ref8');
-    const msg_b = ctx.messages.get('ref9');
+    const msg_a = ctx.getMessage('ref8');
+    const msg_b = ctx.getMessage('ref9');
     const val_a = ctx.format(msg_a, args, errs)
     const val_b = ctx.format(msg_b, args, errs)
     assert.strictEqual(val_a, 'A4');
@@ -102,8 +102,8 @@ suite('Referencing values', function(){
   });
 
   test('references the attributes', function(){
-    const msg_a = ctx.messages.get('ref10');
-    const msg_b = ctx.messages.get('ref11');
+    const msg_a = ctx.getMessage('ref10');
+    const msg_b = ctx.getMessage('ref11');
     const val_a = ctx.format(msg_a, args, errs)
     const val_b = ctx.format(msg_b, args, errs)
     assert.strictEqual(val_a, 'A5');

--- a/tools/perf/benchmark.d8.js
+++ b/tools/perf/benchmark.d8.js
@@ -24,13 +24,11 @@ var ctx = new Fluent.MessageContext('en-US');
 var errors = ctx.addMessages(ftlCode);
 
 times.format = Date.now();
-for (let id of ctx.messages.keys()) {
-  const message = ctx.messages.get(id);
-
+for (const [id, message] of ctx.messages) {
   ctx.format(message, args, errors);
-  if (message.traits) {
-    for (let trait of message.traits) {
-      ctx.format(trait.val, args, errors)
+  if (message.attrs) {
+    for (const name in message.attrs) {
+      ctx.format(message.attrs[name], args, errors)
     }
   }
 }

--- a/tools/perf/benchmark.jsshell.js
+++ b/tools/perf/benchmark.jsshell.js
@@ -24,13 +24,11 @@ var ctx = new Fluent.MessageContext('en-US');
 var errors = ctx.addMessages(ftlCode);
 
 times.format = dateNow();
-for (let id of ctx.messages.keys()) {
-  const message = ctx.messages.get(id);
-
+for (const [id, message] of ctx.messages) {
   ctx.format(message, args, errors);
-  if (message.traits) {
-    for (let trait of message.traits) {
-      ctx.format(trait.val, args, errors)
+  if (message.attrs) {
+    for (const name in message.attrs) {
+      ctx.format(message.attrs[name], args, errors)
     }
   }
 }

--- a/tools/perf/benchmark.node.js
+++ b/tools/perf/benchmark.node.js
@@ -28,13 +28,11 @@ var ctx = new Fluent.MessageContext('en-US');
 var errors = ctx.addMessages(ftlCode);
 
 cumulative.format = process.hrtime(start);
-for (let id of ctx.messages.keys()) {
-  const message = ctx.messages.get(id);
-
+for (const [id, message] of ctx.messages) {
   ctx.format(message, args, errors);
-  if (message.traits) {
-    for (let trait of message.traits) {
-      ctx.format(trait.val, args, errors)
+  if (message.attrs) {
+    for (const name in message.attrs) {
+      ctx.format(message.attrs[name], args, errors)
     }
   }
 }

--- a/tools/perf/makefile
+++ b/tools/perf/makefile
@@ -1,13 +1,10 @@
 perf: perf-jsshell
 
 perf-%:
-	@$(MAKE) -s build
 	@./tools/perf/test.js -e $* -s 30 -p
 
 perf-compare-%:
-	@$(MAKE) -s build
 	@./tools/perf/test.js -e $* -s 30 -p -c $(PERF_REFERENCE)
 
 perf-reference-%:
-	@$(MAKE) -s build
 	@./tools/perf/test.js -e $* -s 30 -r > $(PERF_REFERENCE)


### PR DESCRIPTION
Right now consumers are expected to use `ctx.messages.get()` to get the internal representation of a message from the context. Let's make it clear what the public API of `MessageContext` is by adding explicit `hasMessage` and `getMessage` methods.