### PR TITLE
Remove FluentType.isTypeOf

### DIFF
--- a/fluent/CHANGELOG.md
+++ b/fluent/CHANGELOG.md
@@ -12,6 +12,15 @@
     Without MessageContext.formatToParts, all use-cases for
     FluentType.valueOf boil down to stringification.
 
+  - Remove FluentType.isTypeOf.
+
+    fluent-react's markup overlays (#101) removed the dependency on fluent's
+    FluentType which was hardcoded as an import from fluent/compat. Without
+    this dependency all imports from fluent are in the hands of developers
+    again and they can decide to use the ES2015+ or the compat builds as they
+    wish. As long as they do it consistently, regular instanceof checks will
+    work well.
+
 
 ## fluent 0.4.2 (November 27, 2017)
 

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -362,7 +362,7 @@ function ExternalArgument(env, {name}) {
   const arg = args[name];
 
   // Return early if the argument already is an instance of FluentType.
-  if (FluentType.isTypeOf(arg)) {
+  if (arg instanceof FluentType) {
     return arg;
   }
 

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -34,39 +34,6 @@ export class FluentType {
   toString() {
     throw new Error('Subclasses of FluentType must implement toString.');
   }
-
-  /**
-   * Internal field used for detecting instances of FluentType.
-   *
-   * @private
-   */
-  get $$typeof() {
-    return Symbol.for('FluentType');
-  }
-
-  /**
-   * Check if a value is an instance of FluentType.
-   *
-   * In some build/transpilation setups instanceof is unreliable for detecting
-   * subclasses of FluentType. Instead, FluentType.isTypeOf uses the $$typeof
-   * field and the FluentType Symbol to determine the type of the argument.
-   *
-   * @param {Any} obj - The value to check the type of.
-   * @returns {bool}
-   */
-  static isTypeOf(obj) {
-    // The best-case scenario: the bundler didn't break the identity of
-    // FluentType.
-    if (obj instanceof FluentType) {
-      return true;
-    }
-
-    // Discard all primitive values, Object.prototype, and Object.create(null)
-    // which by definition cannot be instances of FluentType. Then check the
-    // value of the custom $$typeof field defined by the base FluentType class.
-    return obj instanceof Object
-      && obj.$$typeof === Symbol.for('FluentType');
-  }
 }
 
 export class FluentNone extends FluentType {


### PR DESCRIPTION
fluent-react's markup overlays (#101) removed the dependency on fluent's FluentType which was hardcoded as an import from fluent/compat. Without this dependency all imports from fluent are in the hands of developers again and they can decide to use the ES2015+ or the compat builds as they wish. As long as they do it consistently, regular instanceof checks will work well.