### PR TITLE
fluent-react: Filter props with <Localized attrs={{…}}>

### DIFF
--- a/fluent-react/CHANGELOG.md
+++ b/fluent-react/CHANGELOG.md
@@ -50,8 +50,59 @@
     the element passed as a prop is cloned with the translated text content
     taken from the `DocumentFragment` used as `children`.
 
+  - Filter props set by translations with <Localized attrs={{…}}>.
 
- #### Migrating from `fluent-react` 0.4.1
+    The `<Localized>` component now requires the `attrs` prop to set any
+    localized attributes as props on the wrapped component. `attrs` should be
+    an object with attribute names as keys and booleans as values.
+
+    ```jsx
+    <Localized id="type-name" attrs={{placeholder: true}}>
+        <input
+            type="text"
+            placeholder="Localizable placeholder"
+            value={name}
+            onChange={…}
+        />
+    </Localized>
+    ```
+
+    By default, if `attrs` is not passed, no attributes will be set. This is
+    a breaking change compared to the previous behavior: in `fluent-react`
+    0.4.1 and before `<Localized>` would set _all_ attributes found in the
+    translation.
+
+#### Migrating from `fluent-react` 0.4.1 to 0.6.0
+
+If you're setting localized attributes as props of elements wrapped in
+`<Localized>`, in `fluent-react` 0.6.0 you'll need to also explicitly allow
+the props you're interested in using the `attrs` prop. This protects your
+components from accidentally gaining props they aren't expecting or from
+translations overwriting important props which shouldn't change.
+
+```jsx
+// BEFORE (fluent-react 0.4.1)
+<Localized id="type-name">
+    <input
+        type="text"
+        placeholder="Localizable placeholder"
+        value={name}
+        onChange={…}
+    />
+</Localized>
+```
+
+```jsx
+// AFTER (fluent-react 0.6.0)
+<Localized id="type-name" attrs={{placeholder: true}}>
+    <input
+        type="text"
+        placeholder="Localizable placeholder"
+        value={name}
+        onChange={…}
+    />
+</Localized>
+```
 
 In `fluent-react` 0.4.1 it was possible to pass React elements as _external
 arguments_ to localization via the `$`-prefixed props, just like you'd pass

--- a/fluent-react/examples/text-input/src/App.js
+++ b/fluent-react/examples/text-input/src/App.js
@@ -32,10 +32,10 @@ export default class App extends Component {
             </Localized>
         }
 
-        <Localized id="type-name">
+        <Localized id="type-name" attrs={{placeholder: true}}>
           <input
             type="text"
-            placeholder="Your name"
+            placeholder="Type your name"
             onChange={evt => this.handleNameChange(evt.target.value)}
             value={name}
           />

--- a/fluent-react/test/localized_render_test.js
+++ b/fluent-react/test/localized_render_test.js
@@ -7,7 +7,7 @@ import ReactLocalization from '../src/localization';
 import { Localized } from '../src/index';
 
 suite('Localized - rendering', function() {
-  test('rendering the value', function() {
+  test('render the value', function() {
     const mcx = new MessageContext();
     const l10n = new ReactLocalization([mcx]);
 
@@ -27,7 +27,71 @@ foo = FOO
     ));
   });
 
-  test('rendering the attributes', function() {
+  test('render an allowed attribute', function() {
+    const mcx = new MessageContext();
+    const l10n = new ReactLocalization([mcx]);
+
+    mcx.addMessages(`
+foo
+    .attr = ATTR
+`)
+
+    const wrapper = shallow(
+      <Localized id="foo" attrs={{attr: true}}>
+        <div />
+      </Localized>,
+      { context: { l10n } }
+    );
+
+    assert.ok(wrapper.contains(
+      <div attr="ATTR" />
+    ));
+  });
+
+  test('only render allowed attributes', function() {
+    const mcx = new MessageContext();
+    const l10n = new ReactLocalization([mcx]);
+
+    mcx.addMessages(`
+foo
+    .attr1 = ATTR 1
+    .attr2 = ATTR 2
+`)
+
+    const wrapper = shallow(
+      <Localized id="foo" attrs={{attr2: true}}>
+        <div />
+      </Localized>,
+      { context: { l10n } }
+    );
+
+    assert.ok(wrapper.contains(
+      <div attr2="ATTR 2" />
+    ));
+  });
+
+  test('filter out forbidden attributes', function() {
+    const mcx = new MessageContext();
+    const l10n = new ReactLocalization([mcx]);
+
+    mcx.addMessages(`
+foo
+    .attr = ATTR
+`)
+
+    const wrapper = shallow(
+      <Localized id="foo" attrs={{attr: false}}>
+        <div />
+      </Localized>,
+      { context: { l10n } }
+    );
+
+    assert.ok(wrapper.contains(
+      <div />
+    ));
+  });
+
+  test('filter all attributes if attrs not given', function() {
     const mcx = new MessageContext();
     const l10n = new ReactLocalization([mcx]);
 
@@ -44,17 +108,80 @@ foo
     );
 
     assert.ok(wrapper.contains(
-      <div attr="ATTR" />
+      <div />
     ));
   });
 
-  test('preserves existing attributes', function() {
+  test('preserve existing attributes when setting new ones', function() {
     const mcx = new MessageContext();
     const l10n = new ReactLocalization([mcx]);
 
     mcx.addMessages(`
 foo
     .attr = ATTR
+`)
+
+    const wrapper = shallow(
+      <Localized id="foo" attrs={{attr: true}}>
+        <div existing={true} />
+      </Localized>,
+      { context: { l10n } }
+    );
+
+    assert.ok(wrapper.contains(
+      <div existing={true} attr="ATTR" />
+    ));
+  });
+
+  test('overwrite existing attributes if allowed', function() {
+    const mcx = new MessageContext();
+    const l10n = new ReactLocalization([mcx]);
+
+    mcx.addMessages(`
+foo
+    .existing = ATTR
+`)
+
+    const wrapper = shallow(
+      <Localized id="foo" attrs={{existing: true}}>
+        <div existing={true} />
+      </Localized>,
+      { context: { l10n } }
+    );
+
+    assert.ok(wrapper.contains(
+      <div existing="ATTR" />
+    ));
+  });
+
+  test('protect existing attributes if setting is forbidden', function() {
+    const mcx = new MessageContext();
+    const l10n = new ReactLocalization([mcx]);
+
+    mcx.addMessages(`
+foo
+    .existing = ATTR
+`)
+
+    const wrapper = shallow(
+      <Localized id="foo" attrs={{existing: false}}>
+        <div existing={true} />
+      </Localized>,
+      { context: { l10n } }
+    );
+
+    assert.ok(wrapper.contains(
+      <div existing={true} />
+    ));
+  });
+
+  test('protect existing attributes by default', function() {
+    const mcx = new MessageContext();
+    const l10n = new ReactLocalization([mcx]);
+
+    mcx.addMessages(`
+foo
+    .existing = ATTR
 `)
 
     const wrapper = shallow(
@@ -65,7 +192,7 @@ foo
     );
 
     assert.ok(wrapper.contains(
-      <div existing={true} attr="ATTR" />
+      <div existing={true} />
     ));
   });
 


### PR DESCRIPTION
Fixes #139.

The <Localized> component now requires the `attrs` prop to set any localized attributes as props on the wrapped component. `attrs` should be an object with attribute names as keys and booleans as values.

```jsx
<Localized id="type-name" attrs={{placeholder: true}}>
    <input
        type="text"
        placeholder="Type your name"
        onChange={…}
        value={name}
    />
</Localized>
```

By default, if `attrs` is not passed, no attributes will be set. This is a breaking change compared to the previous behavior: in `fluent-react` 0.4.1 and before `<Localized>` would set _all_ attributes found in the
translation.