### PR TITLE
fluent-dom: Remove getIndexOfType

### DIFF
--- a/fluent-dom/package.json
+++ b/fluent-dom/package.json
@@ -29,5 +29,8 @@
   ],
   "engine": {
     "node": ">=6"
+  },
+  "devDependencies": {
+    "jsdom": "^9.12.0"
   }
 }

--- a/fluent-dom/src/overlay.js
+++ b/fluent-dom/src/overlay.js
@@ -110,10 +110,10 @@ function overlay(sourceElement, translationElement) {
       continue;
     }
 
-    const index = getIndexOfType(childElement);
-    const sourceChild = getNthElementOfType(sourceElement, childElement, index);
+    const sourceChild = getElementOfType(sourceElement, childElement.tagName);
     if (sourceChild) {
       // There is a corresponding element in the source, let's use it.
+      sourceElement.removeChild(sourceChild);
       overlay(sourceChild, childElement);
       result.appendChild(sourceChild);
       continue;
@@ -163,11 +163,7 @@ function overlay(sourceElement, translationElement) {
  */
 function isElementAllowed(element) {
   const allowed = ALLOWED_ELEMENTS[element.namespaceURI];
-  if (!allowed) {
-    return false;
-  }
-
-  return allowed.includes(element.tagName.toLowerCase());
+  return allowed && allowed.includes(element.tagName.toLowerCase());
 }
 
 /**
@@ -219,45 +215,19 @@ function isAttrAllowed(attr, element) {
 }
 
 /**
- * Get n-th immediate child of context that is of the same type as element.
- * XXX Use querySelector(':scope > ELEMENT:nth-of-type(index)'), when:
- * 1) :scope is widely supported in more browsers and 2) it works with
- * DocumentFragments.
+ * Get the first child of context of the given type.
  *
  * @param {DOMFragment} context
- * @param {Element}     element
- * @param {Number}      index
+ * @param {String}      tagName
  * @returns {Element | null}
  * @private
  */
-function getNthElementOfType(context, element, index) {
-  let nthOfType = 0;
-  for (let i = 0, child; (child = context.children[i]); i++) {
+function getElementOfType(context, tagName) {
+  for (const child of context.children) {
     if (child.nodeType === child.ELEMENT_NODE &&
-        child.tagName.toLowerCase() === element.tagName.toLowerCase()) {
-      if (nthOfType === index) {
-        return child;
-      }
-      nthOfType++;
+        child.tagName.toLowerCase() === tagName.toLowerCase()) {
+      return child;
     }
   }
   return null;
-}
-
-/**
- * Get the index of the element among siblings of the same type.
- *
- * @param {Element} element
- * @returns {Number}
- * @private
- */
-function getIndexOfType(element) {
-  let index = 0;
-  let child;
-  while ((child = element.previousElementSibling)) {
-    if (child.tagName === element.tagName) {
-      index++;
-    }
-  }
-  return index;
 }

--- a/fluent-dom/test/overlay_test.js
+++ b/fluent-dom/test/overlay_test.js
@@ -1,0 +1,106 @@
+import assert from 'assert';
+import overlayElement from '../src/overlay';
+
+function elem(name) {
+  return function(str) {
+    const element = document.createElement(name);
+    element.innerHTML = str;
+    return element;
+  }
+}
+
+suite('Overlay DOM elements', function() {
+
+  test('string value', function() {
+    const element = elem('div')`Foo`;
+    const translation = {
+      value: 'Bar',
+      attrs: null
+    };
+
+    overlayElement(element, translation);
+    assert.equal(element.innerHTML, 'Bar');
+  });
+
+  test('one child', function() {
+    const element = elem('div')`<a href="bar"></a>`;
+    const translation = {
+      value: 'Foo <a title="baz">Baz</a>',
+      attrs: null
+    };
+
+    overlayElement(element, translation);
+    assert.equal(element.innerHTML, 'Foo <a href="bar" title="baz">Baz</a>');
+  });
+
+  test('one child with own attributes', function() {
+    const element = elem('div')`Foo <a href="bar" title="bar">Bar</a>`;
+    const translation = {
+      value: 'Foo <a href="baz" title="baz">Baz</a>',
+      attrs: null
+    };
+
+    overlayElement(element, translation);
+    assert.equal(element.innerHTML, 'Foo <a href="bar" title="baz">Baz</a>');
+  });
+
+  test('two children of the same type', function() {
+    const element = elem('div')`<a href="foo"></a> <a href="bar"></a>`;
+    const translation = {
+      value: '<a title="foo">Foo</a> <a title="bar">Bar</a>',
+      attrs: null
+    };
+
+    overlayElement(element, translation);
+    assert.equal(element.innerHTML, '<a href="foo" title="foo">Foo</a> <a href="bar" title="bar">Bar</a>');
+  });
+
+  test('two children of different types in order', function() {
+    const element = elem('div')`<a href="foo"></a> <input type="text">`;
+    const translation = {
+      value: '<a title="foo">Foo</a> <input placeholder="Bar" />',
+      attrs: null
+    };
+
+    overlayElement(element, translation);
+    assert.equal(element.innerHTML, '<a href="foo" title="foo">Foo</a> <input type="text" placeholder="Bar">');
+  });
+
+  test('two children of different types not in order', function() {
+    const element = elem('div')`<a href="foo"></a> <input type="text">`;
+    const translation = {
+      value: '<input placeholder="Bar" /> <a title="foo">Foo</a>',
+      attrs: null
+    };
+
+    overlayElement(element, translation);
+    assert.equal(element.innerHTML, '<input type="text" placeholder="Bar"> <a href="foo" title="foo">Foo</a>');
+  });
+
+});
+
+suite('Allowing elements in translation', function() {
+
+  test('allowed element', function() {
+    const element = elem('div')`Foo`;
+    const translation = {
+      value: 'Foo <em>Bar</em> Baz',
+      attrs: null
+    };
+
+    overlayElement(element, translation);
+    assert.equal(element.innerHTML, 'Foo <em>Bar</em> Baz');
+  });
+
+  test('forbidden element', function() {
+    const element = elem('div')`Foo`;
+    const translation = {
+      value: 'Foo <img src="img.png" />',
+      attrs: null
+    };
+
+    overlayElement(element, translation);
+    assert.equal(element.innerHTML, 'Foo ');
+  });
+
+});

--- a/fluent-dom/test/setup.js
+++ b/fluent-dom/test/setup.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const jsdom = require('jsdom').jsdom;
+
+global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach(property => {
+  if (typeof global[property] === 'undefined') {
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};
+
+require('babel-register')({
+  babelrc: false,
+  plugins: ['transform-es2015-modules-commonjs']
+});


### PR DESCRIPTION
Fixes #56.

`getIndexOfType` was broken. Initially I intended to remove the feature of allowing reordering elements of different types in the translation. Then I realized that with another `removeChild` called on the source element, we can keep the feature while making this code simpler.

I added a few tests. Many more are needed, but this should be a good start.