### PR TITLE
fluent-react: Introduce the withLocalization HOC

### DIFF
--- a/fluent-react/CHANGELOG.md
+++ b/fluent-react/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+  - Added the `withLocalization` HOC.
+
+    It may be used to connect a component with a Localization. It injects the
+    `formatString` prop.
+
   - The compat build is now transpiled using rollup-plugin-babel.
 
     This ensures that the "use strict" pragma is scoped to the UMD wrapper.  It

--- a/fluent-react/README.md
+++ b/fluent-react/README.md
@@ -27,6 +27,8 @@ welcome = Welcome, { $username }.
 ```
 
 
+### The Localized Component
+
 Wrap your localizable elements in the `Localized` component:
 
 ```javascript
@@ -37,8 +39,27 @@ import { Localized } from 'fluent-react';
 </Localized>
 ```
 
-The `id` prop should be the unique identifier of the translation.  Any
-attributes found in the translation will be applied to the wrapped element.
+The `id` prop should be the unique identifier of the translation.  [Attributes
+defined in the translation][attrs] will be applied to the wrapped element.
+
+[attrs]: http://projectfluent.io/fluent/guide/attributes.html
+
+```
+type-name
+    .placeholder = Your name
+```
+
+```javascript
+<Localized id="type-name">
+    <input
+        type="text"
+        placeholder="Your name"
+        onChange={…}
+        value={…}
+    />
+</Localized>
+```
+
 You can also pass arguments to the translation as `$`-prefixed props on
 `Localized`:
 
@@ -69,6 +90,9 @@ It's also possible to pass React elements as arguments to translations:
     <p>{'Click { $linkA } or { $linkB}.'}</p>
 </Localized>
 ```
+
+
+### The Localization Provider
 
 All `<Localized>` components need access to an instance of the `Localization`
 class, the central localization store to which they subscribe.  The
@@ -129,7 +153,7 @@ export function* generateMessages(currentLocales) {
 [context]: https://facebook.github.io/react/docs/context.html
 
 
-## The messages iterable
+### The messages iterable
 
 The design of the `LocalizationProvider` requires a little bit of work from the
 developer.  The `messages` iterable needs to be created manually.  This is
@@ -156,6 +180,35 @@ translations (including any fallback) must be fetched at once before
 In the future we might be able to allow async fetching of fallback locales.
 
 [fluent-langneg]: https://github.com/projectfluent/fluent.js/tree/master/fluent-langneg
+
+
+### The withLocalization decorator
+
+Sometimes it's useful to imperatively format a translation rather than rely on
+the declarative `<Localized />` API.  Good examples of this are the
+`window.alert` and `window.confirm` functions.
+
+It's possible to connect any component to its enclosing `LocalizationProvider`
+using the `withLocalization` higher-order component (HOC).
+
+```javascript
+import { withLocalization } from 'fluent-react/compat';
+
+function HelloButton(props) {
+    const { formatString } = props;
+
+    return (
+        <button onClick={() => alert(formatString('hello'))}>
+            👋
+        </button>
+    );
+}
+
+export default withLocalization(HelloButton);
+```
+
+The connected component must be a descendant of a `LocalizationProvider` to
+have access to the translations stored there.
 
 
 ## A complete example

--- a/fluent-react/examples/higher-order/package.json
+++ b/fluent-react/examples/higher-order/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fluent-react-example-higher-order",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "react-scripts": "0.9.0"
+  },
+  "dependencies": {
+    "fluent": "^0.3.1",
+    "fluent-intl-polyfill": "^0.1.0",
+    "fluent-langneg": "^0.0.2",
+    "fluent-react": "^0.3.0",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/fluent-react/examples/higher-order/public/index.html
+++ b/fluent-react/examples/higher-order/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Higher-order component - a fluent-react example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/fluent-react/examples/higher-order/src/App.js
+++ b/fluent-react/examples/higher-order/src/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Localized, withLocalization } from 'fluent-react/compat';
+
+function App(props) {
+  function showAlert() {
+    const { formatString } = props;
+    alert(formatString('hello'));
+  }
+
+  return (
+    <div>
+      <Localized id="button-show-alert">
+        <button onClick={showAlert}>Click me!</button>
+      </Localized>
+    </div>
+  );
+}
+
+export default withLocalization(App);

--- a/fluent-react/examples/higher-order/src/index.js
+++ b/fluent-react/examples/higher-order/src/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { LocalizationProvider } from 'fluent-react/compat';
+
+import { generateMessages } from './l10n';
+import App from './App';
+
+ReactDOM.render(
+  <LocalizationProvider messages={generateMessages(navigator.languages)}>
+    <App />
+  </LocalizationProvider>,
+  document.getElementById('root')
+);

--- a/fluent-react/examples/higher-order/src/l10n.js
+++ b/fluent-react/examples/higher-order/src/l10n.js
@@ -1,0 +1,30 @@
+import 'fluent-intl-polyfill/compat';
+import { MessageContext } from 'fluent/compat';
+import negotiateLanguages from 'fluent-langneg/compat';
+
+const MESSAGES_ALL = {
+  'pl': `
+hello = Witaj świecie!
+button-show-alert = Kliknij mnie
+  `,
+  'en-US': `
+hello = Hello, world!
+button-show-alert = Click me
+  `,
+};
+
+export function* generateMessages(userLocales) {
+  // Choose locales that are best for the user.
+  const currentLocales = negotiateLanguages(
+    userLocales,
+    ['en-US', 'pl'],
+    { defaultLocale: 'en-US' }
+  );
+
+  for (const locale of currentLocales) {
+    const cx = new MessageContext(locale);
+    cx.addMessages(MESSAGES_ALL[locale]);
+    yield cx;
+  }
+}
+

--- a/fluent-react/src/index.js
+++ b/fluent-react/src/index.js
@@ -18,4 +18,5 @@
  */
 
 export { default as LocalizationProvider } from './provider';
+export { default as withLocalization } from './with_localization';
 export { default as Localized } from './localized';

--- a/fluent-react/src/localization.js
+++ b/fluent-react/src/localization.js
@@ -81,3 +81,15 @@ function memoize(iterable) {
     }
   };
 }
+
+export function isLocalization(props, propName) {
+  const prop = props[propName];
+
+  if (prop instanceof Localization) {
+    return null;
+  }
+
+  return new Error(
+    `The ${propName} context field must be an instance of Localization.`
+  );
+}

--- a/fluent-react/src/localized.js
+++ b/fluent-react/src/localized.js
@@ -2,7 +2,7 @@ import { isValidElement, cloneElement, Component, Children } from 'react';
 import PropTypes from 'prop-types';
 import { MessageArgument } from 'fluent/compat';
 
-import Localization from './localization';
+import { isLocalization } from './localization';
 
 /*
  * A Fluent argument type for React elements.
@@ -166,15 +166,3 @@ Localized.contextTypes = {
 Localized.propTypes = {
   children: PropTypes.element.isRequired,
 };
-
-function isLocalization(props, propName) {
-  const prop = props[propName];
-
-  if (prop instanceof Localization) {
-    return null;
-  }
-
-  return new Error(
-    `The ${propName} context field must be an instance of Localization.`
-  );
-}

--- a/fluent-react/src/with_localization.js
+++ b/fluent-react/src/with_localization.js
@@ -1,0 +1,50 @@
+import { createElement, Component } from 'react';
+
+import { isLocalization } from './localization';
+
+export default function withLocalization(Inner) {
+  class WithLocalization extends Component {
+    constructor(props, context) {
+      super(props, context);
+      this.formatString = this.formatString.bind(this);
+    }
+
+    formatString(id, args) {
+      const { l10n } = this.context;
+
+      if (!l10n) {
+        throw new Error(
+          `${this.displayName} must be a descendant of a LocalizationProvider.`
+        );
+      }
+
+      const mcx = l10n.getMessageContext(id);
+
+      if (mcx === null) {
+        return id;
+      }
+
+      const msg = mcx.getMessage(id);
+      return mcx.format(msg, args);
+    }
+
+    render() {
+      return createElement(
+        Inner,
+        Object.assign({ formatString: this.formatString }, this.props)
+      );
+    }
+  }
+
+  WithLocalization.displayName = `WithLocalization(${displayName(Inner)})`;
+
+  WithLocalization.contextTypes = {
+    l10n: isLocalization
+  };
+
+  return WithLocalization;
+}
+
+function displayName(component) {
+  return component.displayName || component.name || 'Component';
+}

--- a/fluent-react/test/localized_valid_test.js
+++ b/fluent-react/test/localized_valid_test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import assert from 'assert';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { LocalizationProvider, Localized } from '../src/index';
 import Localization from '../src/localization';
 
@@ -15,7 +15,7 @@ suite('Localized - validation', function() {
   });
 
   test('inside of a LocalizationProvider', function() {
-    const wrapper = mount(
+    const wrapper = shallow(
       <LocalizationProvider messages={[]}>
         <Localized>
           <div />

--- a/fluent-react/test/with_localization_test.js
+++ b/fluent-react/test/with_localization_test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import assert from 'assert';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+import MessageContext from './message_context_stub';
+import Localization from '../src/localization';
+import { withLocalization, LocalizationProvider } from '../src';
+
+function DummyComponent() {
+  return <div />;
+}
+
+suite('withLocalization', function() {
+  test('render inside of a LocalizationProvider', function() {
+    const EnhancedComponent = withLocalization(DummyComponent);
+
+    const wrapper = shallow(
+      <LocalizationProvider messages={[]}>
+        <EnhancedComponent />
+      </LocalizationProvider>
+    );
+    assert.equal(wrapper.length, 1);
+  });
+
+  test('render outside of a LocalizationProvider', function() {
+    const EnhancedComponent = withLocalization(DummyComponent);
+
+    const wrapper = shallow(
+      <EnhancedComponent />,
+    );
+    assert.equal(wrapper.length, 1);
+  });
+
+  test('formatString with access to the l10n context', function() {
+    const mcx = new MessageContext();
+    const l10n = new Localization([mcx]);
+    const EnhancedComponent = withLocalization(DummyComponent);
+
+    const wrapper = shallow(
+      <EnhancedComponent />,
+      { context: { l10n } }
+    );
+
+    const formatString = wrapper.prop('formatString');
+    assert.equal(formatString('foo'), 'FOO');
+  });
+
+  test('formatString without access to the l10n context', function() {
+    const mcx = new MessageContext();
+    const l10n = new Localization([mcx]);
+    const EnhancedComponent = withLocalization(DummyComponent);
+
+    const wrapper = shallow(
+      <EnhancedComponent />
+    );
+
+    const formatString = wrapper.prop('formatString');
+    assert.throws(formatString, /descendant of a LocalizationProvider/);
+  });
+});


### PR DESCRIPTION
The `withLocalization` decorator is a higher-order component which can be used to gain imperative access to a `Localization`.

Sometimes it's useful to imperatively format a translation rather than rely on the declarative `<Localized />` API.  Good examples of this are the `window.alert` and `window.confirm` functions.

The `withLocalization` HOC connects a component to its enclosing `LocalizationProvider` and injects the `formatString` prop into the wrapped component.  The `formatString` method returns a translation given an id and an optional arguments object.

```javascript
import { withLocalization } from 'fluent-react/compat';

function HelloButton(props) {
  const { formatString } = props;

  return (
    <button onClick={() => alert(formatString('hello'))}>
      👋
    </button>
  );
}

export default withLocalization(HelloButton);
```