### PR TITLE
Use a Symbol for detecting instances of FluentType

### DIFF
--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -382,7 +382,8 @@ function ExternalArgument(env, {name}) {
 
   const arg = args[name];
 
-  if (arg instanceof FluentType) {
+  // Return early if the argument already is an instance of FluentType.
+  if (FluentType.isTypeOf(arg)) {
     return arg;
   }
 

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -40,6 +40,39 @@ export class FluentType {
   valueOf() {
     throw new Error('Subclasses of FluentType must implement valueOf.');
   }
+
+  /**
+   * Internal field used for detecting instances of FluentType.
+   *
+   * @private
+   */
+  get $$typeof() {
+    return Symbol.for('FluentType');
+  }
+
+  /**
+   * Check if a value is an instance of FluentType.
+   *
+   * In some build/transpilation setups instanceof is unreliable for detecting
+   * subclasses of FluentType. Instead, FluentType.isTypeOf uses the $$typeof
+   * field and the FluentType Symbol to determine the type of the argument.
+   *
+   * @param {Any} obj - The value to check the type of.
+   * @returns {bool}
+   */
+  static isTypeOf(obj) {
+    // The best-case scenario: the bundler didn't break the identity of
+    // FluentType.
+    if (obj instanceof FluentType) {
+      return true;
+    }
+
+    // Discard all primitive values, Object.prototype, and Object.create(null)
+    // which by definition cannot be instances of FluentType. Then check the
+    // value of the custom $$typeof field defined by the base FluentType class.
+    return obj instanceof Object
+      && obj.$$typeof === Symbol.for('FluentType');
+  }
 }
 
 export class FluentNone extends FluentType {

--- a/fluent/test/arguments_test.js
+++ b/fluent/test/arguments_test.js
@@ -243,7 +243,11 @@ suite('External arguments', function() {
 
       const parts = ctx.formatToParts(msg, args, errs);
       assert.equal(errs.length, 0);
-      assert.deepEqual(parts, [args.arg]);
+
+      const [part] = parts;
+      assert.equal(part, args.arg);
+      assert.equal(part.$$typeof, Symbol.for('FluentType'));
+      assert.equal(FluentType.isTypeOf(part), true);
 
       const vals = parts.map(part => part.valueOf(ctx));
       assert.deepEqual(vals, [argval]);
@@ -254,7 +258,11 @@ suite('External arguments', function() {
 
       const parts = ctx.formatToParts(msg, args, errs);
       assert.equal(errs.length, 0);
-      assert.deepEqual(parts, [args.arg]);
+
+      const [part] = parts;
+      assert.equal(part, args.arg);
+      assert.equal(part.$$typeof, Symbol.for('FluentType'));
+      assert.equal(FluentType.isTypeOf(part), true);
 
       const vals = parts.map(part => part.valueOf(ctx));
       assert.deepEqual(vals, [argval]);


### PR DESCRIPTION
Some bundlers make `instanceof` unreliable. Use a static `FluentType.isTypeOf` method to detect instances of `FluentType` via a `$$typeof` field and a `FluentType` symbol.