### PR TITLE
Don't include the trailing newline in Comment and Section spans

### DIFF
--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -109,6 +109,25 @@ export class FTLParserStream extends ParserStream {
     return ((cc >= 48 && cc <= 57) || cc === 45); // 0-9
   }
 
+  isPeekNextLineComment() {
+    if (!this.currentPeekIs('\n')) {
+      return false;
+    }
+
+    this.peek();
+
+    if (this.currentPeekIs('/')) {
+      this.peek();
+      if (this.currentPeekIs('/')) {
+        this.resetPeek();
+        return true;
+      }
+    }
+
+    this.resetPeek();
+    return false;
+  }
+
   isPeekNextLineVariantStart() {
     if (!this.currentPeekIs('\n')) {
       return false;

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -68,6 +68,7 @@ export default class FluentParser {
         entries.push(entry);
       }
 
+      ps.skipInlineWS();
       ps.skipBlankLines();
     }
 
@@ -177,10 +178,6 @@ export default class FluentParser {
 
     ps.expectChar(']');
     ps.expectChar(']');
-
-    ps.skipInlineWS();
-
-    ps.expectChar('\n');
 
     return new AST.Section(symb, comment);
   }

--- a/fluent-syntax/test/fixtures_structure/resource_comment.json
+++ b/fluent-syntax/test/fixtures_structure/resource_comment.json
@@ -8,7 +8,7 @@
     "span": {
       "type": "Span",
       "start": 0,
-      "end": 53
+      "end": 52
     }
   },
   "span": {

--- a/fluent-syntax/test/fixtures_structure/resource_comment_trailing_line.json
+++ b/fluent-syntax/test/fixtures_structure/resource_comment_trailing_line.json
@@ -8,7 +8,7 @@
     "span": {
       "type": "Span",
       "start": 0,
-      "end": 53
+      "end": 52
     }
   },
   "span": {

--- a/fluent-syntax/test/fixtures_structure/section.json
+++ b/fluent-syntax/test/fixtures_structure/section.json
@@ -17,7 +17,7 @@
       "span": {
         "type": "Span",
         "start": 1,
-        "end": 25
+        "end": 24
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/standalone_comment.json
+++ b/fluent-syntax/test/fixtures_structure/standalone_comment.json
@@ -48,7 +48,7 @@
       "span": {
         "type": "Span",
         "start": 13,
-        "end": 45
+        "end": 44
       }
     }
   ],


### PR DESCRIPTION
With this change, the spans for Comments and Sections correctly end at the last character of the  production. Before this change, the following newline was also included in the span.