### PR TITLE
Add Spans to all Nodes

### DIFF
--- a/fluent-syntax/CHANGELOG.md
+++ b/fluent-syntax/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-  - …
+  - Most AST nodes can now have a Span.
+
+    Use `new FluentParser({ withSpans: true })` to enable this behavior.
+
+  - The `withAnnotations` config option to `FluentParser` has been removed.
+
+    The parser always produces Annotations if necessary now.
+
 
 ## fluent-syntax 0.4.0 (May 17th, 2017)
 

--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -1,8 +1,24 @@
-class Node {
+/*
+ * Base class for all Fluent AST nodes.
+ *
+ * All productions described in the ASDL subclass BaseNode, including Span and
+ * Annotation.
+ *
+ */
+class BaseNode {
   constructor() {}
 }
 
-export class Resource extends Node {
+/*
+ * Base class for AST nodes which can have Spans.
+ */
+class SyntaxNode extends BaseNode {
+  addSpan(start, end) {
+    this.span = new Span(start, end);
+  }
+}
+
+export class Resource extends SyntaxNode {
   constructor(body = [], comment = null) {
     super();
     this.type = 'Resource';
@@ -11,16 +27,11 @@ export class Resource extends Node {
   }
 }
 
-export class Entry extends Node {
-  constructor(span = null, annotations = []) {
+export class Entry extends SyntaxNode {
+  constructor() {
     super();
     this.type = 'Entry';
-    this.span = span;
-    this.annotations = annotations;
-  }
-
-  addSpan(start, end) {
-    this.span = new Span(start, end);
+    this.annotations = [];
   }
 
   addAnnotation(annot) {
@@ -29,11 +40,8 @@ export class Entry extends Node {
 }
 
 export class Message extends Entry {
-  constructor(
-    id, value = null, attributes = null, tags = null, comment = null,
-    span, annotations
-  ) {
-    super(span, annotations);
+  constructor(id, value = null, attributes = [], tags = [], comment = null) {
+    super();
     this.type = 'Message';
     this.id = id;
     this.value = value;
@@ -43,7 +51,7 @@ export class Message extends Entry {
   }
 }
 
-export class Pattern extends Node {
+export class Pattern extends SyntaxNode {
   constructor(elements) {
     super();
     this.type = 'Pattern';
@@ -51,7 +59,7 @@ export class Pattern extends Node {
   }
 }
 
-export class TextElement extends Node {
+export class TextElement extends SyntaxNode {
   constructor(value) {
     super();
     this.type = 'TextElement';
@@ -59,7 +67,7 @@ export class TextElement extends Node {
   }
 }
 
-export class Expression extends Node {
+export class Expression extends SyntaxNode {
   constructor() {
     super();
     this.type = 'Expression';
@@ -134,7 +142,7 @@ export class CallExpression extends Expression {
   }
 }
 
-export class Attribute extends Node {
+export class Attribute extends SyntaxNode {
   constructor(id, value) {
     super();
     this.type = 'Attribute';
@@ -143,7 +151,7 @@ export class Attribute extends Node {
   }
 }
 
-export class Tag extends Node {
+export class Tag extends SyntaxNode {
   constructor(name) {
     super();
     this.type = 'Tag';
@@ -151,7 +159,7 @@ export class Tag extends Node {
   }
 }
 
-export class Variant extends Node {
+export class Variant extends SyntaxNode {
   constructor(key, value, def = false) {
     super();
     this.type = 'Variant';
@@ -161,7 +169,7 @@ export class Variant extends Node {
   }
 }
 
-export class NamedArgument extends Node {
+export class NamedArgument extends SyntaxNode {
   constructor(name, val) {
     super();
     this.type = 'NamedArgument';
@@ -170,7 +178,7 @@ export class NamedArgument extends Node {
   }
 }
 
-export class Identifier extends Node {
+export class Identifier extends SyntaxNode {
   constructor(name) {
     super();
     this.type = 'Identifier';
@@ -186,16 +194,16 @@ export class Symbol extends Identifier {
 }
 
 export class Comment extends Entry {
-  constructor(content, span, annotations) {
-    super(span, annotations);
+  constructor(content) {
+    super();
     this.type = 'Comment';
     this.content = content;
   }
 }
 
 export class Section extends Entry {
-  constructor(name, comment = null, span, annotations) {
-    super(span, annotations);
+  constructor(name, comment = null) {
+    super();
     this.type = 'Section';
     this.name = name;
     this.comment = comment;
@@ -210,14 +218,14 @@ export class Function extends Identifier {
 }
 
 export class Junk extends Entry {
-  constructor(content, span, annotations) {
-    super(span, annotations);
+  constructor(content) {
+    super();
     this.type = 'Junk';
     this.content = content;
   }
 }
 
-export class Span extends Node {
+export class Span extends BaseNode {
   constructor(start, end) {
     super();
     this.type = 'Span';
@@ -226,16 +234,12 @@ export class Span extends Node {
   }
 }
 
-export class Annotation extends Node {
+export class Annotation extends SyntaxNode {
   constructor(code, args = [], message) {
     super();
     this.type = 'Annotation';
     this.code = code;
     this.args = args;
     this.message = message;
-  }
-
-  addSpan(start, end) {
-    this.span = new Span(start, end);
   }
 }

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -22,7 +22,7 @@ export default class FluentParser {
     const entries = [];
 
     while (ps.current()) {
-      const entry = getEntryOrJunk(this, ps);
+      const entry = this.getEntryOrJunk(ps);
 
       if (entry.type === 'Comment' && entries.length === 0) {
         comment = entry;
@@ -39,550 +39,550 @@ export default class FluentParser {
   parseEntry(source) {
     const ps = new FTLParserStream(source);
     ps.skipWSLines();
-    return getEntryOrJunk(this, ps);
-  }
-}
-
-function getEntryOrJunk(parser, ps) {
-  const entryStartPos = ps.getIndex();
-
-  try {
-    const entry = getEntry(ps);
-    if (parser.withSpans) {
-      entry.addSpan(entryStartPos, ps.getIndex());
-    }
-    return entry;
-  } catch (err) {
-    if (!(err instanceof ParseError)) {
-      throw err;
-    }
-
-    const errorIndex = ps.getIndex();
-    ps.skipToNextEntryStart();
-    const nextEntryStart = ps.getIndex();
-
-    // Create a Junk instance
-    const slice = ps.getSlice(entryStartPos, nextEntryStart);
-    const junk = new AST.Junk(slice);
-    if (parser.withSpans) {
-      junk.addSpan(entryStartPos, nextEntryStart);
-    }
-    if (parser.withAnnotations) {
-      const annot = new AST.Annotation(err.code, err.args, err.message);
-      annot.addSpan(errorIndex, errorIndex);
-      junk.addAnnotation(annot);
-    }
-    return junk;
-  }
-}
-
-function getEntry(ps) {
-  let comment;
-
-  if (ps.currentIs('/')) {
-    comment = getComment(ps);
+    return this.getEntryOrJunk(ps);
   }
 
-  if (ps.currentIs('[')) {
-    return getSection(ps, comment);
-  }
+  getEntryOrJunk(ps) {
+    const entryStartPos = ps.getIndex();
 
-  if (ps.isIDStart()) {
-    return getMessage(ps, comment);
-  }
-
-  if (comment) {
-    return comment;
-  }
-  throw new ParseError('E0002');
-}
-
-function getComment(ps) {
-  ps.expectChar('/');
-  ps.expectChar('/');
-  ps.takeCharIf(' ');
-
-  let content = '';
-
-  while (true) {
-    let ch;
-    while ((ch = ps.takeChar(x => x !== '\n'))) {
-      content += ch;
-    }
-
-    ps.next();
-
-    if (ps.current() === '/') {
-      content += '\n';
-      ps.next();
-      ps.expectChar('/');
-      ps.takeCharIf(' ');
-    } else {
-      break;
-    }
-  }
-  return new AST.Comment(content);
-}
-
-function getSection(ps, comment) {
-  ps.expectChar('[');
-  ps.expectChar('[');
-
-  ps.skipLineWS();
-
-  const symb = getSymbol(ps);
-
-  ps.skipLineWS();
-
-  ps.expectChar(']');
-  ps.expectChar(']');
-
-  ps.skipLineWS();
-
-  ps.expectChar('\n');
-
-  return new AST.Section(symb, comment);
-}
-
-function getMessage(ps, comment) {
-  const id = getIdentifier(ps);
-
-  ps.skipLineWS();
-
-  let pattern;
-  let attrs;
-  let tags;
-
-  if (ps.currentIs('=')) {
-    ps.next();
-    ps.skipLineWS();
-
-    pattern = getPattern(ps);
-  }
-
-  if (ps.isPeekNextLineAttributeStart()) {
-    attrs = getAttributes(ps);
-  }
-
-  if (ps.isPeekNextLineTagStart()) {
-    if (attrs !== undefined) {
-      throw new ParseError('E0012');
-    }
-    tags = getTags(ps);
-  }
-
-  if (pattern === undefined && attrs === undefined && tags === undefined) {
-    throw new ParseError('E0005', id.name);
-  }
-
-  return new AST.Message(id, pattern, attrs, tags, comment);
-}
-
-function getAttributes(ps) {
-  const attrs = [];
-
-  while (true) {
-    ps.expectChar('\n');
-    ps.skipLineWS();
-
-    ps.expectChar('.');
-
-    const key = getIdentifier(ps);
-
-    ps.skipLineWS();
-
-    ps.expectChar('=');
-
-    ps.skipLineWS();
-
-    const value = getPattern(ps);
-
-    if (value === undefined) {
-      throw new ParseError('E0006', 'value');
-    }
-
-    attrs.push(new AST.Attribute(key, value));
-
-    if (!ps.isPeekNextLineAttributeStart()) {
-      break;
-    }
-  }
-  return attrs;
-}
-
-function getTags(ps) {
-  const tags = [];
-
-  while (true) {
-    ps.expectChar('\n');
-    ps.skipLineWS();
-
-    ps.expectChar('#');
-
-    const symbol = getSymbol(ps);
-
-    tags.push(new AST.Tag(symbol));
-
-    if (!ps.isPeekNextLineTagStart()) {
-      break;
-    }
-  }
-  return tags;
-}
-
-function getIdentifier(ps) {
-  let name = '';
-
-  name += ps.takeIDStart();
-
-  let ch;
-  while ((ch = ps.takeIDChar())) {
-    name += ch;
-  }
-
-  return new AST.Identifier(name);
-}
-
-function getVariantKey(ps) {
-  const ch = ps.current();
-
-  if (!ch) {
-    throw new ParseError('E0013');
-  }
-
-  const cc = ch.charCodeAt(0);
-
-  if ((cc >= 48 && cc <= 57) || cc === 45) { // 0-9, -
-    return getNumber(ps);
-  }
-
-  return getSymbol(ps);
-}
-
-function getVariants(ps) {
-  const variants = [];
-  let hasDefault = false;
-
-  while (true) {
-    let defaultIndex = false;
-
-    ps.expectChar('\n');
-    ps.skipLineWS();
-
-    if (ps.currentIs('*')) {
-      if (hasDefault) {
-        throw new ParseError('E0015');
+    try {
+      const entry = this.getEntry(ps);
+      if (this.withSpans) {
+        entry.addSpan(entryStartPos, ps.getIndex());
       }
-      ps.next();
-      defaultIndex = true;
-      hasDefault = true;
+      return entry;
+    } catch (err) {
+      if (!(err instanceof ParseError)) {
+        throw err;
+      }
+
+      const errorIndex = ps.getIndex();
+      ps.skipToNextEntryStart();
+      const nextEntryStart = ps.getIndex();
+
+      // Create a Junk instance
+      const slice = ps.getSlice(entryStartPos, nextEntryStart);
+      const junk = new AST.Junk(slice);
+      if (this.withSpans) {
+        junk.addSpan(entryStartPos, nextEntryStart);
+      }
+      if (this.withAnnotations) {
+        const annot = new AST.Annotation(err.code, err.args, err.message);
+        annot.addSpan(errorIndex, errorIndex);
+        junk.addAnnotation(annot);
+      }
+      return junk;
+    }
+  }
+
+  getEntry(ps) {
+    let comment;
+
+    if (ps.currentIs('/')) {
+      comment = this.getComment(ps);
     }
 
+    if (ps.currentIs('[')) {
+      return this.getSection(ps, comment);
+    }
+
+    if (ps.isIDStart()) {
+      return this.getMessage(ps, comment);
+    }
+
+    if (comment) {
+      return comment;
+    }
+    throw new ParseError('E0002');
+  }
+
+  getComment(ps) {
+    ps.expectChar('/');
+    ps.expectChar('/');
+    ps.takeCharIf(' ');
+
+    let content = '';
+
+    while (true) {
+      let ch;
+      while ((ch = ps.takeChar(x => x !== '\n'))) {
+        content += ch;
+      }
+
+      ps.next();
+
+      if (ps.current() === '/') {
+        content += '\n';
+        ps.next();
+        ps.expectChar('/');
+        ps.takeCharIf(' ');
+      } else {
+        break;
+      }
+    }
+    return new AST.Comment(content);
+  }
+
+  getSection(ps, comment) {
+    ps.expectChar('[');
     ps.expectChar('[');
 
-    const key = getVariantKey(ps);
+    ps.skipLineWS();
 
+    const symb = this.getSymbol(ps);
+
+    ps.skipLineWS();
+
+    ps.expectChar(']');
     ps.expectChar(']');
 
     ps.skipLineWS();
 
-    const value = getPattern(ps);
-
-    if (!value) {
-      throw new ParseError('E0006', 'value');
-    }
-
-    variants.push(new AST.Variant(key, value, defaultIndex));
-
-    if (!ps.isPeekNextLineVariantStart()) {
-      break;
-    }
-  }
-
-  if (!hasDefault) {
-    throw new ParseError('E0010');
-  }
-
-  return variants;
-}
-
-function getSymbol(ps) {
-  let name = '';
-
-  name += ps.takeIDStart();
-
-  while (true) {
-    const ch = ps.takeSymbChar();
-    if (ch) {
-      name += ch;
-    } else {
-      break;
-    }
-  }
-
-  return new AST.Symbol(name.trimRight());
-}
-
-function getDigits(ps) {
-  let num = '';
-
-  let ch;
-  while ((ch = ps.takeDigit())) {
-    num += ch;
-  }
-
-  if (num.length === 0) {
-    throw new ParseError('E0004', '0-9');
-  }
-
-  return num;
-}
-
-function getNumber(ps) {
-  let num = '';
-
-  if (ps.currentIs('-')) {
-    num += '-';
-    ps.next();
-  }
-
-  num = `${num}${getDigits(ps)}`;
-
-  if (ps.currentIs('.')) {
-    num += '.';
-    ps.next();
-    num = `${num}${getDigits(ps)}`;
-  }
-
-  return new AST.NumberExpression(num);
-}
-
-function getPattern(ps) {
-  let buffer = '';
-  const elements = [];
-  let firstLine = true;
-
-  let ch;
-  while ((ch = ps.current())) {
-    if (ch === '\n') {
-      if (firstLine && buffer.length !== 0) {
-        break;
-      }
-
-      if (!ps.isPeekNextLinePattern()) {
-        break;
-      }
-
-      ps.next();
-      ps.skipLineWS();
-
-      if (!firstLine) {
-        buffer += ch;
-      }
-      firstLine = false;
-      continue;
-    } else if (ch === '\\') {
-      const ch2 = ps.peek();
-      if (ch2 === '{' || ch2 === '"') {
-        buffer += ch2;
-      } else {
-        buffer += ch + ch2;
-      }
-      ps.next();
-    } else if (ch === '{') {
-      ps.next();
-
-      ps.skipLineWS();
-
-      if (buffer.length !== 0) {
-        elements.push(new AST.TextElement(buffer));
-      }
-
-      buffer = '';
-
-      elements.push(getExpression(ps));
-
-      ps.expectChar('}');
-
-      continue;
-    } else {
-      buffer += ps.ch;
-    }
-    ps.next();
-  }
-
-  if (buffer.length !== 0) {
-    elements.push(new AST.TextElement(buffer));
-  }
-
-  return new AST.Pattern(elements);
-}
-
-function getExpression(ps) {
-  if (ps.isPeekNextLineVariantStart()) {
-    const variants = getVariants(ps);
-
     ps.expectChar('\n');
-    ps.expectChar(' ');
+
+    return new AST.Section(symb, comment);
+  }
+
+  getMessage(ps, comment) {
+    const id = this.getIdentifier(ps);
+
     ps.skipLineWS();
 
-    return new AST.SelectExpression(null, variants);
+    let pattern;
+    let attrs;
+    let tags;
+
+    if (ps.currentIs('=')) {
+      ps.next();
+      ps.skipLineWS();
+
+      pattern = this.getPattern(ps);
+    }
+
+    if (ps.isPeekNextLineAttributeStart()) {
+      attrs = this.getAttributes(ps);
+    }
+
+    if (ps.isPeekNextLineTagStart()) {
+      if (attrs !== undefined) {
+        throw new ParseError('E0012');
+      }
+      tags = this.getTags(ps);
+    }
+
+    if (pattern === undefined && attrs === undefined && tags === undefined) {
+      throw new ParseError('E0005', id.name);
+    }
+
+    return new AST.Message(id, pattern, attrs, tags, comment);
   }
 
-  const selector = getSelectorExpression(ps);
+  getAttributes(ps) {
+    const attrs = [];
 
-  ps.skipLineWS();
+    while (true) {
+      ps.expectChar('\n');
+      ps.skipLineWS();
 
-  if (ps.currentIs('-')) {
-    ps.peek();
-    if (!ps.currentPeekIs('>')) {
-      ps.resetPeek();
-    } else {
-      ps.next();
-      ps.next();
+      ps.expectChar('.');
+
+      const key = this.getIdentifier(ps);
 
       ps.skipLineWS();
 
-      const variants = getVariants(ps);
+      ps.expectChar('=');
 
-      if (variants.length === 0) {
-        throw new ParseError('E0011');
+      ps.skipLineWS();
+
+      const value = this.getPattern(ps);
+
+      if (value === undefined) {
+        throw new ParseError('E0006', 'value');
       }
+
+      attrs.push(new AST.Attribute(key, value));
+
+      if (!ps.isPeekNextLineAttributeStart()) {
+        break;
+      }
+    }
+    return attrs;
+  }
+
+  getTags(ps) {
+    const tags = [];
+
+    while (true) {
+      ps.expectChar('\n');
+      ps.skipLineWS();
+
+      ps.expectChar('#');
+
+      const symbol = this.getSymbol(ps);
+
+      tags.push(new AST.Tag(symbol));
+
+      if (!ps.isPeekNextLineTagStart()) {
+        break;
+      }
+    }
+    return tags;
+  }
+
+  getIdentifier(ps) {
+    let name = '';
+
+    name += ps.takeIDStart();
+
+    let ch;
+    while ((ch = ps.takeIDChar())) {
+      name += ch;
+    }
+
+    return new AST.Identifier(name);
+  }
+
+  getVariantKey(ps) {
+    const ch = ps.current();
+
+    if (!ch) {
+      throw new ParseError('E0013');
+    }
+
+    const cc = ch.charCodeAt(0);
+
+    if ((cc >= 48 && cc <= 57) || cc === 45) { // 0-9, -
+      return this.getNumber(ps);
+    }
+
+    return this.getSymbol(ps);
+  }
+
+  getVariants(ps) {
+    const variants = [];
+    let hasDefault = false;
+
+    while (true) {
+      let defaultIndex = false;
+
+      ps.expectChar('\n');
+      ps.skipLineWS();
+
+      if (ps.currentIs('*')) {
+        if (hasDefault) {
+          throw new ParseError('E0015');
+        }
+        ps.next();
+        defaultIndex = true;
+        hasDefault = true;
+      }
+
+      ps.expectChar('[');
+
+      const key = this.getVariantKey(ps);
+
+      ps.expectChar(']');
+
+      ps.skipLineWS();
+
+      const value = this.getPattern(ps);
+
+      if (!value) {
+        throw new ParseError('E0006', 'value');
+      }
+
+      variants.push(new AST.Variant(key, value, defaultIndex));
+
+      if (!ps.isPeekNextLineVariantStart()) {
+        break;
+      }
+    }
+
+    if (!hasDefault) {
+      throw new ParseError('E0010');
+    }
+
+    return variants;
+  }
+
+  getSymbol(ps) {
+    let name = '';
+
+    name += ps.takeIDStart();
+
+    while (true) {
+      const ch = ps.takeSymbChar();
+      if (ch) {
+        name += ch;
+      } else {
+        break;
+      }
+    }
+
+    return new AST.Symbol(name.trimRight());
+  }
+
+  getDigits(ps) {
+    let num = '';
+
+    let ch;
+    while ((ch = ps.takeDigit())) {
+      num += ch;
+    }
+
+    if (num.length === 0) {
+      throw new ParseError('E0004', '0-9');
+    }
+
+    return num;
+  }
+
+  getNumber(ps) {
+    let num = '';
+
+    if (ps.currentIs('-')) {
+      num += '-';
+      ps.next();
+    }
+
+    num = `${num}${this.getDigits(ps)}`;
+
+    if (ps.currentIs('.')) {
+      num += '.';
+      ps.next();
+      num = `${num}${this.getDigits(ps)}`;
+    }
+
+    return new AST.NumberExpression(num);
+  }
+
+  getPattern(ps) {
+    let buffer = '';
+    const elements = [];
+    let firstLine = true;
+
+    let ch;
+    while ((ch = ps.current())) {
+      if (ch === '\n') {
+        if (firstLine && buffer.length !== 0) {
+          break;
+        }
+
+        if (!ps.isPeekNextLinePattern()) {
+          break;
+        }
+
+        ps.next();
+        ps.skipLineWS();
+
+        if (!firstLine) {
+          buffer += ch;
+        }
+        firstLine = false;
+        continue;
+      } else if (ch === '\\') {
+        const ch2 = ps.peek();
+        if (ch2 === '{' || ch2 === '"') {
+          buffer += ch2;
+        } else {
+          buffer += ch + ch2;
+        }
+        ps.next();
+      } else if (ch === '{') {
+        ps.next();
+
+        ps.skipLineWS();
+
+        if (buffer.length !== 0) {
+          elements.push(new AST.TextElement(buffer));
+        }
+
+        buffer = '';
+
+        elements.push(this.getExpression(ps));
+
+        ps.expectChar('}');
+
+        continue;
+      } else {
+        buffer += ps.ch;
+      }
+      ps.next();
+    }
+
+    if (buffer.length !== 0) {
+      elements.push(new AST.TextElement(buffer));
+    }
+
+    return new AST.Pattern(elements);
+  }
+
+  getExpression(ps) {
+    if (ps.isPeekNextLineVariantStart()) {
+      const variants = this.getVariants(ps);
 
       ps.expectChar('\n');
       ps.expectChar(' ');
       ps.skipLineWS();
 
-      return new AST.SelectExpression(selector, variants);
+      return new AST.SelectExpression(null, variants);
     }
+
+    const selector = this.getSelectorExpression(ps);
+
+    ps.skipLineWS();
+
+    if (ps.currentIs('-')) {
+      ps.peek();
+      if (!ps.currentPeekIs('>')) {
+        ps.resetPeek();
+      } else {
+        ps.next();
+        ps.next();
+
+        ps.skipLineWS();
+
+        const variants = this.getVariants(ps);
+
+        if (variants.length === 0) {
+          throw new ParseError('E0011');
+        }
+
+        ps.expectChar('\n');
+        ps.expectChar(' ');
+        ps.skipLineWS();
+
+        return new AST.SelectExpression(selector, variants);
+      }
+    }
+
+    return selector;
   }
 
-  return selector;
-}
+  getSelectorExpression(ps) {
+    const literal = this.getLiteral(ps);
 
-function getSelectorExpression(ps) {
-  const literal = getLiteral(ps);
+    if (literal.type !== 'MessageReference') {
+      return literal;
+    }
 
-  if (literal.type !== 'MessageReference') {
+    const ch = ps.current();
+
+    if (ch === '.') {
+      ps.next();
+
+      const attr = this.getIdentifier(ps);
+      return new AST.AttributeExpression(literal.id, attr);
+    }
+
+    if (ch === '[') {
+      ps.next();
+
+      const key = this.getVariantKey(ps);
+
+      ps.expectChar(']');
+
+      return new AST.VariantExpression(literal.id, key);
+    }
+
+    if (ch === '(') {
+      ps.next();
+
+      const args = this.getCallArgs(ps);
+
+      ps.expectChar(')');
+
+      return new AST.CallExpression(literal.id, args);
+    }
+
     return literal;
   }
 
-  const ch = ps.current();
-
-  if (ch === '.') {
-    ps.next();
-
-    const attr = getIdentifier(ps);
-    return new AST.AttributeExpression(literal.id, attr);
-  }
-
-  if (ch === '[') {
-    ps.next();
-
-    const key = getVariantKey(ps);
-
-    ps.expectChar(']');
-
-    return new AST.VariantExpression(literal.id, key);
-  }
-
-  if (ch === '(') {
-    ps.next();
-
-    const args = getCallArgs(ps);
-
-    ps.expectChar(')');
-
-    return new AST.CallExpression(literal.id, args);
-  }
-
-  return literal;
-}
-
-function getCallArgs(ps) {
-  const args = [];
-
-  ps.skipLineWS();
-
-  while (true) {
-    if (ps.current() === ')') {
-      break;
-    }
-
-    const exp = getSelectorExpression(ps);
+  getCallArgs(ps) {
+    const args = [];
 
     ps.skipLineWS();
 
-    if (ps.current() === ':') {
-      if (exp.type !== 'MessageReference') {
-        throw new ParseError('E0009');
+    while (true) {
+      if (ps.current() === ')') {
+        break;
       }
 
-      ps.next();
+      const exp = this.getSelectorExpression(ps);
+
       ps.skipLineWS();
 
-      const val = getArgVal(ps);
+      if (ps.current() === ':') {
+        if (exp.type !== 'MessageReference') {
+          throw new ParseError('E0009');
+        }
 
-      args.push(new AST.NamedArgument(exp.id, val));
-    } else {
-      args.push(exp);
-    }
+        ps.next();
+        ps.skipLineWS();
 
-    ps.skipLineWS();
+        const val = this.getArgVal(ps);
 
-    if (ps.current() === ',') {
-      ps.next();
+        args.push(new AST.NamedArgument(exp.id, val));
+      } else {
+        args.push(exp);
+      }
+
       ps.skipLineWS();
-      continue;
-    } else {
-      break;
+
+      if (ps.current() === ',') {
+        ps.next();
+        ps.skipLineWS();
+        continue;
+      } else {
+        break;
+      }
     }
-  }
-  return args;
-}
-
-function getArgVal(ps) {
-  if (ps.isNumberStart()) {
-    return getNumber(ps);
-  } else if (ps.currentIs('"')) {
-    return getString(ps);
-  }
-  throw new ParseError('E0006', 'value');
-}
-
-function getString(ps) {
-  let val = '';
-
-  ps.expectChar('"');
-
-  let ch;
-  while ((ch = ps.takeChar(x => x !== '"'))) {
-    val += ch;
+    return args;
   }
 
-  ps.next();
-
-  return new AST.StringExpression(val);
-
-}
-
-function getLiteral(ps) {
-  const ch = ps.current();
-
-  if (!ch) {
-    throw new ParseError('E0014');
+  getArgVal(ps) {
+    if (ps.isNumberStart()) {
+      return this.getNumber(ps);
+    } else if (ps.currentIs('"')) {
+      return this.getString(ps);
+    }
+    throw new ParseError('E0006', 'value');
   }
 
-  if (ps.isNumberStart()) {
-    return getNumber(ps);
-  } else if (ch === '"') {
-    return getString(ps);
-  } else if (ch === '$') {
+  getString(ps) {
+    let val = '';
+
+    ps.expectChar('"');
+
+    let ch;
+    while ((ch = ps.takeChar(x => x !== '"'))) {
+      val += ch;
+    }
+
     ps.next();
-    const name = getIdentifier(ps);
-    return new AST.ExternalArgument(name);
+
+    return new AST.StringExpression(val);
+
   }
 
-  const name = getIdentifier(ps);
-  return new AST.MessageReference(name);
+  getLiteral(ps) {
+    const ch = ps.current();
+
+    if (!ch) {
+      throw new ParseError('E0014');
+    }
+
+    if (ps.isNumberStart()) {
+      return this.getNumber(ps);
+    } else if (ch === '"') {
+      return this.getString(ps);
+    } else if (ch === '$') {
+      ps.next();
+      const name = this.getIdentifier(ps);
+      return new AST.ExternalArgument(name);
+    }
+
+    const name = this.getIdentifier(ps);
+    return new AST.MessageReference(name);
+  }
 }

--- a/fluent-syntax/src/serializer.js
+++ b/fluent-syntax/src/serializer.js
@@ -88,16 +88,12 @@ function serializeMessage(message) {
     parts.push(serializeValue(message.value));
   }
 
-  if (message.tags) {
-    for (const tag of message.tags) {
-      parts.push(serializeTag(tag));
-    }
+  for (const tag of message.tags) {
+    parts.push(serializeTag(tag));
   }
 
-  if (message.attributes) {
-    for (const attribute of message.attributes) {
-      parts.push(serializeAttribute(attribute));
-    }
+  for (const attribute of message.attributes) {
+    parts.push(serializeAttribute(attribute));
   }
 
   parts.push('\n');

--- a/fluent-syntax/test/entry_test.js
+++ b/fluent-syntax/test/entry_test.js
@@ -19,22 +19,37 @@ suite('Parse entry', function() {
         "end": 9,
         "type": "Span"
       },
-      "tags": null,
+      "tags": [],
       "value": {
         "elements": [
           {
             "type": "TextElement",
-            "value": "Foo"
+            "value": "Foo",
+            "span": {
+              "start": 6,
+              "end": 9,
+              "type": "Span"
+            }
           }
         ],
-        "type": "Pattern"
+        "type": "Pattern",
+        "span": {
+          "start": 6,
+          "end": 9,
+          "type": "Span"
+        }
       },
       "annotations": [],
-      "attributes": null,
+      "attributes": [],
       "type": "Message",
       "id": {
         "type": "Identifier",
-        "name": "foo"
+        "name": "foo",
+        "span": {
+          "start": 0,
+          "end": 3,
+          "type": "Span"
+        }
       }
     };
 
@@ -57,7 +72,7 @@ suite('Serialize entry', function() {
         "end": 9,
         "type": "Span"
       },
-      "tags": null,
+      "tags": [],
       "value": {
         "elements": [
           {
@@ -65,14 +80,24 @@ suite('Serialize entry', function() {
             "value": "Foo"
           }
         ],
-        "type": "Pattern"
+        "type": "Pattern",
+        "span": {
+          "start": 6,
+          "end": 9,
+          "type": "Span"
+        }
       },
       "annotations": [],
-      "attributes": null,
+      "attributes": [],
       "type": "Message",
       "id": {
         "type": "Identifier",
-        "name": "foo"
+        "name": "foo",
+        "span": {
+          "start": 0,
+          "end": 3,
+          "type": "Span"
+        }
       }
     };
     const output = ftl`

--- a/fluent-syntax/test/fixtures_structure/message_with_empty_pattern.json
+++ b/fluent-syntax/test/fixtures_structure/message_with_empty_pattern.json
@@ -3,24 +3,39 @@
   "body": [
     {
       "type": "Message",
+      "annotations": [],
+      "id": {
+        "type": "Identifier",
+        "name": "foo",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 3
+        }
+      },
+      "value": {
+        "type": "Pattern",
+        "elements": [],
+        "span": {
+          "type": "Span",
+          "start": 6,
+          "end": 6
+        }
+      },
+      "attributes": [],
+      "tags": [],
+      "comment": null,
       "span": {
         "type": "Span",
         "start": 0,
         "end": 6
-      },
-      "annotations": [],
-      "id": {
-        "type": "Identifier",
-        "name": "foo"
-      },
-      "value": {
-        "type": "Pattern",
-        "elements": []
-      },
-      "attributes": null,
-      "tags": null,
-      "comment": null
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 7
+  }
 }

--- a/fluent-syntax/test/fixtures_structure/placeable_at_eol.json
+++ b/fluent-syntax/test/fixtures_structure/placeable_at_eol.json
@@ -3,40 +3,75 @@
   "body": [
     {
       "type": "Message",
-      "span": {
-        "type": "Span",
-        "start": 0,
-        "end": 130
-      },
       "annotations": [],
       "id": {
         "type": "Identifier",
-        "name": "key"
+        "name": "key",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 3
+        }
       },
       "value": {
         "type": "Pattern",
         "elements": [
           {
             "type": "TextElement",
-            "value": "A multiline message with a "
+            "value": "A multiline message with a ",
+            "span": {
+              "type": "Span",
+              "start": 5,
+              "end": 39
+            }
           },
           {
             "type": "MessageReference",
             "id": {
               "type": "Identifier",
-              "name": "placeable"
+              "name": "placeable",
+              "span": {
+                "type": "Span",
+                "start": 39,
+                "end": 48
+              }
+            },
+            "span": {
+              "type": "Span",
+              "start": 39,
+              "end": 48
             }
           },
           {
             "type": "TextElement",
-            "value": "\nat the end of line.  The message should\nconsist of three lines of text."
+            "value": "\nat the end of line.  The message should\nconsist of three lines of text.",
+            "span": {
+              "type": "Span",
+              "start": 50,
+              "end": 130
+            }
           }
-        ]
+        ],
+        "span": {
+          "type": "Span",
+          "start": 5,
+          "end": 130
+        }
       },
-      "attributes": null,
-      "tags": null,
-      "comment": null
+      "attributes": [],
+      "tags": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 0,
+        "end": 130
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 131
+  }
 }

--- a/fluent-syntax/test/fixtures_structure/resource_comment.json
+++ b/fluent-syntax/test/fixtures_structure/resource_comment.json
@@ -3,12 +3,17 @@
   "body": [],
   "comment": {
     "type": "Comment",
+    "annotations": [],
+    "content": "This is a resource wide comment\nIt's multiline",
     "span": {
       "type": "Span",
       "start": 0,
       "end": 53
-    },
-    "annotations": [],
-    "content": "This is a resource wide comment\nIt's multiline"
+    }
+  },
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 53
   }
 }

--- a/fluent-syntax/test/fixtures_structure/resource_comment_trailing_line.json
+++ b/fluent-syntax/test/fixtures_structure/resource_comment_trailing_line.json
@@ -3,12 +3,17 @@
   "body": [],
   "comment": {
     "type": "Comment",
+    "annotations": [],
+    "content": "This is a comment\nThis comment is multiline\n",
     "span": {
       "type": "Span",
       "start": 0,
       "end": 53
-    },
-    "annotations": [],
-    "content": "This is a comment\nThis comment is multiline\n"
+    }
+  },
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 53
   }
 }

--- a/fluent-syntax/test/fixtures_structure/section.json
+++ b/fluent-syntax/test/fixtures_structure/section.json
@@ -3,18 +3,28 @@
   "body": [
     {
       "type": "Section",
+      "annotations": [],
+      "name": {
+        "type": "Symbol",
+        "name": "This is a section",
+        "span": {
+          "type": "Span",
+          "start": 4,
+          "end": 22
+        }
+      },
+      "comment": null,
       "span": {
         "type": "Span",
         "start": 1,
         "end": 25
-      },
-      "annotations": [],
-      "name": {
-        "type": "Symbol",
-        "name": "This is a section"
-      },
-      "comment": null
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 25
+  }
 }

--- a/fluent-syntax/test/fixtures_structure/simple_message.json
+++ b/fluent-syntax/test/fixtures_structure/simple_message.json
@@ -3,29 +3,49 @@
   "body": [
     {
       "type": "Message",
-      "span": {
-        "type": "Span",
-        "start": 0,
-        "end": 9
-      },
       "annotations": [],
       "id": {
         "type": "Identifier",
-        "name": "foo"
+        "name": "foo",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 3
+        }
       },
       "value": {
         "type": "Pattern",
         "elements": [
           {
             "type": "TextElement",
-            "value": "Foo"
+            "value": "Foo",
+            "span": {
+              "type": "Span",
+              "start": 6,
+              "end": 9
+            }
           }
-        ]
+        ],
+        "span": {
+          "type": "Span",
+          "start": 6,
+          "end": 9
+        }
       },
-      "attributes": null,
-      "tags": null,
-      "comment": null
+      "attributes": [],
+      "tags": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 0,
+        "end": 9
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 10
+  }
 }

--- a/fluent-syntax/test/fixtures_structure/standalone_comment.json
+++ b/fluent-syntax/test/fixtures_structure/standalone_comment.json
@@ -3,39 +3,59 @@
   "body": [
     {
       "type": "Message",
-      "span": {
-        "type": "Span",
-        "start": 0,
-        "end": 11
-      },
       "annotations": [],
       "id": {
         "type": "Identifier",
-        "name": "foo"
+        "name": "foo",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 3
+        }
       },
       "value": {
         "type": "Pattern",
         "elements": [
           {
             "type": "TextElement",
-            "value": "Value"
+            "value": "Value",
+            "span": {
+              "type": "Span",
+              "start": 6,
+              "end": 11
+            }
           }
-        ]
+        ],
+        "span": {
+          "type": "Span",
+          "start": 6,
+          "end": 11
+        }
       },
-      "attributes": null,
-      "tags": null,
-      "comment": null
+      "attributes": [],
+      "tags": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 0,
+        "end": 11
+      }
     },
     {
       "type": "Comment",
+      "annotations": [],
+      "content": "This is a standalone comment",
       "span": {
         "type": "Span",
         "start": 13,
         "end": 45
-      },
-      "annotations": [],
-      "content": "This is a standalone comment"
+      }
     }
   ],
-  "comment": null
+  "comment": null,
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 45
+  }
 }


### PR DESCRIPTION
Most AST nodes can now have a Span.  Use `new FluentParser({ withSpans: true })` to enable this behavior. The `withAnnotations` config option to `FluentParser` has been removed. The parser always produces Annotations if necessary now.