### PR TITLE
Introduce mapContextSync and CachedIterable.

### DIFF
--- a/fluent/CHANGELOG.md
+++ b/fluent/CHANGELOG.md
@@ -2,7 +2,44 @@
 
 ## Unreleased
 
-  - …
+  - Introduce mapContextSync and CachedIterable.
+
+    An ordered iterable of MessageContext instances can represent the
+    current negotiated fallback chain of languages.  This iterable can be
+    used to find the best existing translation for a given identifier.
+
+    The mapContext* methods can be used to find the first MessageContext in
+    the given iterable which contains the translation with the given
+    identifier.  If the iterable is ordered according to the result of
+    a language negotiation the returned MessageContext contains the best
+    available translation.
+
+    A simple function which formats translations based on the identifier
+    might be implemented as follows:
+
+        formatString(id, args) {
+            const ctx = mapContextSync(contexts, id);
+
+            if (ctx === null) {
+                return id;
+            }
+
+            const msg = ctx.getMessage(id);
+            return ctx.format(msg, args);
+        }
+
+    In order to pass an iterator to mapContext*, wrap it in CachedIterable.
+    This allows multiple calls to mapContext* without advancing and
+    eventually depleting the iterator.
+
+        function *generateMessages() {
+            // Some lazy logic for yielding MessageContexts.
+            yield *[ctx1, ctx2];
+        }
+
+        const contexts = new CachedIterable(generateMessages());
+        const ctx = mapContextSync(contexts, id);
+
 
 ## fluent 0.4.0 (May 17th, 2017)
 

--- a/fluent/src/cached_iterable.js
+++ b/fluent/src/cached_iterable.js
@@ -1,0 +1,30 @@
+/*
+ * CachedIterable caches the elements yielded by an iterable.
+ *
+ * It can be used to iterate over an iterable many times without depleting the
+ * iterable.
+ */
+export default class CachedIterable {
+  constructor(iterable) {
+    if (!(Symbol.iterator in Object(iterable))) {
+      throw new TypeError('Argument must implement the iteration protocol.');
+    }
+
+    this.iterator = iterable[Symbol.iterator]();
+    this.seen = [];
+  }
+
+  [Symbol.iterator]() {
+    const { seen, iterator } = this;
+    let cur = 0;
+
+    return {
+      next() {
+        if (seen.length <= cur) {
+          seen.push(iterator.next());
+        }
+        return seen[cur++];
+      }
+    };
+  }
+}

--- a/fluent/src/fallback.js
+++ b/fluent/src/fallback.js
@@ -1,0 +1,73 @@
+/*
+ * @overview
+ *
+ * Functions for managing ordered sequences of MessageContexts.
+ *
+ * An ordered iterable of MessageContext instances can represent the current
+ * negotiated fallback chain of languages.  This iterable can be used to find
+ * the best existing translation for a given identifier.
+ *
+ * The mapContext* methods can be used to find the first MessageContext in the
+ * given iterable which contains the translation with the given identifier.  If
+ * the iterable is ordered according to the result of a language negotiation
+ * the returned MessageContext contains the best available translation.
+ *
+ * A simple function which formats translations based on the identifier might
+ * be implemented as follows:
+ *
+ *     formatString(id, args) {
+ *         const ctx = mapContextSync(contexts, id);
+ *
+ *         if (ctx === null) {
+ *             return id;
+ *         }
+ *
+ *         const msg = ctx.getMessage(id);
+ *         return ctx.format(msg, args);
+ *     }
+ *
+ * In order to pass an iterator to mapContext*, wrap it in CachedIterable.
+ * This allows multiple calls to mapContext* without advancing and eventually
+ * depleting the iterator.
+ *
+ *     function *generateMessages() {
+ *         // Some lazy logic for yielding MessageContexts.
+ *         yield *[ctx1, ctx2];
+ *     }
+ *
+ *     const contexts = new CachedIterable(generateMessages());
+ *     const ctx = mapContextSync(contexts, id);
+ *
+ */
+
+/*
+ * Synchronously map an identifier or an array of identifiers to the best
+ * `MessageContext` instance(s).
+ *
+ * @param {Iterable} iterable
+ * @param {string|Array<string>} ids
+ * @returns {MessageContext|Array<MessageContext>}
+ */
+
+export function mapContextSync(iterable, ids) {
+  if (!Array.isArray(ids)) {
+    return getContextForId(iterable, ids);
+  }
+
+  return ids.map(
+    id => getContextForId(iterable, id)
+  );
+}
+
+/*
+ * Find the best `MessageContext` with the translation for `id`.
+ */
+function getContextForId(iterable, id) {
+  for (const context of iterable) {
+    if (context.hasMessage(id)) {
+      return context;
+    }
+  }
+
+  return null;
+}

--- a/fluent/src/index.js
+++ b/fluent/src/index.js
@@ -1,3 +1,12 @@
+/*
+ * @module fluent
+ * @overview
+ *
+ * `fluent` is a JavaScript implementation of Project Fluent, a localization
+ * framework designed to unleash the expressive power of the natural language.
+ *
+ */
+
 export { default as _parse } from './parser';
 
 export { MessageContext } from './context';
@@ -6,3 +15,6 @@ export {
   FluentNumber as MessageNumberArgument,
   FluentDateTime as MessageDateTimeArgument,
 } from './types';
+
+export { default as CachedIterable } from './cached_iterable';
+export { mapContextSync } from './fallback';

--- a/fluent/test/cached_terable_test.js
+++ b/fluent/test/cached_terable_test.js
@@ -1,0 +1,86 @@
+import assert from 'assert';
+
+import CachedIterable from '../src/cached_iterable';
+
+suite('CachedIterable', function() {
+  suite('constructor errors', function(){
+    test('no argument', function() {
+      function run() {
+        new CachedIterable();
+      }
+
+      assert.throws(run, TypeError);
+      assert.throws(run, /iteration protocol/);
+    });
+
+    test('null argument', function() {
+      function run() {
+        new CachedIterable(null);
+      }
+
+      assert.throws(run, TypeError);
+      assert.throws(run, /iteration protocol/);
+    });
+
+    test('bool argument', function() {
+      function run() {
+        new CachedIterable(1);
+      }
+
+      assert.throws(run, TypeError);
+      assert.throws(run, /iteration protocol/);
+    });
+
+    test('number argument', function() {
+      function run() {
+        new CachedIterable(1);
+      }
+
+      assert.throws(run, TypeError);
+      assert.throws(run, /iteration protocol/);
+    });
+  });
+
+  suite('iteration', function(){
+    let o1, o2;
+
+    suiteSetup(function() {
+      o1 = Object();
+      o2 = Object();
+    });
+
+    test('eager iterable', function() {
+      const iter = new CachedIterable([o1, o2]);
+      assert.deepEqual([...iter], [o1, o2]);
+    });
+
+    test('eager iterable works more than once', function() {
+      const iter = new CachedIterable([o1, o2]);
+      assert.deepEqual([...iter], [o1, o2]);
+      assert.deepEqual([...iter], [o1, o2]);
+    });
+
+    test('lazy iterable', function() {
+      function *generate() {
+        yield *[o1, o2];
+      }
+
+      const iter = new CachedIterable(generate());
+      assert.deepEqual([...iter], [o1, o2]);
+    });
+
+    test('lazy iterable works more than once', function() {
+      function *generate() {
+        let i = 2;
+
+        while (--i) {
+          yield Object();
+        }
+      }
+
+      const iter = new CachedIterable(generate());
+      const first = [...iter];
+      assert.deepEqual([...iter], first);
+    });
+  });
+});

--- a/fluent/test/fallback_test.js
+++ b/fluent/test/fallback_test.js
@@ -1,0 +1,87 @@
+import assert from 'assert';
+
+import CachedIterable from '../src/cached_iterable';
+import MessageContext from './message_context_stub';
+import { mapContextSync } from '../src/index';
+
+suite('Fallback — single id', function() {
+  let ctx1, ctx2;
+
+  suiteSetup(function() {
+    ctx1 = new MessageContext();
+    ctx1._setMessages(['bar']);
+    ctx2 = new MessageContext();
+    ctx2._setMessages(['foo', 'bar']);
+  });
+
+  test('eager iterable', function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.equal(mapContextSync(contexts, 'foo'), ctx2);
+    assert.equal(mapContextSync(contexts, 'bar'), ctx1);
+  });
+
+  test('eager iterable works more than once', function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.equal(mapContextSync(contexts, 'foo'), ctx2);
+    assert.equal(mapContextSync(contexts, 'bar'), ctx1);
+    assert.equal(mapContextSync(contexts, 'foo'), ctx2);
+    assert.equal(mapContextSync(contexts, 'bar'), ctx1);
+  });
+
+  test('lazy iterable', function() {
+    function *generateMessages() {
+      yield *[ctx1, ctx2];
+    }
+
+    const contexts = new CachedIterable(generateMessages());
+    assert.equal(mapContextSync(contexts, 'foo'), ctx2);
+    assert.equal(mapContextSync(contexts, 'bar'), ctx1);
+  });
+
+  test('lazy iterable works more than once', function() {
+    function *generateMessages() {
+      yield *[ctx1, ctx2];
+    }
+
+    const contexts = new CachedIterable(generateMessages());
+    assert.equal(mapContextSync(contexts, 'foo'), ctx2);
+    assert.equal(mapContextSync(contexts, 'bar'), ctx1);
+    assert.equal(mapContextSync(contexts, 'foo'), ctx2);
+    assert.equal(mapContextSync(contexts, 'bar'), ctx1);
+  });
+});
+
+suite('Fallback — multiple ids', function() {
+  let ctx1, ctx2;
+
+  suiteSetup(function() {
+    ctx1 = new MessageContext();
+    ctx1._setMessages(['foo', 'bar']);
+    ctx2 = new MessageContext();
+    ctx2._setMessages(['foo', 'bar', 'baz']);
+  });
+
+  test('existing translations', function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.deepEqual(
+      mapContextSync(contexts, ['foo', 'bar']),
+      [ctx1, ctx1]
+    );
+  });
+
+  test('fallback translations', function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.deepEqual(
+      mapContextSync(contexts, ['foo', 'bar', 'baz']),
+      [ctx1, ctx1, ctx2]
+    );
+  });
+
+  test('missing translations', function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.deepEqual(
+      mapContextSync(contexts, ['foo', 'bar', 'baz', 'qux']),
+      [ctx1, ctx1, ctx2, null]
+    );
+  });
+});

--- a/fluent/test/message_context_stub.js
+++ b/fluent/test/message_context_stub.js
@@ -1,0 +1,23 @@
+export default class MessageContext {
+  _setMessages(ids) {
+    this.ids = ids;
+  }
+
+  hasMessage(id) {
+    return this.ids.includes(id);
+  }
+
+  getMessage(id) {
+    if (this.hasMessage(id)) {
+      return id.toUpperCase();
+    }
+  }
+
+  format(msg) {
+    return msg;
+  }
+
+  formatToParts(msg) {
+    return [msg];
+  }
+}


### PR DESCRIPTION
(Another take on #40.)

An ordered iterable of MessageContext instances can represent the
current negotiated fallback chain of languages.  This iterable can be
used to find the best existing translation for a given identifier.

The mapContext* methods can be used to find the first MessageContext in
the given iterable which contains the translation with the given
identifier.  If the iterable is ordered according to the result of
a language negotiation the returned MessageContext contains the best
available translation.

A simple function which formats translations based on the identifier
might be implemented as follows:

    formatString(id, args) {
        const ctx = mapContextSync(contexts, id);

        if (ctx === null) {
            return id;
        }

        const msg = ctx.getMessage(id);
        return ctx.format(msg, args);
    }

In order to pass an iterator to mapContext*, wrap it in CachedIterable.
This allows multiple calls to mapContext* without advancing and
eventually depleting the iterator.

    function *generateMessages() {
        // Some lazy logic for yielding MessageContexts.
        yield *[ctx1, ctx2];
    }

    const contexts = new CachedIterable(generateMessages());
    const ctx = mapContextSync(contexts, id);