### PR TITLE
Construct the translation array with the length of the expected return value

### DIFF
--- a/fluent-dom/src/localization.js
+++ b/fluent-dom/src/localization.js
@@ -54,7 +54,7 @@ export default class Localization {
    * @private
    */
   async formatWithFallback(keys, method) {
-    const translations = [];
+    const translations = new Array(keys.length);
     for (let ctx of this.ctxs) {
       // This can operate on synchronous and asynchronous
       // contexts coming from the iterator.


### PR DESCRIPTION
Small change, but I think worth having - this makes `formatValues` and `formatMessages` return the array with the length matching the length of passed keys, even if no translation can be found.