### PR TITLE
Add data-l10n-attrs for whitelisting attributes

### DIFF
--- a/fluent-dom/src/overlay.js
+++ b/fluent-dom/src/overlay.js
@@ -71,14 +71,12 @@ export default function overlayElement(element, translation) {
     return;
   }
 
-  const whitelistedAttrs = element.hasAttribute('data-l10n-attrs') ?
-    element.getAttribute('data-l10n-attrs')
-      .split(',').map(attr => attr.trim()) :
-    null;
+  const explicitlyAllowed = element.hasAttribute('data-l10n-attrs')
+    ? element.getAttribute('data-l10n-attrs').split(',').map(i => i.trim())
+    : null;
 
   for (const [name, val] of translation.attrs) {
-    if (isAttrAllowed({ name }, element) ||
-        (whitelistedAttrs && whitelistedAttrs.includes(name))) {
+    if (isAttrAllowed({ name }, element, explicitlyAllowed)) {
       element.setAttribute(name, val);
     }
   }
@@ -179,12 +177,20 @@ function isElementAllowed(element) {
  * DOM attributes, or when the translation has traits which map to DOM
  * attributes.
  *
+ * `explicitlyAllowed` can be passed as a list of attributes explicitly
+ * allowed on this element.
+ *
  * @param   {{name: string}} attr
  * @param   {Element}        element
+ * @param   {Array}          explicitlyAllowed
  * @returns {boolean}
  * @private
  */
-function isAttrAllowed(attr, element) {
+function isAttrAllowed(attr, element, explicitlyAllowed = null) {
+  if (explicitlyAllowed && explicitlyAllowed.includes(attr)) {
+    return true;
+  }
+
   const allowed = ALLOWED_ATTRIBUTES[element.namespaceURI];
   if (!allowed) {
     return false;

--- a/fluent-dom/src/overlay.js
+++ b/fluent-dom/src/overlay.js
@@ -71,8 +71,14 @@ export default function overlayElement(element, translation) {
     return;
   }
 
+  const whitelistedAttrs = element.hasAttribute('data-l10n-attrs') ?
+    element.getAttribute('data-l10n-attrs')
+      .split(',').map(attr => attr.trim()) :
+    null;
+
   for (const [name, val] of translation.attrs) {
-    if (isAttrAllowed({ name }, element)) {
+    if (isAttrAllowed({ name }, element) ||
+        (whitelistedAttrs && whitelistedAttrs.includes(name))) {
       element.setAttribute(name, val);
     }
   }

--- a/fluent-web/examples/webcomponent.html
+++ b/fluent-web/examples/webcomponent.html
@@ -71,6 +71,8 @@
       </div>
     </template>
 
-    <fluent-widget data-l10n-id="proceed-button"></fluent-widget>
+    <fluent-widget
+      data-l10n-id="proceed-button"
+      data-l10n-attrs="label, action-ok, action-cancel"></fluent-widget>
   </body>
 </html>


### PR DESCRIPTION
This is necessary for web components to be localizable.