### PR TITLE
Add eager parameter to the constructor of CachedIterable

### DIFF
--- a/fluent/CHANGELOG.md
+++ b/fluent/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-  - …
+  - Add touchNext to CachedIterable
+
+    This allows the user of CachedIterable to trigger construction of an
+    element yielded from the generator early.
 
 ## fluent 0.4.1 (June 22, 2017)
 

--- a/fluent/src/cached_iterable.js
+++ b/fluent/src/cached_iterable.js
@@ -5,6 +5,12 @@
  * iterable.
  */
 export default class CachedIterable {
+  /**
+   * Create an `CachedIterable` instance.
+   *
+   * @param {Iterable} iterable
+   * @returns {CachedIterable}
+   */
   constructor(iterable) {
     if (!(Symbol.iterator in Object(iterable))) {
       throw new TypeError('Argument must implement the iteration protocol.');
@@ -26,5 +32,16 @@ export default class CachedIterable {
         return seen[cur++];
       }
     };
+  }
+
+  /**
+   * This method allows user to consume the next element from the iterator
+   * into the cache.
+   */
+  touchNext() {
+    const { seen, iterator } = this;
+    if (seen.length === 0 || seen[seen.length - 1].done === false) {
+      seen.push(iterator.next());
+    }
   }
 }

--- a/fluent/test/cached_iterable_test.js
+++ b/fluent/test/cached_iterable_test.js
@@ -83,4 +83,54 @@ suite('CachedIterable', function() {
       assert.deepEqual([...iter], first);
     });
   });
+
+  suite('touchNext', function(){
+    let o1, o2;
+
+    suiteSetup(function() {
+      o1 = Object();
+      o2 = Object();
+    });
+
+    test('consumes an element into the cache', function() {
+      const iter = new CachedIterable([o1, o2]);
+      assert.equal(iter.seen.length, 0);
+      iter.touchNext();
+      assert.equal(iter.seen.length, 1);
+    });
+
+    test('allows to consume multiple elements into the cache', function() {
+      const iter = new CachedIterable([o1, o2]);
+      iter.touchNext();
+      iter.touchNext();
+      assert.equal(iter.seen.length, 2);
+    });
+
+    test('stops at the last element', function() {
+      const iter = new CachedIterable([o1, o2]);
+      iter.touchNext();
+      iter.touchNext();
+      iter.touchNext();
+      assert.equal(iter.seen.length, 3);
+
+      iter.touchNext();
+      assert.equal(iter.seen.length, 3);
+    });
+
+    test('works on an empty iterable', function() {
+      const iter = new CachedIterable([]);
+      iter.touchNext();
+      iter.touchNext();
+      iter.touchNext();
+      assert.equal(iter.seen.length, 1);
+    });
+
+    test('iteration for such cache works', function() {
+      const iter = new CachedIterable([o1, o2]);
+      iter.touchNext();
+      iter.touchNext();
+      iter.touchNext();
+      assert.deepEqual([...iter], [o1, o2]);
+    });
+  });
 });


### PR DESCRIPTION
This will allow both fluent-web and fluent-gecko to trigger the initial fetch as soon as the iterable is created.