### PR TITLE
fluent-react: Introduce the Placeholder component

### DIFF
--- a/fluent-react/examples/hello-world/src/App.js
+++ b/fluent-react/examples/hello-world/src/App.js
@@ -7,6 +7,10 @@ export default function App() {
       <Localized id="title">
         <h1>Hello, world!</h1>
       </Localized>
+
+      <Localized id="learn-more">
+        <p>Consult the <a href="https://github.com/projectfluent/fluent.js/wiki/React-Bindings">documentation</a> to learn more about fluent-react.</p>
+      </Localized>
     </div>
   );
 }

--- a/fluent-react/examples/hello-world/src/l10n.js
+++ b/fluent-react/examples/hello-world/src/l10n.js
@@ -1,13 +1,21 @@
+import React from 'react';
 import 'fluent-intl-polyfill/compat';
 import { MessageContext } from 'fluent/compat';
 import negotiateLanguages from 'fluent-langneg/compat';
+import { Placeholder } from 'fluent-react/compat';
 
 const MESSAGES_ALL = {
   'pl': `
 title = Witaj świecie!
+learn-more =
+    Odwiedź { LINK("dokumentację", title: "Wiki", href: "http://example.com") },
+    aby dowiedzieć się więcej o { LINK("fluent-react") }.
   `,
   'en-US': `
 title = Hello, world!
+learn-more =
+    Consult the { LINK("documentation", title: "Wiki") } to learn more
+    about fluent-react.
   `,
 };
 
@@ -20,7 +28,16 @@ export function* generateMessages(userLocales) {
   );
 
   for (const locale of currentLocales) {
-    const cx = new MessageContext(locale);
+    const cx = new MessageContext(locale, {
+      functions: {
+        // Text is the only positional argument we care about.
+        // Title is the only named argument we care about.
+        // This gives us filtering unsafe props (like href) for free!
+        LINK: function([text], {title}) {
+          return <Placeholder title={title}>{text}</Placeholder>;
+        }
+      }
+    });
     cx.addMessages(MESSAGES_ALL[locale]);
     yield cx;
   }

--- a/fluent-react/src/index.js
+++ b/fluent-react/src/index.js
@@ -22,3 +22,4 @@ export { default as withLocalization } from './with_localization';
 export { default as Localized } from './localized';
 export { default as ReactLocalization, isReactLocalization }
   from './localization';
+export { default as Placeholder } from './placeholder';

--- a/fluent-react/src/placeholder.js
+++ b/fluent-react/src/placeholder.js
@@ -1,0 +1,5 @@
+import { createElement } from 'react';
+
+export default function Placeholder(props) {
+  return createElement('span', props);
+}


### PR DESCRIPTION
Placeholders can be used as return values from custom functions passed into `MessageContext`.  `Localized.render` will try to match them in order with original children of the wrapped component.

Given the following HTML/JSX:

```jsx
<Localized id="warning-upgrade">
  <p>
    <a href="https://www.mozilla.org/firefox/">Upgrade Firefox</a> to get started.
  </p>
</Localized>
```

The translation may look like this:

    warning-upgrade =
        { LINK("Upgrade Firefox", title: "New version of Firefox is available!") }
        to get started.

The LINK function is defined in the MessageContext constructor:

```javascript
import { MessageContext } from 'fluent';
import negotiateLanguages from 'fluent-langneg';
import { Placeholder } from 'fluent-react';

export function* generateMessages(userLocales) {
  // Choose locales that are best for the user.
  const currentLocales = negotiateLanguages(
    userLocales,
    ['en-US', 'pl'],
    { defaultLocale: 'en-US' }
  );

  for (const locale of currentLocales) {
    const cx = new MessageContext(locale, {
      functions: {
        // Text is the only positional argument we care about.
        // Title is the only named argument we care about.
        // This gives us filtering unsafe props (like href) for free!
        LINK: function([text], {title}) {
          return <Placeholder title={title}>{text}</Placeholder>;
        }
      }
    });
    cx.addMessages(MESSAGES_ALL[locale]);
    yield cx;
  }
}
```