### PR TITLE
Add mapContextAsync

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
+    "presets": [
+        "stage-3"
+    ],
     "plugins": [
         "babel-plugin-transform-es2015-modules-commonjs"
     ]

--- a/bundle_config.js
+++ b/bundle_config.js
@@ -1,0 +1,14 @@
+import acornAsyncIteration from 'acorn-async-iteration/inject';
+
+export default {
+  output: {
+    format: 'umd'
+  },
+  acorn: {
+    ecmaVersion: 9,
+    plugins: { asyncIteration: true }
+  },
+  acornInjectPlugins: [
+    acornAsyncIteration
+  ]
+};

--- a/common.mk
+++ b/common.mk
@@ -23,10 +23,12 @@ test:
 ifneq (,$(wildcard ./test/__setup.js))
 	@mocha --recursive --ui tdd \
 	    --require babel-register \
+	    --require babel-polyfill \
 	    --require ./test/__setup
 else
 	@mocha --recursive --ui tdd \
-	    --require babel-register
+	    --require babel-register \
+	    --require babel-polyfill
 endif
 
 html: $(SOURCES)

--- a/compat_config.js
+++ b/compat_config.js
@@ -1,6 +1,9 @@
 import babel from 'rollup-plugin-babel';
 
 export default {
+  output: {
+    format: 'umd'
+  },
   plugins: [
     babel({
       'babelrc': false,

--- a/compat_config.js
+++ b/compat_config.js
@@ -8,6 +8,7 @@ export default {
     babel({
       'babelrc': false,
       'presets': [
+        'stage-3',
         ['env', {
           // Cf. https://github.com/rollup/rollup-plugin-babel#modules
           'modules': false,

--- a/eslint_src.json
+++ b/eslint_src.json
@@ -1,6 +1,7 @@
 {
+    "parser": "babel-eslint",
     "parserOptions": {
-        "ecmaVersion": 8,
+        "ecmaVersion": 9,
         "sourceType": "module"
     },
     "env": {

--- a/eslint_test.json
+++ b/eslint_test.json
@@ -1,6 +1,7 @@
 {
+    "parser": "babel-eslint",
     "parserOptions": {
-        "ecmaVersion": 8,
+        "ecmaVersion": 9,
         "sourceType": "module",
         "ecmaFeatures": {
             "jsx": true

--- a/fluent-dom/makefile
+++ b/fluent-dom/makefile
@@ -7,7 +7,7 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-		--output.format umd \
+		--config $(ROOT)/bundle_config.js \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
 		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \
@@ -17,7 +17,6 @@ $(PACKAGE).js: $(SOURCES)
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 		--config $(ROOT)/compat_config.js \
-		--output.format umd \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
 		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \

--- a/fluent-gecko/xpcom_config.js
+++ b/fluent-gecko/xpcom_config.js
@@ -1,6 +1,8 @@
+import bundleConfig from '../bundle_config';
+
 const version = require('../fluent/package.json').version;
 
-export default {
+export default Object.assign({}, bundleConfig, {
   preferConst: true,
   context: 'this',
   output: {
@@ -23,4 +25,4 @@ export default {
  */\n\n`,
     intro: `/* fluent@${version} */`,
   }
-};
+});

--- a/fluent-gecko/xpcom_dom_config.js
+++ b/fluent-gecko/xpcom_dom_config.js
@@ -1,8 +1,9 @@
 import { resolve } from 'path';
+import bundleConfig from '../bundle_config';
 
 const version = require('../fluent/package.json').version;
 
-export default {
+export default Object.assign({}, bundleConfig, {
   external: [
     resolve('../fluent-dom/src/localization.js')
   ],
@@ -28,4 +29,4 @@ export default {
   },
   preferConst: true,
   context: 'this'
-};
+});

--- a/fluent-intl-polyfill/bundle_config.js
+++ b/fluent-intl-polyfill/bundle_config.js
@@ -1,9 +1,10 @@
+import bundleConfig from '../bundle_config';
 import nodeResolve from 'rollup-plugin-node-resolve';
 
-export default {
+export default Object.assign({}, bundleConfig, {
   context: 'this',
   plugins: [
     nodeResolve(),
   ]
-};
+});
 

--- a/fluent-intl-polyfill/compat_config.js
+++ b/fluent-intl-polyfill/compat_config.js
@@ -1,26 +1,11 @@
+import compatConfig from '../compat_config';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 
-export default {
-  output: {
-    format: 'umd'
-  },
+export default Object.assign({}, compatConfig, {
   context: 'this',
   plugins: [
     nodeResolve(),
-    babel({
-      'babelrc': false,
-      'presets': [
-        ['env', {
-          'modules': false
-        }]
-      ],
-      'plugins': [
-        'external-helpers',
-        ['babel-plugin-transform-builtin-extend', {
-          globals: ['Error']
-        }]
-      ]
-    }),
+    ...compatConfig.plugins
   ],
-};
+});

--- a/fluent-intl-polyfill/compat_config.js
+++ b/fluent-intl-polyfill/compat_config.js
@@ -2,6 +2,9 @@ import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 
 export default {
+  output: {
+    format: 'umd'
+  },
   context: 'this',
   plugins: [
     nodeResolve(),

--- a/fluent-intl-polyfill/makefile
+++ b/fluent-intl-polyfill/makefile
@@ -7,18 +7,16 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --output.format umd \
+	    --config $(CURDIR)/bundle_config.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
-	    --config $(CURDIR)/bundle_config.js \
 	    --output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(CURDIR)/compat_config.js \
-	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \

--- a/fluent-langneg/makefile
+++ b/fluent-langneg/makefile
@@ -7,7 +7,7 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --output.format umd \
+	    --config $(ROOT)/bundle_config.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -17,7 +17,6 @@ $(PACKAGE).js: $(SOURCES)
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(ROOT)/compat_config.js \
-	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \

--- a/fluent-react/makefile
+++ b/fluent-react/makefile
@@ -8,7 +8,7 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --output.format umd \
+	    --config $(ROOT)/bundle_config.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -19,7 +19,6 @@ $(PACKAGE).js: $(SOURCES)
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(ROOT)/compat_config.js \
-	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \

--- a/fluent-syntax/makefile
+++ b/fluent-syntax/makefile
@@ -7,7 +7,7 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --output.format umd \
+	    --config $(ROOT)/bundle_config.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -17,7 +17,6 @@ $(PACKAGE).js: $(SOURCES)
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(ROOT)/compat_config.js \
-	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \

--- a/fluent-web/bundle_config.js
+++ b/fluent-web/bundle_config.js
@@ -1,8 +1,12 @@
+import bundleConfig from '../bundle_config';
 import nodeResolve from 'rollup-plugin-node-resolve';
 
-export default {
+export default Object.assign({}, bundleConfig, {
+  output: {
+    format: 'iife'
+  },
   context: 'this',
   plugins: [
     nodeResolve(),
   ]
-};
+});

--- a/fluent-web/compat_config.js
+++ b/fluent-web/compat_config.js
@@ -1,26 +1,11 @@
+import compatConfig from '../compat_config';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 
-export default {
-  output: {
-    format: 'umd'
-  },
+export default Object.assign({}, compatConfig, {
   context: 'this',
   plugins: [
     nodeResolve(),
-    babel({
-      'babelrc': false,
-      'presets': [
-        ['env', {
-          'modules': false
-        }]
-      ],
-      'plugins': [
-        'external-helpers',
-        ['babel-plugin-transform-builtin-extend', {
-          globals: ['Error']
-        }]
-      ]
-    }),
+    ...compatConfig.plugins
   ],
-};
+});

--- a/fluent-web/compat_config.js
+++ b/fluent-web/compat_config.js
@@ -2,6 +2,9 @@ import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 
 export default {
+  output: {
+    format: 'umd'
+  },
   context: 'this',
   plugins: [
     nodeResolve(),

--- a/fluent-web/makefile
+++ b/fluent-web/makefile
@@ -7,18 +7,16 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-		--output.format iife \
+		--config $(CURDIR)/bundle_config.js \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
 		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \
-		--config $(CURDIR)/bundle_config.js \
 		--output.file $@
 	@echo -e " $(OK) $@ built"
 
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 		--config $(CURDIR)/compat_config.js \
-		--output.format umd \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
 		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \

--- a/fluent/makefile
+++ b/fluent/makefile
@@ -7,7 +7,7 @@ build: $(PACKAGE).js compat.js
 
 $(PACKAGE).js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
-	    --output.format umd \
+	    --config $(ROOT)/bundle_config.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -17,7 +17,6 @@ $(PACKAGE).js: $(SOURCES)
 compat.js: $(SOURCES)
 	@rollup $(CURDIR)/src/index.js \
 	    --config $(ROOT)/compat_config.js \
-	    --output.format umd \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \

--- a/fluent/src/index.js
+++ b/fluent/src/index.js
@@ -17,4 +17,4 @@ export {
 } from './types';
 
 export { default as CachedIterable } from './cached_iterable';
-export { mapContextSync } from './fallback';
+export { mapContextSync, mapContextAsync } from './fallback';

--- a/fluent/test/fallback_async_test.js
+++ b/fluent/test/fallback_async_test.js
@@ -1,0 +1,122 @@
+import assert from 'assert';
+
+import CachedIterable from '../src/cached_iterable';
+import MessageContext from './message_context_stub';
+import { mapContextAsync } from '../src/index';
+
+suite('Async Fallback — single id', function() {
+  let ctx1, ctx2;
+
+  suiteSetup(function() {
+    ctx1 = new MessageContext();
+    ctx1._setMessages(['bar']);
+    ctx2 = new MessageContext();
+    ctx2._setMessages(['foo', 'bar']);
+  });
+
+  test('eager iterable', async function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.equal(await mapContextAsync(contexts, 'foo'), ctx2);
+    assert.equal(await mapContextAsync(contexts, 'bar'), ctx1);
+  });
+
+  test('eager iterable works more than once', async function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.equal(await mapContextAsync(contexts, 'foo'), ctx2);
+    assert.equal(await mapContextAsync(contexts, 'bar'), ctx1);
+    assert.equal(await mapContextAsync(contexts, 'foo'), ctx2);
+    assert.equal(await mapContextAsync(contexts, 'bar'), ctx1);
+  });
+
+  test('lazy iterable', async function() {
+    async function *generateMessages() {
+      yield *[ctx1, ctx2];
+    }
+
+    const contexts = new CachedIterable(generateMessages());
+    assert.equal(await mapContextAsync(contexts, 'foo'), ctx2);
+    assert.equal(await mapContextAsync(contexts, 'bar'), ctx1);
+  });
+
+  test('lazy iterable works more than once', async function() {
+    async function *generateMessages() {
+      yield *[ctx1, ctx2];
+    }
+
+    const contexts = new CachedIterable(generateMessages());
+    assert.equal(await mapContextAsync(contexts, 'foo'), ctx2);
+    assert.equal(await mapContextAsync(contexts, 'bar'), ctx1);
+    assert.equal(await mapContextAsync(contexts, 'foo'), ctx2);
+    assert.equal(await mapContextAsync(contexts, 'bar'), ctx1);
+  });
+});
+
+suite('Async Fallback — multiple ids', async function() {
+  let ctx1, ctx2;
+
+  suiteSetup(function() {
+    ctx1 = new MessageContext();
+    ctx1._setMessages(['foo', 'bar']);
+    ctx2 = new MessageContext();
+    ctx2._setMessages(['foo', 'bar', 'baz']);
+  });
+
+  test('existing translations', async function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.deepEqual(
+      await mapContextAsync(contexts, ['foo', 'bar']),
+      [ctx1, ctx1]
+    );
+  });
+
+  test('fallback translations', async function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.deepEqual(
+      await mapContextAsync(contexts, ['foo', 'bar', 'baz']),
+      [ctx1, ctx1, ctx2]
+    );
+  });
+
+  test('missing translations', async function() {
+    const contexts = new CachedIterable([ctx1, ctx2]);
+    assert.deepEqual(
+      await mapContextAsync(contexts, ['foo', 'bar', 'baz', 'qux']),
+      [ctx1, ctx1, ctx2, null]
+    );
+  });
+});
+
+suite('Async Fallback — early return', async function() {
+  let ctx1, ctx2;
+
+  suiteSetup(function() {
+    ctx1 = new MessageContext();
+    ctx1._setMessages(['foo', 'bar']);
+    ctx2 = new MessageContext();
+    ctx2._setMessages(['foo', 'bar', 'baz']);
+  });
+
+  test('break early if possible', async function() {
+    const contexts = [ctx1, ctx2].values();
+    assert.deepEqual(
+      await mapContextAsync(contexts, ['foo', 'bar']),
+      [ctx1, ctx1]
+    );
+    assert.deepEqual(
+      contexts.next(),
+      {value: ctx2, done: false}
+    );
+  });
+
+  test('iterate over all contexts', async function() {
+    const contexts = [ctx1, ctx2].values();
+    assert.deepEqual(
+      await mapContextAsync(contexts, ['foo', 'bar', 'baz']),
+      [ctx1, ctx1, ctx2]
+    );
+    assert.deepEqual(
+      contexts.next(),
+      {value: undefined, done: true}
+    );
+  });
+});

--- a/fluent/test/fallback_sync_test.js
+++ b/fluent/test/fallback_sync_test.js
@@ -4,7 +4,7 @@ import CachedIterable from '../src/cached_iterable';
 import MessageContext from './message_context_stub';
 import { mapContextSync } from '../src/index';
 
-suite('Fallback — single id', function() {
+suite('Sync Fallback — single id', function() {
   let ctx1, ctx2;
 
   suiteSetup(function() {
@@ -51,7 +51,7 @@ suite('Fallback — single id', function() {
   });
 });
 
-suite('Fallback — multiple ids', function() {
+suite('Sync Fallback — multiple ids', function() {
   let ctx1, ctx2;
 
   suiteSetup(function() {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "acorn-async-iteration": "^0.1.0",
+    "babel-eslint": "^8.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=8.9.0"
   },
   "devDependencies": {
+    "acorn-async-iteration": "^0.1.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
@@ -20,8 +21,8 @@
     "jsdoc": "^3.5.5",
     "mocha": "^4.1.0",
     "prettyjson": "^1.2.1",
-    "rollup": "^0.53.3",
+    "rollup": "^0.55.0",
     "rollup-plugin-babel": "^3.0.3",
-    "rollup-plugin-node-resolve": "^3.0.0"
+    "rollup-plugin-node-resolve": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-stage-3": "^6.24.1",
     "babel-register": "^6.26.0",
     "colors": "^1.1.2",
     "commander": "^2.12",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-3": "^6.24.1",
     "babel-register": "^6.26.0",


### PR DESCRIPTION
`mapContextAsync` asynchronously maps an identifier or an array of identifiers to the best `MessageContext` instance(s) from an async iterable.

The implementation is the easy part.

  - [x] Implement `mapContextAsync`.
  - [x] Write tests.

The hard part is getting our build and testing toolchain to parse `for await` :( Here's the list of things that need fixing:

  - [x] Support `for await` in Rollup which bundles the dist files.

    The [async iterators propsal](https://github.com/tc39/proposal-async-iteration) is still at [Stage 3](https://github.com/tc39/proposals/blob/2f701f68c48f4044c161c3ad290ce0350a09b457/README.md#stage-3). Acorn, the parser that Rollup uses, only supports Stage 4 proposals. There's a [plugin](https://github.com/adrianheine/acorn-async-iteration) which adds support for `for await` but it's currently not possible to extend Acorn via Rollup options. I submitted a PR to Rollup to allow adding plugins to Acorn (https://github.com/rollup/rollup/pull/1857).

  - [x] Support `for await` in Babel which transpiles dist files to compat files.

    Once Rollup bundles the dist files, we use Babel to transpile it to an older version of ECMAScript. There's a [transform-async-generator-functions plugin](https://www.npmjs.com/package/babel-plugin-transform-async-generator-functions) which hopefully can help Babel parse and transpile `for await` properly.

  - [x] Support `for await` when running tests.

    We use `babel-register` when running tests so that node imports ES modules properly. If we continue using it for this reason, we also need Babel to parse `for await` properly (cf. `transform-async-generator-functions` from above). Or, we could try using [@std/esm](https://github.com/standard-things/esm) which is designed just for this purpose.

  - [x] Support `for await` in the linter.

    Eslint also doesn't support non-Stage 4 proposals. There's [babel-eslint](https://github.com/babel/babel-eslint) which we might be able to use. Or, since Eslint uses Espree which is built on top of Acorn, maybe we can plug `acorn-async-iteration` into it somehow.

Yay, JavaScript!