### PR TITLE
Introduce FluentParser, FluentSerializer

### DIFF
--- a/fluent-syntax/CHANGELOG.md
+++ b/fluent-syntax/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+  - Introduce the FluentParser and the FluentSerializer classes.
+
+    Instances can be used to store config for multiple parse/serialize
+    operations.
+
+    The fluent-syntax package still exports the `parse` and `serialize`
+    helpers.  For more fine-grained control, `FluentParser` and
+    `FluentSerializer` may be used for instantiation.
+
   - Build compat.js using babel-plugin-transform-builtin-extend.
 
     This ensures the correct behavior of `err instanceof ParseError`.

--- a/fluent-syntax/src/index.js
+++ b/fluent-syntax/src/index.js
@@ -1,6 +1,18 @@
+import FluentParser from './parser';
+import FluentSerializer from './serializer';
+
 export * from './ast';
-export * from './parser';
-export * from './serializer';
+export { FluentParser, FluentSerializer };
+
+export function parse(source, opts) {
+  const parser = new FluentParser(opts);
+  return parser.parse(source);
+}
+
+export function serialize(resource, opts) {
+  const serializer = new FluentSerializer(opts);
+  return serializer.serialize(resource);
+}
 
 export function lineOffset(source, pos) {
   // Substract 1 to get the offset.

--- a/fluent-syntax/src/serializer.js
+++ b/fluent-syntax/src/serializer.js
@@ -2,7 +2,6 @@ function indent(content) {
   return content.split('\n').join('\n    ');
 }
 
-
 function containNewLine(elems) {
   const withNewLine = elems.filter(
     elem => (elem.type === 'TextElement' && elem.value.includes('\n'))
@@ -10,38 +9,42 @@ function containNewLine(elems) {
   return !!withNewLine.length;
 }
 
-
-export function serialize(resource, withJunk = false) {
-  const parts = [];
-
-  if (resource.comment) {
-    parts.push(
-      `${serializeComment(resource.comment)}\n\n`
-    );
+export default class FluentSerializer {
+  constructor({ withJunk = false } = {}) {
+    this.withJunk = withJunk;
   }
 
-  for (const entry of resource.body) {
-    if (entry.types !== 'Junk' || withJunk) {
-      parts.push(serializeEntry(entry));
+  serialize(resource) {
+    const parts = [];
+
+    if (resource.comment) {
+      parts.push(
+        `${serializeComment(resource.comment)}\n\n`
+      );
     }
+
+    for (const entry of resource.body) {
+      if (entry.types !== 'Junk' || this.withJunk) {
+        parts.push(this.serializeEntry(entry));
+      }
+    }
+
+    return parts.join('');
   }
 
-  return parts.join('');
-}
-
-
-export function serializeEntry(entry) {
-  switch (entry.type) {
-    case 'Message':
-      return serializeMessage(entry);
-    case 'Section':
-      return serializeSection(entry);
-    case 'Comment':
-      return serializeComment(entry);
-    case 'Junk':
-      return serializeJunk(entry);
-    default :
-      throw new Error(`Unknown entry type: ${entry.type}`);
+  serializeEntry(entry) {
+    switch (entry.type) {
+      case 'Message':
+        return serializeMessage(entry);
+      case 'Section':
+        return serializeSection(entry);
+      case 'Comment':
+        return serializeComment(entry);
+      case 'Junk':
+        return serializeJunk(entry);
+      default :
+        throw new Error(`Unknown entry type: ${entry.type}`);
+    }
   }
 }
 

--- a/fluent-syntax/test/behavior_test.js
+++ b/fluent-syntax/test/behavior_test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { join } from 'path';
 import { readdir } from 'fs';
 import { readfile } from './util';
-import { parse } from '../src/parser';
+import { parse } from '../src';
 
 const sigil = '^\/\/~ ';
 const reDirective = new RegExp(`${sigil}(.*)[\n$]`, 'gm');

--- a/fluent-syntax/test/entry_test.js
+++ b/fluent-syntax/test/entry_test.js
@@ -1,11 +1,13 @@
 import assert from 'assert';
 import { ftl } from './util';
 
-import { parseEntry } from '../src/parser';
-import { serializeEntry } from '../src/serializer';
-
+import { FluentParser, FluentSerializer } from '../src';
 
 suite('Parse entry', function() {
+  setup(function() {
+    this.parser = new FluentParser();
+  });
+
   test('simple message', function() {
     const input = ftl`
       foo = Foo
@@ -36,13 +38,17 @@ suite('Parse entry', function() {
       }
     };
 
-    const message = parseEntry(input)
+    const message = this.parser.parseEntry(input)
     assert.deepEqual(message, output)
   });
 });
 
 
 suite('Serialize entry', function() {
+  setup(function() {
+    this.serializer = new FluentSerializer();
+  });
+
   test('simple message', function() {
     const input = {
       "comment": null,
@@ -73,7 +79,7 @@ suite('Serialize entry', function() {
       foo = Foo
     `;
 
-    const message = serializeEntry(input)
+    const message = this.serializer.serializeEntry(input)
     assert.deepEqual(message, output)
   });
 });

--- a/fluent-syntax/test/serializer_test.js
+++ b/fluent-syntax/test/serializer_test.js
@@ -1,8 +1,7 @@
 import assert from 'assert';
 import { ftl } from './util';
 
-import { parse } from '../src/parser';
-import { serialize } from '../src/serializer';
+import { parse, serialize } from '../src';
 
 
 function pretty(text) {
@@ -122,7 +121,7 @@ suite('Serializer', function() {
     assert.equal(pretty(input), input);
   });
 
-  test.skip('multiline with placeable', function() {
+  test('multiline with placeable', function() {
     const input = ftl`
       foo =
           Foo { bar }

--- a/fluent-syntax/test/structure_test.js
+++ b/fluent-syntax/test/structure_test.js
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { readdir } from 'fs';
 import { readfile } from './util';
 
-import { parse } from '../src/parser';
+import { parse } from '../src';
 
 const fixtures = join(__dirname, 'fixtures_structure');
 


### PR DESCRIPTION
The fluent-syntax package still exports the `parse` and `serialize`
helpers.  For more fine-grained control, `FluentParser` and
`FluentSerializer` may be used for instantiation.

This is a port of changes made in https://github.com/projectfluent/python-fluent/pull/9.