### PR TITLE
FluentType.valueOf

### DIFF
--- a/fluent/src/builtins.js
+++ b/fluent/src/builtins.js
@@ -15,9 +15,9 @@ import { FluentNumber, FluentDateTime } from './types';
 
 export default {
   'NUMBER': ([arg], opts) =>
-    new FluentNumber(value(arg), merge(arg.opts, opts)),
+    new FluentNumber(arg.valueOf(), merge(arg.opts, opts)),
   'DATETIME': ([arg], opts) =>
-    new FluentDateTime(value(arg), merge(arg.opts, opts)),
+    new FluentDateTime(arg.valueOf(), merge(arg.opts, opts)),
 };
 
 function merge(argopts, opts) {
@@ -27,14 +27,7 @@ function merge(argopts, opts) {
 function values(opts) {
   const unwrapped = {};
   for (const [name, opt] of Object.entries(opts)) {
-    unwrapped[name] = value(opt);
+    unwrapped[name] = opt.valueOf();
   }
   return unwrapped;
-}
-
-function value(arg) {
-  // StringExpression-typed options are parsed as regular strings by the
-  // runtime parser and are not converted to a FluentType by the resolver.
-  // They don't have the "value" property; they are the value.
-  return typeof arg === 'string' ? arg : arg.value;
 }

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -22,9 +22,18 @@ export class FluentType {
   }
 
   /**
-   * Unwrap the instance of `FluentType` to a string.
+   * Unwrap the raw value stored by this `FluentType`.
    *
-   * Unwrapped values are suitable for use outside of the `MessageContext`.
+   * @returns {Any}
+   */
+  valueOf() {
+    return this.value;
+  }
+
+  /**
+   * Format this instance of `FluentType` to a string.
+   *
+   * Formatted values are suitable for use outside of the `MessageContext`.
    * This method can use `Intl` formatters memoized by the `MessageContext`
    * instance passed as an argument.
    *


### PR DESCRIPTION
In https://github.com/projectfluent/fluent.js/pull/101/commits/3036df2c39634202717777beefd199b0a7eb4947 I went back to using `toString` for formatting, which opened a way to us `valueOf` for retrieving values of `FluentTypes`, including strings.