### PR TITLE
Use relative imports in fluent-web and fluent-dom

### DIFF
--- a/fluent-dom/src/localization.js
+++ b/fluent-dom/src/localization.js
@@ -1,7 +1,7 @@
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
 /* global console */
 
-import CachedIterable from '../../fluent/src/cached_iterable';
+import { CachedIterable } from '../../fluent/src/index';
 
 /**
  * Specialized version of an Error used to indicate errors that are result

--- a/fluent-web/package.json
+++ b/fluent-web/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "fluent": "^0.4.0",
-    "fluent-langneg": "^0.0.2",
-    "fluent-dom": "0.0.1"
+    "fluent-langneg": "^0.0.2"
   }
 }


### PR DESCRIPTION
Fixes #57.

Both fluent-web and fluent-dom are at versions 0.0.1. I expect the API
to fluctuate before it stabilizes. Let's use relative imports for the
while being so that it's easier to iterate.

Once we reach 0.1, we can bring back package imports and proper
dependency management via package.json.

Along with this, this PR cleans up a few things:

  - I removed `fetchSync` intorduced in 60eb916

  - I renamed `resIds` to `resourceIds` in line with the change from
    fb50012

  - I removed `CachedIterable` from fluent-web; as of 5f45963 it is part
    of fluent-dom.