### PR TITLE
Allow for <img/> element in DOM Overlays

### DIFF
--- a/fluent-dom/src/overlay.js
+++ b/fluent-dom/src/overlay.js
@@ -11,7 +11,10 @@ const LOCALIZABLE_ELEMENTS = {
   'http://www.w3.org/1999/xhtml': [
     'a', 'em', 'strong', 'small', 's', 'cite', 'q', 'dfn', 'abbr', 'data',
     'time', 'code', 'var', 'samp', 'kbd', 'sub', 'sup', 'i', 'b', 'u',
-    'mark', 'ruby', 'rt', 'rp', 'bdi', 'bdo', 'span', 'br', 'wbr'
+    'mark', 'ruby', 'rt', 'rp', 'bdi', 'bdo', 'span', 'br', 'wbr',
+
+    // Elements below were manually selected for inclusion
+    'img',
   ],
 };
 

--- a/fluent-dom/test/overlay_test.js
+++ b/fluent-dom/test/overlay_test.js
@@ -24,7 +24,7 @@ suite('Filtering elements in translation', function() {
   test('forbidden element', function() {
     const element = elem('div')`Foo`;
     const translation = {
-      value: 'FOO <img src="img.png" />',
+      value: 'FOO <iframe src="img.png" />',
       attrs: null
     };
 


### PR DESCRIPTION
Required for https://bugzilla.mozilla.org/show_bug.cgi?id=1424682