### PR TITLE
Update to Rollup 0.56.x for ES2018 support

### DIFF
--- a/bundle_config.js
+++ b/bundle_config.js
@@ -1,14 +1,8 @@
-import acornAsyncIteration from 'acorn-async-iteration/inject';
-
 export default {
   output: {
-    format: 'umd'
+    format: 'umd',
   },
   acorn: {
     ecmaVersion: 9,
-    plugins: { asyncIteration: true }
   },
-  acornInjectPlugins: [
-    acornAsyncIteration
-  ]
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "node": ">=8.9.0"
   },
   "devDependencies": {
-    "acorn-async-iteration": "^0.1.0",
     "babel-eslint": "^8.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
@@ -24,8 +23,8 @@
     "jsdoc": "^3.5.5",
     "mocha": "^4.1.0",
     "prettyjson": "^1.2.1",
-    "rollup": "^0.55.0",
+    "rollup": "^0.56.2",
     "rollup-plugin-babel": "^3.0.3",
-    "rollup-plugin-node-resolve": "^3.0.2"
+    "rollup-plugin-node-resolve": "^3.0.3"
   }
 }


### PR DESCRIPTION
Rollup 0.56.x uses Acorn 5.4.1 which has built-in support for the new ECMAScript 2018 features: async iteration and object rest/spread.