### PR TITLE
Bump our keywords to help with SEO on npmjs

### DIFF
--- a/fluent-dom/package.json
+++ b/fluent-dom/package.json
@@ -25,7 +25,15 @@
   "module": "./src/index.js",
   "keywords": [
     "localization",
-    "l10n"
+    "l10n",
+    "internationalization",
+    "i18n",
+    "locale",
+    "language",
+    "formatting",
+    "translate",
+    "translation",
+    "format"
   ],
   "engines": {
     "node": ">=8.9.0"

--- a/fluent-langneg/package.json
+++ b/fluent-langneg/package.json
@@ -26,7 +26,12 @@
   },
   "keywords": [
     "localization",
-    "l10n"
+    "l10n",
+    "internationalization",
+    "i18n",
+    "locale",
+    "language",
+    "language-negotiation"
   ],
   "engines": {
     "node": ">=8.9.0"

--- a/fluent-react/package.json
+++ b/fluent-react/package.json
@@ -26,7 +26,21 @@
   },
   "keywords": [
     "localization",
-    "l10n"
+    "l10n",
+    "internationalization",
+    "i18n",
+    "ftl",
+    "plural",
+    "gender",
+    "locale",
+    "language",
+    "formatting",
+    "translate",
+    "translation",
+    "format",
+    "parser",
+    "react",
+    "reactjs"
   ],
   "engines": {
     "node": ">=8.9.0"

--- a/fluent-syntax/package.json
+++ b/fluent-syntax/package.json
@@ -26,7 +26,22 @@
   },
   "keywords": [
     "localization",
-    "l10n"
+    "l10n",
+    "internationalization",
+    "i18n",
+    "ftl",
+    "plural",
+    "gender",
+    "locale",
+    "language",
+    "formatting",
+    "translate",
+    "translation",
+    "format",
+    "ast",
+    "serializer",
+    "parser"
+
   ],
   "engines": {
     "node": ">=8.9.0"

--- a/fluent-web/package.json
+++ b/fluent-web/package.json
@@ -25,7 +25,15 @@
   "module": "./src/index.js",
   "keywords": [
     "localization",
-    "l10n"
+    "l10n",
+    "internationalization",
+    "i18n",
+    "locale",
+    "language",
+    "formatting",
+    "translate",
+    "translation",
+    "format"
   ],
   "engines": {
     "node": ">=8.9.0"

--- a/fluent/package.json
+++ b/fluent/package.json
@@ -26,7 +26,19 @@
   },
   "keywords": [
     "localization",
-    "l10n"
+    "l10n",
+    "internationalization",
+    "i18n",
+    "ftl",
+    "plural",
+    "gender",
+    "locale",
+    "language",
+    "formatting",
+    "translate",
+    "translation",
+    "format",
+    "parser"
   ],
   "engines": {
     "node": ">=8.9.0"


### PR DESCRIPTION
Seems like a lot of tools like npm comparer use package.json keywords, and ours is very limited compared to other l10n libraries. Bumping them to help with SEO.