### PR TITLE
add(getString): add third argument to getString for fallback message

### DIFF
--- a/fluent-react/src/localization.js
+++ b/fluent-react/src/localization.js
@@ -65,11 +65,11 @@ export default class ReactLocalization {
   /*
    * Find a translation by `id` and format it to a string using `args`.
    */
-  getString(id, args) {
+  getString(id, args, fallback) {
     const mcx = this.getMessageContext(id);
 
     if (mcx === null) {
-      return id;
+      return fallback || id;
     }
 
     const msg = mcx.getMessage(id);

--- a/fluent-react/src/with_localization.js
+++ b/fluent-react/src/with_localization.js
@@ -12,14 +12,14 @@ export default function withLocalization(Inner) {
     /*
      * Find a translation by `id` and format it to a string using `args`.
      */
-    getString(id, args) {
+    getString(id, args, fallback) {
       const { l10n } = this.context;
 
       if (!l10n) {
-        return id;
+        return fallback || id;
       }
 
-      return l10n.getString(id, args);
+      return l10n.getString(id, args, fallback);
     }
 
     render() {

--- a/fluent-react/test/with_localization_test.js
+++ b/fluent-react/test/with_localization_test.js
@@ -46,7 +46,26 @@ foo = FOO
 
     const getString = wrapper.prop('getString');
     // Returns the translation.
-    assert.equal(getString('foo'), 'FOO');
+    assert.equal(getString('foo', {}), 'FOO');
+  });
+
+  test('getString with access to the l10n context, with fallback value', function() {
+    const mcx = new MessageContext();
+    const l10n = new ReactLocalization([mcx]);
+    const EnhancedComponent = withLocalization(DummyComponent);
+
+    mcx.addMessages(`
+foo = FOO
+`);
+
+    const wrapper = shallow(
+      <EnhancedComponent />,
+      { context: { l10n } }
+    );
+
+    const getString = wrapper.prop('getString');
+    // Returns the translation, even if fallback value provided.
+    assert.equal(getString('bar', {}, 'fallback'), 'fallback');
   });
 
   test('getString without access to the l10n context', function() {
@@ -63,7 +82,25 @@ foo = FOO
     );
 
     const getString = wrapper.prop('getString');
-    // Returns the id.
+    // Returns the id if no fallback.
     assert.equal(getString('foo', {arg: 1}), 'foo');
+  });
+
+  test('getString without access to the l10n context, with fallback value', function() {
+    const mcx = new MessageContext();
+    const l10n = new ReactLocalization([mcx]);
+    const EnhancedComponent = withLocalization(DummyComponent);
+
+    mcx.addMessages(`
+foo = FOO
+`);
+
+    const wrapper = shallow(
+      <EnhancedComponent />
+    );
+
+    const getString = wrapper.prop('getString');
+    // Returns the fallback if provided.
+    assert.equal(getString('foo', {arg: 1}, 'fallback message'), 'fallback message');
   });
 });


### PR DESCRIPTION
addresses issue https://github.com/projectfluent/fluent.js/issues/145
adds a third argument to the `getString` function in `withLocalized` wrapped components to allow for definition of a fallback message in case the message id is not fount in the message context.

Additional future benefit to be including fallback string in extraction scripts.