### PR TITLE
Support a subset of Syntax 0.5 in RuntimeParser 0.4.1

### DIFF
--- a/fluent/test/compat_0.4_0.5_test.js
+++ b/fluent/test/compat_0.4_0.5_test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+import assert from 'assert';
+
+import { MessageContext } from '../src/context';
+import { ftl } from './util';
+
+suite.only('Compatibility', function () {
+  suite('browser/preferences/main.ftl', function () {
+    let args, errs;
+
+    setup(function () {
+      args = {
+        num: 3
+      };
+      errs = [];
+    });
+
+    test('0.4 syntax', function () {
+      const ctx = new MessageContext('en-US', { useIsolating: false });
+      const parsingErrors = ctx.addMessages(ftl`
+        // Variables:
+        //   $num - default value of the \`dom.ipc.processCount\` pref.
+        default-content-process-count
+            .label = { $num } (default)
+      `);
+
+      assert.deepEqual(parsingErrors, []);
+
+      const msg = ctx.getMessage('default-content-process-count');
+
+      assert.equal(
+        ctx.format(msg, args, errs),
+        null);
+      assert.equal(errs.length, 0);
+
+      assert.equal(
+        ctx.format(msg.attrs.label, args, errs),
+        '3 (default)');
+      assert.equal(errs.length, 0);
+    });
+
+    test('0.5 syntax', function () {
+      const ctx = new MessageContext('en-US', { useIsolating: false });
+      const parsingErrors = ctx.addMessages(ftl`
+        # Variables:
+        #   $num - default value of the \`dom.ipc.processCount\` pref.
+        default-content-process-count =
+            .label = { $num } (default)
+      `);
+
+      assert.deepEqual(parsingErrors, [
+        new SyntaxError('Expected an identifier (starting with [a-zA-Z_])')
+      ]);
+
+      const msg = ctx.getMessage('default-content-process-count');
+
+      assert.equal(
+        ctx.format(msg, args, errs),
+        null);
+      assert.equal(errs.length, 0);
+
+      assert.equal(
+        ctx.format(msg.attrs.label, args, errs),
+        '3 (default)');
+      assert.equal(errs.length, 0);
+    });
+  });
+
+  suite('browser/preferences/privacy.ftl', function () {
+    let args, errs;
+
+    setup(function () {
+      args = {};
+      errs = [];
+    });
+
+    test('0.4 syntax', function () {
+      const ctx = new MessageContext('en-US', { useIsolating: false });
+      const parsingErrors = ctx.addMessages(ftl`
+        // This Source Code Form is subject to the terms of the Mozilla Public
+        // License, v. 2.0. If a copy of the MPL was not distributed with this
+        // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+        [[ Do Not Track ]]
+
+        do-not-track-description = Send websites a “Do Not Track” signal
+        do-not-track-learn-more = Learn more
+        do-not-track-option-default
+            .label = Only when using Tracking Protection
+        do-not-track-option-always
+            .label = Always
+      `);
+
+      assert.deepEqual(parsingErrors, []);
+
+      const msg1 = ctx.getMessage('do-not-track-description');
+      assert.equal(
+        ctx.format(msg1, args, errs),
+        'Send websites a “Do Not Track” signal');
+      assert.equal(errs.length, 0);
+
+      const msg2 = ctx.getMessage('do-not-track-learn-more');
+      assert.equal(
+        ctx.format(msg2, args, errs),
+        'Learn more');
+      assert.equal(errs.length, 0);
+
+      const msg3 = ctx.getMessage('do-not-track-option-default');
+      assert.equal(
+        ctx.format(msg3.attrs.label, args, errs),
+        'Only when using Tracking Protection');
+      assert.equal(errs.length, 0);
+
+      const msg4 = ctx.getMessage('do-not-track-option-always');
+      assert.equal(
+        ctx.format(msg4.attrs.label, args, errs),
+        'Always');
+      assert.equal(errs.length, 0);
+    });
+
+    test('0.5 syntax', function () {
+      const ctx = new MessageContext('en-US', { useIsolating: false });
+      const parsingErrors = ctx.addMessages(ftl`
+        # This Source Code Form is subject to the terms of the Mozilla Public
+        # License, v. 2.0. If a copy of the MPL was not distributed with this
+        # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+        ## Do Not Track
+
+        do-not-track-description = Send websites a “Do Not Track” signal
+        do-not-track-learn-more = Learn more
+        do-not-track-option-default =
+            .label = Only when using Tracking Protection
+        do-not-track-option-always =
+            .label = Always
+      `);
+
+      assert.deepEqual(parsingErrors, [
+        new SyntaxError('Expected an identifier (starting with [a-zA-Z_])')
+      ]);
+
+      const msg1 = ctx.getMessage('do-not-track-description');
+      assert.equal(
+        ctx.format(msg1, args, errs),
+        'Send websites a “Do Not Track” signal');
+      assert.equal(errs.length, 0);
+
+      const msg2 = ctx.getMessage('do-not-track-learn-more');
+      assert.equal(
+        ctx.format(msg2, args, errs),
+        'Learn more');
+      assert.equal(errs.length, 0);
+
+      const msg3 = ctx.getMessage('do-not-track-option-default');
+      assert.equal(
+        ctx.format(msg3.attrs.label, args, errs),
+        'Only when using Tracking Protection');
+      assert.equal(errs.length, 0);
+
+      const msg4 = ctx.getMessage('do-not-track-option-always');
+      assert.equal(
+        ctx.format(msg4.attrs.label, args, errs),
+        'Always');
+      assert.equal(errs.length, 0);
+    });
+  });
+});

--- a/fluent/test/compat_0.4_0.5_test.js
+++ b/fluent/test/compat_0.4_0.5_test.js
@@ -5,7 +5,7 @@ import assert from 'assert';
 import { MessageContext } from '../src/context';
 import { ftl } from './util';
 
-suite.only('Compatibility', function () {
+suite('Compatibility', function () {
   suite('browser/preferences/main.ftl', function () {
     let args, errs;
 

--- a/fluent/test/compat_0.4_0.5_test.js
+++ b/fluent/test/compat_0.4_0.5_test.js
@@ -3,7 +3,6 @@
 import assert from 'assert';
 
 import { MessageContext } from '../src/context';
-import { ftl } from './util';
 
 suite('Compatibility', function () {
   suite('browser/preferences/main.ftl', function () {
@@ -18,12 +17,12 @@ suite('Compatibility', function () {
 
     test('0.4 syntax', function () {
       const ctx = new MessageContext('en-US', { useIsolating: false });
-      const parsingErrors = ctx.addMessages(ftl`
-        // Variables:
-        //   $num - default value of the \`dom.ipc.processCount\` pref.
-        default-content-process-count
-            .label = { $num } (default)
-      `);
+      const parsingErrors = ctx.addMessages(`
+// Variables:
+//   $num - default value of the \`dom.ipc.processCount\` pref.
+default-content-process-count
+    .label = { $num } (default)
+`);
 
       assert.deepEqual(parsingErrors, []);
 
@@ -42,12 +41,12 @@ suite('Compatibility', function () {
 
     test('0.5 syntax', function () {
       const ctx = new MessageContext('en-US', { useIsolating: false });
-      const parsingErrors = ctx.addMessages(ftl`
-        # Variables:
-        #   $num - default value of the \`dom.ipc.processCount\` pref.
-        default-content-process-count =
-            .label = { $num } (default)
-      `);
+      const parsingErrors = ctx.addMessages(`
+# Variables:
+#   $num - default value of the \`dom.ipc.processCount\` pref.
+default-content-process-count =
+    .label = { $num } (default)
+`);
 
       assert.deepEqual(parsingErrors, [
         new SyntaxError('Expected an identifier (starting with [a-zA-Z_])')
@@ -77,20 +76,20 @@ suite('Compatibility', function () {
 
     test('0.4 syntax', function () {
       const ctx = new MessageContext('en-US', { useIsolating: false });
-      const parsingErrors = ctx.addMessages(ftl`
-        // This Source Code Form is subject to the terms of the Mozilla Public
-        // License, v. 2.0. If a copy of the MPL was not distributed with this
-        // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+      const parsingErrors = ctx.addMessages(`
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-        [[ Do Not Track ]]
+[[ Do Not Track ]]
 
-        do-not-track-description = Send websites a “Do Not Track” signal
-        do-not-track-learn-more = Learn more
-        do-not-track-option-default
-            .label = Only when using Tracking Protection
-        do-not-track-option-always
-            .label = Always
-      `);
+do-not-track-description = Send websites a “Do Not Track” signal
+do-not-track-learn-more = Learn more
+do-not-track-option-default
+    .label = Only when using Tracking Protection
+do-not-track-option-always
+    .label = Always
+`);
 
       assert.deepEqual(parsingErrors, []);
 
@@ -121,20 +120,20 @@ suite('Compatibility', function () {
 
     test('0.5 syntax', function () {
       const ctx = new MessageContext('en-US', { useIsolating: false });
-      const parsingErrors = ctx.addMessages(ftl`
-        # This Source Code Form is subject to the terms of the Mozilla Public
-        # License, v. 2.0. If a copy of the MPL was not distributed with this
-        # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+      const parsingErrors = ctx.addMessages(`
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-        ## Do Not Track
+## Do Not Track
 
-        do-not-track-description = Send websites a “Do Not Track” signal
-        do-not-track-learn-more = Learn more
-        do-not-track-option-default =
-            .label = Only when using Tracking Protection
-        do-not-track-option-always =
-            .label = Always
-      `);
+do-not-track-description = Send websites a “Do Not Track” signal
+do-not-track-learn-more = Learn more
+do-not-track-option-default =
+    .label = Only when using Tracking Protection
+do-not-track-option-always =
+    .label = Always
+`);
 
       assert.deepEqual(parsingErrors, [
         new SyntaxError('Expected an identifier (starting with [a-zA-Z_])')

--- a/tools/main.ftl
+++ b/tools/main.ftl
@@ -1,0 +1,4 @@
+# Variables:
+#   $num - default value of the `dom.ipc.processCount` pref.
+default-content-process-count =
+    .label = { $num } (default)

--- a/tools/privacy.ftl
+++ b/tools/privacy.ftl
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+## Do Not Track
+
+do-not-track-description = Send websites a “Do Not Track” signal that you don’t want to be tracked
+do-not-track-learn-more = Learn more
+do-not-track-option-default =
+    .label = Only when using Tracking Protection
+do-not-track-option-always =
+    .label = Always


### PR DESCRIPTION
This is a branch for [bug 1426463](https://bugzilla.mozilla.org/show_bug.cgi?id=1426463). I don't intend to merge it into master; just wanted to see if CI passes.