### PR TITLE
Update all links to projectfluent.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and others.
 [Read the Fluent Syntax Guide][] in order to learn more about the syntax.  If
 you're a tool author you may be interested in the formal [EBNF grammar][].
 
-[Read the Fluent Syntax Guide]: http://projectfluent.io/fluent/guide/
+[Read the Fluent Syntax Guide]: http://projectfluent.org/fluent/guide/
 [EBNF grammar]: https://github.com/projectfluent/fluent/tree/master/spec
 
 

--- a/fluent-dom/README.md
+++ b/fluent-dom/README.md
@@ -65,10 +65,10 @@ async function main() {
 
 ## Learn more
 
-Find out more about Project Fluent at [projectfluent.io][], including
+Find out more about Project Fluent at [projectfluent.org][], including
 documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
 
-[projectfluent.io]: http://projectfluent.io
-[FTL]: http://projectfluent.io/fluent/guide/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-gecko/README.md
+++ b/fluent-gecko/README.md
@@ -17,11 +17,11 @@ core functionality of formatting translations from FTL files.  See the
 
 ## Learn more
 
-Find out more about Project Fluent at [projectfluent.io][], including
+Find out more about Project Fluent at [projectfluent.org][], including
 documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
 
 [README]: ../fluent/README.md
-[projectfluent.io]: http://projectfluent.io
-[FTL]: http://projectfluent.io/fluent/guide/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-gecko/package.json
+++ b/fluent-gecko/package.json
@@ -2,7 +2,7 @@
   "name": "fluent-gecko",
   "description": "Gecko bindings for Fluent",
   "version": "0.0.1",
-  "homepage": "http://projectfluent.io",
+  "homepage": "http://projectfluent.org",
   "author": "Mozilla <l10n-drivers@mozilla.org>",
   "license": "Apache-2.0",
   "contributors": [

--- a/fluent-intl-polyfill/README.md
+++ b/fluent-intl-polyfill/README.md
@@ -31,7 +31,7 @@ import 'fluent-intl-polyfill';
 
 ## Learn more
 
-Find out more about Project Fluent at [projectfluent.io][], including
+Find out more about Project Fluent at [projectfluent.org][], including
 documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
@@ -39,5 +39,5 @@ implementations, and information about how to get involved.
 [Stage 3+ proposals]: https://github.com/tc39/ecma402#current-proposals
 [Intl.PluralRules]:https://github.com/tc39/proposal-intl-plural-rules
 [intl-pluralrules]: https://www.npmjs.com/package/intl-pluralrules
-[projectfluent.io]: http://projectfluent.io
-[FTL]: http://projectfluent.io/fluent/guide/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-intl-polyfill/package.json
+++ b/fluent-intl-polyfill/package.json
@@ -2,7 +2,7 @@
   "name": "fluent-intl-polyfill",
   "description": "A polyfill for ECMA 402 proposals",
   "version": "0.1.0",
-  "homepage": "http://projectfluent.io",
+  "homepage": "http://projectfluent.org",
   "author": "Mozilla <l10n-drivers@mozilla.org>",
   "license": "Apache-2.0",
   "contributors": [

--- a/fluent-langneg/README.md
+++ b/fluent-langneg/README.md
@@ -25,7 +25,7 @@ const supportedLocales = negotiateLanguages(
 ```
 
 The API reference is available at
-http://projectfluent.io/fluent.js/fluent-langneg.
+http://projectfluent.org/fluent.js/fluent-langneg.
 
 ## Strategies
 
@@ -97,10 +97,10 @@ let supported = negotiateLanguages(requested, available, {
 
 ## Learn more
 
-Find out more about Project Fluent at [projectfluent.io][], including
+Find out more about Project Fluent at [projectfluent.org][], including
 documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
 
-[projectfluent.io]: http://projectfluent.io
-[FTL]: http://projectfluent.io/fluent/guide/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-langneg/package.json
+++ b/fluent-langneg/package.json
@@ -2,7 +2,7 @@
   "name": "fluent-langneg",
   "description": "Language Negotiation API for Fluent",
   "version": "0.1.0",
-  "homepage": "http://projectfluent.io",
+  "homepage": "http://projectfluent.org",
   "author": "Mozilla <l10n-drivers@mozilla.org>",
   "license": "Apache-2.0",
   "contributors": [

--- a/fluent-react/README.md
+++ b/fluent-react/README.md
@@ -52,11 +52,11 @@ minifiction works properly.
 
 ## Learn more
 
-Find out more about Project Fluent at [projectfluent.io][], including
+Find out more about Project Fluent at [projectfluent.org][], including
 documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
 
 [latest preset]: https://babeljs.io/docs/plugins/preset-latest/
-[projectfluent.io]: http://projectfluent.io
-[FTL]: http://projectfluent.io/fluent/guide/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-react/package.json
+++ b/fluent-react/package.json
@@ -2,7 +2,7 @@
   "name": "fluent-react",
   "description": "Fluent bindings for React",
   "version": "0.4.1",
-  "homepage": "http://projectfluent.io",
+  "homepage": "http://projectfluent.org",
   "author": "Mozilla <l10n-drivers@mozilla.org>",
   "license": "Apache-2.0",
   "contributors": [

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -28,7 +28,7 @@ assert(res instanceof Resource);
 ```
 
 The API reference is available at
-http://projectfluent.io/fluent.js/fluent-syntax.
+http://projectfluent.org/fluent.js/fluent-syntax.
 
 
 ## Compatibility
@@ -43,11 +43,11 @@ import 'fluent-syntax/compat';
 
 ## Learn more
 
-Find out more about Project Fluent at [projectfluent.io][], including
+Find out more about Project Fluent at [projectfluent.org][], including
 documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
 
 [latest preset]: https://babeljs.io/docs/plugins/preset-latest/
-[projectfluent.io]: http://projectfluent.io
-[FTL]: http://projectfluent.io/fluent/guide/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-syntax/package.json
+++ b/fluent-syntax/package.json
@@ -2,7 +2,7 @@
   "name": "fluent-syntax",
   "description": "AST and parser for Fluent",
   "version": "0.5.0",
-  "homepage": "http://projectfluent.io",
+  "homepage": "http://projectfluent.org",
   "author": "Mozilla <l10n-drivers@mozilla.org>",
   "license": "Apache-2.0",
   "contributors": [

--- a/fluent-web/README.md
+++ b/fluent-web/README.md
@@ -49,10 +49,10 @@ document.l10n.setAttributes(h1, 'welcome', { user: 'Anna' });
 
 ## Learn more
 
-Find out more about Project Fluent at [projectfluent.io][], including
+Find out more about Project Fluent at [projectfluent.org][], including
 documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
 
-[projectfluent.io]: http://projectfluent.io
-[FTL]: http://projectfluent.io/fluent/guide/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -38,7 +38,7 @@ ctx.format(welcome, { name: 'Anna' });
 // → 'Welcome, Anna, to Foo 3000!'
 ```
 
-The API reference is available at http://projectfluent.io/fluent.js/fluent.
+The API reference is available at http://projectfluent.org/fluent.js/fluent.
 
 
 ## Compatibility
@@ -68,7 +68,7 @@ import { MessageContext } from 'fluent/compat';
 
 ## Learn more
 
-Find out more about Project Fluent at [projectfluent.io][], including
+Find out more about Project Fluent at [projectfluent.org][], including
 documentation of the Fluent file format ([FTL][]), links to other packages and
 implementations, and information about how to get involved.
 
@@ -77,5 +77,5 @@ implementations, and information about how to get involved.
 [fluent-intl-polyfill]: https://www.npmjs.com/package/fluent-intl-polyfill
 [Stage 3 proposal]:https://github.com/tc39/proposal-intl-plural-rules
 [latest preset]: https://babeljs.io/docs/plugins/preset-latest/
-[projectfluent.io]: http://projectfluent.io
-[FTL]: http://projectfluent.io/fluent/guide/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent/package.json
+++ b/fluent/package.json
@@ -2,7 +2,7 @@
   "name": "fluent",
   "description": "Localization library for expressive translations.",
   "version": "0.4.2",
-  "homepage": "http://projectfluent.io",
+  "homepage": "http://projectfluent.org",
   "author": "Mozilla <l10n-drivers@mozilla.org>",
   "license": "Apache-2.0",
   "contributors": [


### PR DESCRIPTION
We are having issues with the `projectfluent.io` domain and its nameservers. I purchased `projectfluent.org` and I'd like to suggest we make it the official domain for the project.