### PR TITLE
Sync gecko changes with mozilla-central

### DIFF
--- a/fluent-dom/makefile
+++ b/fluent-dom/makefile
@@ -7,21 +7,21 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-		--format umd \
+		--output.format umd \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
-		--id $(PACKAGE) \
+		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \
-		--output $@
+		--output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 		--config $(ROOT)/compat_config.js \
-		--format umd \
+		--output.format umd \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
-		--id $(PACKAGE) \
+		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \
-		--output $@
+		--output.file $@
 	@echo -e " $(OK) $@ built"
 
 clean:

--- a/fluent-dom/src/localization.js
+++ b/fluent-dom/src/localization.js
@@ -150,6 +150,10 @@ export default class Localization {
     this.onLanguageChange();
   }
 
+  /**
+   * This method should be called when there's a reason to believe
+   * that language negotiation or available resources changed.
+   */
   onLanguageChange() {
     this.ctxs = new CachedIterable(this.generateMessages(this.resourceIds));
   }

--- a/fluent-gecko/makefile
+++ b/fluent-gecko/makefile
@@ -7,25 +7,25 @@ build: MessageContext.jsm Localization.jsm DOMLocalization.jsm l10n.js
 MessageContext.jsm: $(SOURCES)
 	@rollup $(CURDIR)/src/message_context.js \
 	    --config ./xpcom_config.js \
-	    --output ./dist/$@
+	    --output.file ./dist/$@
 	@echo -e " $(OK) $@ built"
 
 Localization.jsm: $(SOURCES)
 	@rollup $(CURDIR)/src/localization.js \
 	    --config ./xpcom_config.js \
-	    --output ./dist/$@
+	    --output.file ./dist/$@
 	@echo -e " $(OK) $@ built"
 
 DOMLocalization.jsm: $(SOURCES)
 	@rollup $(CURDIR)/src/dom_localization.js \
 	    --config ./xpcom_dom_config.js \
-	    --output ./dist/$@
+	    --output.file ./dist/$@
 	@echo -e " $(OK) $@ built"
 
 l10n.js: $(SOURCES)
 	@rollup $(CURDIR)/src/l10n.js \
-	    --config ./xpcom_config.js \
-	    --output ./dist/$@
+	    --output.format es \
+	    --output.file ./dist/$@
 	@echo -e " $(OK) $@ built"
 
 clean:

--- a/fluent-gecko/src/dom_localization.js
+++ b/fluent-gecko/src/dom_localization.js
@@ -1,4 +1,35 @@
+/* global L10nRegistry, Services */
 import DOMLocalization from '../../fluent-dom/src/dom_localization';
 
-this.DOMLocalization = DOMLocalization;
+/**
+ * The default localization strategy for Gecko. It comabines locales
+ * available in L10nRegistry, with locales requested by the user to
+ * generate the iterator over MessageContexts.
+ *
+ * In the future, we may want to allow certain modules to override this
+ * with a different negotitation strategy to allow for the module to
+ * be localized into a different language - for example DevTools.
+ */
+function defaultGenerateMessages(resourceIds) {
+  const requestedLocales = Services.locale.getRequestedLocales();
+  const availableLocales = L10nRegistry.getAvailableLocales();
+  const defaultLocale = Services.locale.defaultLocale;
+  const locales = Services.locale.negotiateLanguages(
+    requestedLocales, availableLocales, defaultLocale,
+  );
+  return L10nRegistry.generateContexts(locales, resourceIds);
+}
+
+
+class GeckoDOMLocalization extends DOMLocalization {
+  constructor(
+    windowElement,
+    resourceIds,
+    generateMessages = defaultGenerateMessages
+  ) {
+    super(windowElement, resourceIds, generateMessages);
+  }
+}
+
+this.DOMLocalization = GeckoDOMLocalization;
 this.EXPORTED_SYMBOLS = ['DOMLocalization'];

--- a/fluent-gecko/src/localization.js
+++ b/fluent-gecko/src/localization.js
@@ -1,13 +1,44 @@
 /* global Components */
 /* eslint no-unused-vars: 0 */
 
+const Cu = Components.utils;
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 
+const { L10nRegistry } =
+  Cu.import('resource://gre/modules/L10nRegistry.jsm', {});
 const ObserverService =
   Cc['@mozilla.org/observer-service;1'].getService(Ci.nsIObserverService);
+const { Services } =
+  Cu.import('resource://gre/modules/Services.jsm', {});
+
 
 import Localization from '../../fluent-dom/src/localization';
 
-this.Localization = Localization;
-this.EXPORTED_SYMBOLS = [];
+/**
+ * The default localization strategy for Gecko. It comabines locales
+ * available in L10nRegistry, with locales requested by the user to
+ * generate the iterator over MessageContexts.
+ *
+ * In the future, we may want to allow certain modules to override this
+ * with a different negotitation strategy to allow for the module to
+ * be localized into a different language - for example DevTools.
+ */
+function defaultGenerateMessages(resourceIds) {
+  const requestedLocales = Services.locale.getRequestedLocales();
+  const availableLocales = L10nRegistry.getAvailableLocales();
+  const defaultLocale = Services.locale.defaultLocale;
+  const locales = Services.locale.negotiateLanguages(
+    requestedLocales, availableLocales, defaultLocale,
+  );
+  return L10nRegistry.generateContexts(locales, resourceIds);
+}
+
+class GeckoLocalization extends Localization {
+  constructor(resourceIds, generateMessages = defaultGenerateMessages) {
+    super(resourceIds, generateMessages);
+  }
+}
+
+this.Localization = GeckoLocalization;
+this.EXPORTED_SYMBOLS = ['Localization'];

--- a/fluent-gecko/src/message_context.js
+++ b/fluent-gecko/src/message_context.js
@@ -1,4 +1,4 @@
 import { MessageContext } from '../../fluent/src/index';
 
 this.MessageContext = MessageContext;
-this.EXPORTED_SYMBOLS = [];
+this.EXPORTED_SYMBOLS = ['MessageContext'];

--- a/fluent-gecko/xpcom_config.js
+++ b/fluent-gecko/xpcom_config.js
@@ -1,7 +1,6 @@
 const version = require('../fluent/package.json').version;
 
 export default {
-  format: 'es',
   banner: `/* vim: set ts=2 et sw=2 tw=80 filetype=javascript: */
 
 /* Copyright 2017 Mozilla Foundation and others
@@ -21,5 +20,11 @@ export default {
 
   intro: `/* fluent@${version} */`,
   preferConst: true,
-  context: 'this'
+  context: 'this',
+  output: {
+    format: 'es',
+  },
+  acron: {
+    ecmaVersion: '9'
+  }
 };

--- a/fluent-gecko/xpcom_dom_config.js
+++ b/fluent-gecko/xpcom_dom_config.js
@@ -3,7 +3,6 @@ import { resolve } from 'path';
 const version = require('../fluent/package.json').version;
 
 export default {
-  format: 'es',
   banner: `/* vim: set ts=2 et sw=2 tw=80 filetype=javascript: */
 
 /* Copyright 2017 Mozilla Foundation and others
@@ -25,6 +24,9 @@ export default {
   external: [
     resolve('../fluent-dom/src/localization.js')
   ],
+  output: {
+    format: 'es',
+  },
   preferConst: true,
   context: 'this'
 };

--- a/fluent-intl-polyfill/makefile
+++ b/fluent-intl-polyfill/makefile
@@ -7,22 +7,22 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
 	    --config $(CURDIR)/bundle_config.js \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(CURDIR)/compat_config.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 clean:

--- a/fluent-langneg/makefile
+++ b/fluent-langneg/makefile
@@ -7,21 +7,21 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(ROOT)/compat_config.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 clean:

--- a/fluent-react/makefile
+++ b/fluent-react/makefile
@@ -8,23 +8,23 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
 	    --globals $(DEPS) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(ROOT)/compat_config.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
 	    --globals $(DEPS) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 clean:

--- a/fluent-syntax/makefile
+++ b/fluent-syntax/makefile
@@ -7,21 +7,21 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(ROOT)/compat_config.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 clean:

--- a/fluent-web/makefile
+++ b/fluent-web/makefile
@@ -7,22 +7,22 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-		--format iife \
+		--output.format iife \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
-		--id $(PACKAGE) \
+		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \
 		--config $(CURDIR)/bundle_config.js \
-		--output $@
+		--output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 		--config $(CURDIR)/compat_config.js \
-		--format umd \
+		--output.format umd \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
-		--id $(PACKAGE) \
+		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \
-		--output $@
+		--output.file $@
 	@echo -e " $(OK) $@ built"
 
 clean:

--- a/fluent/makefile
+++ b/fluent/makefile
@@ -7,21 +7,21 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(ROOT)/compat_config.js \
-	    --format umd \
+	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --id $(PACKAGE) \
+	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
-	    --output $@
+	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 clean:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jsdoc": "^3.5.4",
     "mocha": "^3.0.2",
     "prettyjson": "^1.1.3",
-    "rollup": "^0.41.4",
+    "rollup": "^0.52.1",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^3.0.0"
   }


### PR DESCRIPTION
Pretty trivial updates to fluent-gecko and a couple simple changes that spill to other dependencies.

I had to update rollup to handle more of the syntax we use currently (due to new acron). Guess it's not a bad thing to stay up to date with rollup :)