### PR TITLE
Drop support for node versions before 8 LTS (8.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ feedback.
 Local Development
 -----------------
 
-Hacking on `fluent.js` is easy!  To quickly get started clone the repo:
+Hacking on `fluent.js` is easy! To quickly get started clone the repo:
 
     $ git clone https://github.com/projectfluent/fluent.js.git
     $ cd fluent.js
+
+You'll need node.js 8 LTS (v8.9.0 and up). Older 8.x versions and 7.x
+versions have been reported to work as well. node.js 6.x is not supported.
 
 Install the build tools used by all packages (Babel, Rollup, Mocha etc.):
 

--- a/fluent-dom/package.json
+++ b/fluent-dom/package.json
@@ -27,8 +27,8 @@
     "localization",
     "l10n"
   ],
-  "engine": {
-    "node": ">=6"
+  "engines" : {
+    "node" : ">=8.9.0"
   },
   "devDependencies": {
     "jsdom": "^9.12.0"

--- a/fluent-intl-polyfill/package.json
+++ b/fluent-intl-polyfill/package.json
@@ -28,8 +28,8 @@
     "localization",
     "l10n"
   ],
-  "engine": {
-    "node": ">=6"
+  "engines" : {
+    "node" : ">=8.9.0"
   },
   "dependencies": {
     "intl-pluralrules": "projectfluent/IntlPluralRules#module"

--- a/fluent-langneg/package.json
+++ b/fluent-langneg/package.json
@@ -28,7 +28,7 @@
     "localization",
     "l10n"
   ],
-  "engine": {
-    "node": ">=6"
+  "engines" : {
+    "node" : ">=8.9.0"
   }
 }

--- a/fluent-react/package.json
+++ b/fluent-react/package.json
@@ -28,8 +28,8 @@
     "localization",
     "l10n"
   ],
-  "engine": {
-    "node": ">=6"
+  "engines" : {
+    "node" : ">=8.9.0"
   },
   "dependencies": {
     "fluent": "^0.4.1",

--- a/fluent-syntax/package.json
+++ b/fluent-syntax/package.json
@@ -28,7 +28,7 @@
     "localization",
     "l10n"
   ],
-  "engine": {
-    "node": ">=6"
+  "engines" : {
+    "node" : ">=8.9.0"
   }
 }

--- a/fluent-web/package.json
+++ b/fluent-web/package.json
@@ -27,8 +27,8 @@
     "localization",
     "l10n"
   ],
-  "engine": {
-    "node": ">=6"
+  "engines" : {
+    "node" : ">=8.9.0"
   },
   "dependencies": {
     "fluent": "~0.4.0",

--- a/fluent/package.json
+++ b/fluent/package.json
@@ -28,8 +28,8 @@
     "localization",
     "l10n"
   ],
-  "engine": {
-    "node": ">=6"
+  "engines" : {
+    "node" : ">=8.9.0"
   },
   "devDependencies": {
     "sinon": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "fluent-javascript",
   "version": "0.0.1",
   "private": true,
+  "engines" : {
+    "node" : ">=8.9.0"
+  },
   "devDependencies": {
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",


### PR DESCRIPTION
As per #92, let's explicitly drop support for node versions prior to 8.9.0 which is the first release of the current LTS line (_Carbon_).

References:

  - https://github.com/nodejs/Release
  - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md
  - https://medium.com/the-node-js-collection/news-node-js-8-moves-into-long-term-support-and-node-js-9-becomes-the-new-current-release-line-74cf754a10a0