### PR TITLE
Use babel-preset-env and define the browser support for compat builds

### DIFF
--- a/compat_config.js
+++ b/compat_config.js
@@ -5,13 +5,21 @@ export default {
     babel({
       'babelrc': false,
       'presets': [
-        ['latest', {
-          'es2015': {
-            'modules': false
+        ['env', {
+          // Cf. https://github.com/rollup/rollup-plugin-babel#modules
+          'modules': false,
+          'targets': {
+            'browsers': [
+              '>1%',
+              'last 4 versions',
+              'Firefox ESR',
+              'not ie < 9'
+            ]
           }
         }]
       ],
       'plugins': [
+        // Cf. https://github.com/rollup/rollup-plugin-babel#helpers
         'external-helpers',
         ['babel-plugin-transform-builtin-extend', {
           globals: ['Error']

--- a/fluent-intl-polyfill/compat_config.js
+++ b/fluent-intl-polyfill/compat_config.js
@@ -8,10 +8,8 @@ export default {
     babel({
       'babelrc': false,
       'presets': [
-        ['latest', {
-          'es2015': {
-            'modules': false
-          }
+        ['env', {
+          'modules': false
         }]
       ],
       'plugins': [

--- a/fluent-react/README.md
+++ b/fluent-react/README.md
@@ -32,8 +32,8 @@ Consult the [wiki][] for documentation on how to set up and use `fluent-react`.
 
 ## Compatibility
 
-For legacy browsers, the `compat` build has been transpiled using the current
-version of Babel's [latest preset][]:
+For legacy browsers, the `compat` build has been transpiled using Babel's [env
+preset][]:
 
 ```javascript
 import 'fluent-react/compat';
@@ -57,6 +57,6 @@ documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
 
-[latest preset]: https://babeljs.io/docs/plugins/preset-latest/
+[env preset]: https://babeljs.io/docs/plugins/preset-env/
 [projectfluent.org]: http://projectfluent.org
 [FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -33,8 +33,8 @@ http://projectfluent.org/fluent.js/fluent-syntax.
 
 ## Compatibility
 
-For legacy browsers, the `compat` build has been transpiled using the current
-version of Babel's [latest preset][]:
+For legacy browsers, the `compat` build has been transpiled using Babel's [env
+preset][]:
 
 ```javascript
 import 'fluent-syntax/compat';
@@ -48,6 +48,6 @@ documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
 
-[latest preset]: https://babeljs.io/docs/plugins/preset-latest/
+[env preset]: https://babeljs.io/docs/plugins/preset-env/
 [projectfluent.org]: http://projectfluent.org
 [FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-web/compat_config.js
+++ b/fluent-web/compat_config.js
@@ -8,10 +8,8 @@ export default {
     babel({
       'babelrc': false,
       'presets': [
-        ['latest', {
-          'es2015': {
-            'modules': false
-          }
+        ['env', {
+          'modules': false
         }]
       ],
       'plugins': [

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -58,8 +58,8 @@ import 'fluent-intl-polyfill';
 import { MessageContext } from 'fluent';
 ```
 
-For legacy browsers, the `compat` build has been transpiled using the current
-version of Babel's [latest preset][]:
+For legacy browsers, the `compat` build has been transpiled using Babel's [env
+preset][]:
 
 ```javascript
 import { MessageContext } from 'fluent/compat';
@@ -76,6 +76,6 @@ implementations, and information about how to get involved.
 [intl-pluralrules]: https://www.npmjs.com/package/intl-pluralrules
 [fluent-intl-polyfill]: https://www.npmjs.com/package/fluent-intl-polyfill
 [Stage 3 proposal]:https://github.com/tc39/proposal-intl-plural-rules
-[latest preset]: https://babeljs.io/docs/plugins/preset-latest/
+[env preset]: https://babeljs.io/docs/plugins/preset-env/
 [projectfluent.org]: http://projectfluent.org
 [FTL]: http://projectfluent.org/fluent/guide/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.7",
-    "babel-preset-latest": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
     "colors": "^1.1.2",


### PR DESCRIPTION
This is a continuation of #87. `babel-preset-env` uses https://github.com/ai/browserslist to parse version ranges definitions. I specified a rather wide range here which is based on what `create-react-app` supports.