### PR TITLE
Switch linter to double quotes

### DIFF
--- a/eslint_src.json
+++ b/eslint_src.json
@@ -73,7 +73,7 @@
         "prefer-spread": 2,
         "quotes": [
             2,
-            "single",
+            "double",
             {
                 "avoidEscape": true
             }

--- a/fluent-dom/src/dom_localization.js
+++ b/fluent-dom/src/dom_localization.js
@@ -1,8 +1,8 @@
-import overlayElement from './overlay';
-import Localization from './localization';
+import overlayElement from "./overlay";
+import Localization from "./localization";
 
-const L10NID_ATTR_NAME = 'data-l10n-id';
-const L10NARGS_ATTR_NAME = 'data-l10n-args';
+const L10NID_ATTR_NAME = "data-l10n-id";
+const L10NARGS_ATTR_NAME = "data-l10n-args";
 
 const L10N_ELEMENT_QUERY = `[${L10NID_ATTR_NAME}]`;
 
@@ -128,7 +128,7 @@ export default class DOMLocalization extends Localization {
       if (root === newRoot ||
           root.contains(newRoot) ||
           newRoot.contains(root)) {
-        throw new Error('Cannot add a root that overlaps with existing root.');
+        throw new Error("Cannot add a root that overlaps with existing root.");
       }
     }
 
@@ -198,10 +198,10 @@ export default class DOMLocalization extends Localization {
   translateMutations(mutations) {
     for (const mutation of mutations) {
       switch (mutation.type) {
-        case 'attributes':
+        case "attributes":
           this.pendingElements.add(mutation.target);
           break;
-        case 'childList':
+        case "childList":
           for (const addedNode of mutation.addedNodes) {
             if (addedNode.nodeType === addedNode.ELEMENT_NODE) {
               if (addedNode.childElementCount) {
@@ -298,7 +298,7 @@ export default class DOMLocalization extends Localization {
   getTranslatables(element) {
     const nodes = Array.from(element.querySelectorAll(L10N_ELEMENT_QUERY));
 
-    if (typeof element.hasAttribute === 'function' &&
+    if (typeof element.hasAttribute === "function" &&
         element.hasAttribute(L10NID_ATTR_NAME)) {
       nodes.push(element);
     }

--- a/fluent-dom/src/index.js
+++ b/fluent-dom/src/index.js
@@ -1,2 +1,2 @@
-export { default as DOMLocalization } from './dom_localization';
-export { default as Localization } from './localization';
+export { default as DOMLocalization } from "./dom_localization";
+export { default as Localization } from "./localization";

--- a/fluent-dom/src/localization.js
+++ b/fluent-dom/src/localization.js
@@ -1,7 +1,7 @@
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
 /* global console */
 
-import { CachedIterable } from '../../fluent/src/index';
+import { CachedIterable } from "../../fluent/src/index";
 
 /**
  * Specialized version of an Error used to indicate errors that are result
@@ -16,7 +16,7 @@ import { CachedIterable } from '../../fluent/src/index';
 class L10nError extends Error {
   constructor(message) {
     super();
-    this.name = 'L10nError';
+    this.name = "L10nError";
     this.message = message;
   }
 }
@@ -58,7 +58,7 @@ export default class Localization {
     for (let ctx of this.ctxs) {
       // This can operate on synchronous and asynchronous
       // contexts coming from the iterator.
-      if (typeof ctx.then === 'function') {
+      if (typeof ctx.then === "function") {
         ctx = await ctx;
       }
       const errors = keysFromContext(method, ctx, keys, translations);
@@ -290,7 +290,7 @@ function keysFromContext(method, ctx, keys, translations) {
       hasErrors = true;
     }
 
-    if (messageErrors.length && typeof console !== 'undefined') {
+    if (messageErrors.length && typeof console !== "undefined") {
       messageErrors.forEach(error => console.warn(error));
     }
   });

--- a/fluent-dom/src/overlay.js
+++ b/fluent-dom/src/overlay.js
@@ -8,36 +8,36 @@ const reOverlay = /<|&#?\w+;/;
  * Source: https://www.w3.org/TR/html5/text-level-semantics.html
  */
 const LOCALIZABLE_ELEMENTS = {
-  'http://www.w3.org/1999/xhtml': [
-    'a', 'em', 'strong', 'small', 's', 'cite', 'q', 'dfn', 'abbr', 'data',
-    'time', 'code', 'var', 'samp', 'kbd', 'sub', 'sup', 'i', 'b', 'u',
-    'mark', 'ruby', 'rt', 'rp', 'bdi', 'bdo', 'span', 'br', 'wbr'
+  "http://www.w3.org/1999/xhtml": [
+    "a", "em", "strong", "small", "s", "cite", "q", "dfn", "abbr", "data",
+    "time", "code", "var", "samp", "kbd", "sub", "sup", "i", "b", "u",
+    "mark", "ruby", "rt", "rp", "bdi", "bdo", "span", "br", "wbr"
   ],
 };
 
 const LOCALIZABLE_ATTRIBUTES = {
-  'http://www.w3.org/1999/xhtml': {
-    global: ['title', 'aria-label', 'aria-valuetext', 'aria-moz-hint'],
-    a: ['download'],
-    area: ['download', 'alt'],
+  "http://www.w3.org/1999/xhtml": {
+    global: ["title", "aria-label", "aria-valuetext", "aria-moz-hint"],
+    a: ["download"],
+    area: ["download", "alt"],
     // value is special-cased in isAttrNameLocalizable
-    input: ['alt', 'placeholder'],
-    menuitem: ['label'],
-    menu: ['label'],
-    optgroup: ['label'],
-    option: ['label'],
-    track: ['label'],
-    img: ['alt'],
-    textarea: ['placeholder'],
-    th: ['abbr']
+    input: ["alt", "placeholder"],
+    menuitem: ["label"],
+    menu: ["label"],
+    optgroup: ["label"],
+    option: ["label"],
+    track: ["label"],
+    img: ["alt"],
+    textarea: ["placeholder"],
+    th: ["abbr"]
   },
-  'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul': {
+  "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul": {
     global: [
-      'accesskey', 'aria-label', 'aria-valuetext', 'aria-moz-hint', 'label'
+      "accesskey", "aria-label", "aria-valuetext", "aria-moz-hint", "label"
     ],
-    key: ['key', 'keycode'],
-    textbox: ['placeholder'],
-    toolbarbutton: ['tooltiptext'],
+    key: ["key", "keycode"],
+    textbox: ["placeholder"],
+    toolbarbutton: ["tooltiptext"],
   }
 };
 
@@ -52,7 +52,7 @@ const LOCALIZABLE_ATTRIBUTES = {
 export default function overlayElement(targetElement, translation) {
   const value = translation.value;
 
-  if (typeof value === 'string') {
+  if (typeof value === "string") {
     if (!reOverlay.test(value)) {
       // If the translation doesn't contain any markup skip the overlay logic.
       targetElement.textContent = value;
@@ -60,7 +60,7 @@ export default function overlayElement(targetElement, translation) {
       // Else parse the translation's HTML using an inert template element,
       // sanitize it and replace the targetElement's content.
       const templateElement = targetElement.ownerDocument.createElementNS(
-        'http://www.w3.org/1999/xhtml', 'template');
+        "http://www.w3.org/1999/xhtml", "template");
       templateElement.innerHTML = value;
       targetElement.appendChild(
         // The targetElement will be cleared at the end of sanitization.
@@ -69,9 +69,9 @@ export default function overlayElement(targetElement, translation) {
     }
   }
 
-  const explicitlyAllowed = targetElement.hasAttribute('data-l10n-attrs')
-    ? targetElement.getAttribute('data-l10n-attrs')
-      .split(',').map(i => i.trim())
+  const explicitlyAllowed = targetElement.hasAttribute("data-l10n-attrs")
+    ? targetElement.getAttribute("data-l10n-attrs")
+      .split(",").map(i => i.trim())
     : null;
 
   // Remove localizable attributes which may have been set by a previous
@@ -159,7 +159,7 @@ function sanitizeUsing(translationFragment, sourceElement) {
 
   // SourceElement might have been already modified by shiftNamedElement.
   // Let's clear it to make sure other code doesn't rely on random leftovers.
-  sourceElement.textContent = '';
+  sourceElement.textContent = "";
 
   return translationFragment;
 }
@@ -251,10 +251,10 @@ function isAttrNameLocalizable(name, element, explicitlyAllowed = null) {
   }
 
   // Special case for value on HTML inputs with type button, reset, submit
-  if (element.namespaceURI === 'http://www.w3.org/1999/xhtml' &&
-      elemName === 'input' && attrName === 'value') {
+  if (element.namespaceURI === "http://www.w3.org/1999/xhtml" &&
+      elemName === "input" && attrName === "value") {
     const type = element.type.toLowerCase();
-    if (type === 'submit' || type === 'button' || type === 'reset') {
+    if (type === "submit" || type === "button" || type === "reset") {
       return true;
     }
   }

--- a/fluent-gecko/src/dom_localization.js
+++ b/fluent-gecko/src/dom_localization.js
@@ -1,5 +1,5 @@
 /* global L10nRegistry, Services */
-import DOMLocalization from '../../fluent-dom/src/dom_localization';
+import DOMLocalization from "../../fluent-dom/src/dom_localization";
 
 /**
  * The default localization strategy for Gecko. It comabines locales
@@ -32,4 +32,4 @@ class GeckoDOMLocalization extends DOMLocalization {
 }
 
 this.DOMLocalization = GeckoDOMLocalization;
-this.EXPORTED_SYMBOLS = ['DOMLocalization'];
+this.EXPORTED_SYMBOLS = ["DOMLocalization"];

--- a/fluent-gecko/src/l10n.js
+++ b/fluent-gecko/src/l10n.js
@@ -1,7 +1,7 @@
 /* global Components, document, window */
 {
   const { DOMLocalization } =
-    Components.utils.import('resource://gre/modules/DOMLocalization.jsm');
+    Components.utils.import("resource://gre/modules/DOMLocalization.jsm");
 
   /**
    * Polyfill for document.ready polyfill.
@@ -10,23 +10,23 @@
    * @returns {Promise}
    */
   function documentReady() {
-    if (document.contentType === 'application/vnd.mozilla.xul+xml') {
+    if (document.contentType === "application/vnd.mozilla.xul+xml") {
       // XUL
       return new Promise(
         resolve => document.addEventListener(
-          'MozBeforeInitialXULLayout', resolve, { once: true }
+          "MozBeforeInitialXULLayout", resolve, { once: true }
         )
       );
     }
 
     // HTML
     const rs = document.readyState;
-    if (rs === 'interactive' || rs === 'completed') {
+    if (rs === "interactive" || rs === "completed") {
       return Promise.resolve();
     }
     return new Promise(
       resolve => document.addEventListener(
-        'readystatechange', resolve, { once: true }
+        "readystatechange", resolve, { once: true }
       )
     );
   }
@@ -39,7 +39,7 @@
    */
   function getResourceLinks(elem) {
     return Array.from(elem.querySelectorAll('link[rel="localization"]')).map(
-      el => el.getAttribute('href')
+      el => el.getAttribute("href")
     );
   }
 
@@ -52,7 +52,7 @@
 
   document.l10n.ready = documentReady().then(() => {
     document.l10n.registerObservers();
-    window.addEventListener('unload', () => {
+    window.addEventListener("unload", () => {
       document.l10n.unregisterObservers();
     });
     document.l10n.connectRoot(document.documentElement);

--- a/fluent-gecko/src/localization.js
+++ b/fluent-gecko/src/localization.js
@@ -6,14 +6,14 @@ const Cc = Components.classes;
 const Ci = Components.interfaces;
 
 const { L10nRegistry } =
-  Cu.import('resource://gre/modules/L10nRegistry.jsm', {});
+  Cu.import("resource://gre/modules/L10nRegistry.jsm", {});
 const ObserverService =
-  Cc['@mozilla.org/observer-service;1'].getService(Ci.nsIObserverService);
+  Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 const { Services } =
-  Cu.import('resource://gre/modules/Services.jsm', {});
+  Cu.import("resource://gre/modules/Services.jsm", {});
 
 
-import Localization from '../../fluent-dom/src/localization';
+import Localization from "../../fluent-dom/src/localization";
 
 /**
  * The default localization strategy for Gecko. It comabines locales
@@ -41,4 +41,4 @@ class GeckoLocalization extends Localization {
 }
 
 this.Localization = GeckoLocalization;
-this.EXPORTED_SYMBOLS = ['Localization'];
+this.EXPORTED_SYMBOLS = ["Localization"];

--- a/fluent-gecko/src/message_context.js
+++ b/fluent-gecko/src/message_context.js
@@ -1,4 +1,4 @@
-import { MessageContext } from '../../fluent/src/index';
+import { MessageContext } from "../../fluent/src/index";
 
 this.MessageContext = MessageContext;
-this.EXPORTED_SYMBOLS = ['MessageContext'];
+this.EXPORTED_SYMBOLS = ["MessageContext"];

--- a/fluent-intl-polyfill/src/index.js
+++ b/fluent-intl-polyfill/src/index.js
@@ -6,4 +6,4 @@
  *
  */
 
-export { default as PluralRules } from 'intl-pluralrules';
+export { default as PluralRules } from "intl-pluralrules";

--- a/fluent-langneg/src/accepted_languages.js
+++ b/fluent-langneg/src/accepted_languages.js
@@ -1,7 +1,7 @@
-export default function acceptedLanguages(string = '') {
-  if (typeof string !== 'string') {
-    throw new TypeError('Argument must be a string');
+export default function acceptedLanguages(string = "") {
+  if (typeof string !== "string") {
+    throw new TypeError("Argument must be a string");
   }
-  const tokens = string.split(',').map(t => t.trim());
-  return tokens.filter(t => t !== '').map(t => t.split(';')[0]);
+  const tokens = string.split(",").map(t => t.trim());
+  return tokens.filter(t => t !== "").map(t => t.split(";")[0]);
 }

--- a/fluent-langneg/src/index.js
+++ b/fluent-langneg/src/index.js
@@ -7,5 +7,5 @@
  *
  */
 
-export { default as negotiateLanguages } from './negotiate_languages';
-export { default as acceptedLanguages } from './accepted_languages';
+export { default as negotiateLanguages } from "./negotiate_languages";
+export { default as acceptedLanguages } from "./accepted_languages";

--- a/fluent-langneg/src/locale.js
+++ b/fluent-langneg/src/locale.js
@@ -1,11 +1,11 @@
 /* eslint no-magic-numbers: 0 */
 
-import { getLikelySubtagsMin } from './subtags';
+import { getLikelySubtagsMin } from "./subtags";
 
-const languageCodeRe = '([a-z]{2,3}|\\*)';
-const scriptCodeRe = '(?:-([a-z]{4}|\\*))';
-const regionCodeRe = '(?:-([a-z]{2}|\\*))';
-const variantCodeRe = '(?:-([a-z]{3}|\\*))';
+const languageCodeRe = "([a-z]{2,3}|\\*)";
+const scriptCodeRe = "(?:-([a-z]{4}|\\*))";
+const regionCodeRe = "(?:-([a-z]{2}|\\*))";
+const variantCodeRe = "(?:-([a-z]{3}|\\*))";
 
 /**
  * Regular expression splitting locale id into four pieces:
@@ -20,9 +20,9 @@ const variantCodeRe = '(?:-([a-z]{3}|\\*))';
  * It can also accept a range `*` character on any position.
  */
 const localeRe = new RegExp(
-  `^${languageCodeRe}${scriptCodeRe}?${regionCodeRe}?${variantCodeRe}?$`, 'i');
+  `^${languageCodeRe}${scriptCodeRe}?${regionCodeRe}?${variantCodeRe}?$`, "i");
 
-export const localeParts = ['language', 'script', 'region', 'variant'];
+export const localeParts = ["language", "script", "region", "variant"];
 
 export default class Locale {
   /**
@@ -35,12 +35,12 @@ export default class Locale {
    * properly parsed as `en-*-US-*`.
    */
   constructor(locale, range = false) {
-    const result = localeRe.exec(locale.replace(/_/g, '-'));
+    const result = localeRe.exec(locale.replace(/_/g, "-"));
     if (!result) {
       return;
     }
 
-    const missing = range ? '*' : undefined;
+    const missing = range ? "*" : undefined;
 
     const language = result[1] || missing;
     const script = result[2] || missing;
@@ -60,7 +60,7 @@ export default class Locale {
 
   matches(locale) {
     return localeParts.every(part => {
-      return this[part] === '*' || locale[part] === '*' ||
+      return this[part] === "*" || locale[part] === "*" ||
         (this[part] === undefined && locale[part] === undefined) ||
         (this[part] !== undefined && locale[part] !== undefined &&
         this[part].toLowerCase() === locale[part].toLowerCase());
@@ -68,11 +68,11 @@ export default class Locale {
   }
 
   setVariantRange() {
-    this.variant = '*';
+    this.variant = "*";
   }
 
   setRegionRange() {
-    this.region = '*';
+    this.region = "*";
   }
 
   addLikelySubtags() {

--- a/fluent-langneg/src/matches.js
+++ b/fluent-langneg/src/matches.js
@@ -1,7 +1,7 @@
 /* eslint no-magic-numbers: 0 */
 /* eslint complexity: ["error", { "max": 27 }] */
 
-import Locale from './locale';
+import Locale from "./locale";
 
 /**
  * Negotiates the languages between the list of requested locales against
@@ -101,9 +101,9 @@ export default function filterMatches(
             break;
           }
         }
-        if (strategy === 'lookup') {
+        if (strategy === "lookup") {
           return Array.from(supportedLocales);
-        } else if (strategy === 'filtering') {
+        } else if (strategy === "filtering") {
           continue;
         } else {
           continue outer;
@@ -119,9 +119,9 @@ export default function filterMatches(
       if (requestedLocale.matches(availableLocale)) {
         supportedLocales.add(availableLocale.string);
         availLocales.delete(availableLocale);
-        if (strategy === 'lookup') {
+        if (strategy === "lookup") {
           return Array.from(supportedLocales);
-        } else if (strategy === 'filtering') {
+        } else if (strategy === "filtering") {
           continue;
         } else {
           continue outer;
@@ -138,9 +138,9 @@ export default function filterMatches(
         if (requestedLocale.matches(availableLocale)) {
           supportedLocales.add(availableLocale.string);
           availLocales.delete(availableLocale);
-          if (strategy === 'lookup') {
+          if (strategy === "lookup") {
             return Array.from(supportedLocales);
-          } else if (strategy === 'filtering') {
+          } else if (strategy === "filtering") {
             continue;
           } else {
             continue outer;
@@ -157,9 +157,9 @@ export default function filterMatches(
       if (requestedLocale.matches(availableLocale)) {
         supportedLocales.add(availableLocale.string);
         availLocales.delete(availableLocale);
-        if (strategy === 'lookup') {
+        if (strategy === "lookup") {
           return Array.from(supportedLocales);
-        } else if (strategy === 'filtering') {
+        } else if (strategy === "filtering") {
           continue;
         } else {
           continue outer;
@@ -175,9 +175,9 @@ export default function filterMatches(
       if (requestedLocale.matches(availableLocale)) {
         supportedLocales.add(availableLocale.string);
         availLocales.delete(availableLocale);
-        if (strategy === 'lookup') {
+        if (strategy === "lookup") {
           return Array.from(supportedLocales);
-        } else if (strategy === 'filtering') {
+        } else if (strategy === "filtering") {
           continue;
         } else {
           continue outer;

--- a/fluent-langneg/src/negotiate_languages.js
+++ b/fluent-langneg/src/negotiate_languages.js
@@ -1,17 +1,17 @@
-import filterMatches from './matches';
+import filterMatches from "./matches";
 
 function GetOption(options, property, type, values, fallback) {
   let value = options[property];
 
   if (value !== undefined) {
-    if (type === 'boolean') {
+    if (type === "boolean") {
       value = new Boolean(value);
-    } else if (type === 'string') {
+    } else if (type === "string") {
       value = String(value);
     }
 
     if (values !== undefined && values.indexOf(value) === -1) {
-      throw new Error('Invalid option value');
+      throw new Error("Invalid option value");
     }
 
     return value;
@@ -69,12 +69,12 @@ export default function negotiateLanguages(
   options = {}
 ) {
 
-  const defaultLocale = GetOption(options, 'defaultLocale', 'string');
-  const strategy = GetOption(options, 'strategy', 'string',
-    ['filtering', 'matching', 'lookup'], 'filtering');
+  const defaultLocale = GetOption(options, "defaultLocale", "string");
+  const strategy = GetOption(options, "strategy", "string",
+    ["filtering", "matching", "lookup"], "filtering");
 
-  if (strategy === 'lookup' && !defaultLocale) {
-    throw new Error('defaultLocale cannot be undefined for strategy `lookup`');
+  if (strategy === "lookup" && !defaultLocale) {
+    throw new Error("defaultLocale cannot be undefined for strategy `lookup`");
   }
 
   const resolvedReqLoc = Array.from(Object(requestedLocales)).map(loc => {
@@ -89,7 +89,7 @@ export default function negotiateLanguages(
     resolvedAvailLoc, strategy
   );
 
-  if (strategy === 'lookup') {
+  if (strategy === "lookup") {
     if (supportedLocales.length === 0) {
       supportedLocales.push(defaultLocale);
     }

--- a/fluent-langneg/src/subtags.js
+++ b/fluent-langneg/src/subtags.js
@@ -1,4 +1,4 @@
-import Locale from './locale';
+import Locale from "./locale";
 
 /**
  * Below is a manually a list of likely subtags corresponding to Unicode
@@ -10,43 +10,43 @@ import Locale from './locale';
  * This version of the list is based on CLDR 30.0.3.
  */
 const likelySubtagsMin = {
-  'ar': 'ar-arab-eg',
-  'az-arab': 'az-arab-ir',
-  'az-ir': 'az-arab-ir',
-  'be': 'be-cyrl-by',
-  'da': 'da-latn-dk',
-  'el': 'el-grek-gr',
-  'en': 'en-latn-us',
-  'fa': 'fa-arab-ir',
-  'ja': 'ja-jpan-jp',
-  'ko': 'ko-kore-kr',
-  'pt': 'pt-latn-br',
-  'sr': 'sr-cyrl-rs',
-  'sr-ru': 'sr-latn-ru',
-  'sv': 'sv-latn-se',
-  'ta': 'ta-taml-in',
-  'uk': 'uk-cyrl-ua',
-  'zh': 'zh-hans-cn',
-  'zh-gb': 'zh-hant-gb',
-  'zh-us': 'zh-hant-us',
+  "ar": "ar-arab-eg",
+  "az-arab": "az-arab-ir",
+  "az-ir": "az-arab-ir",
+  "be": "be-cyrl-by",
+  "da": "da-latn-dk",
+  "el": "el-grek-gr",
+  "en": "en-latn-us",
+  "fa": "fa-arab-ir",
+  "ja": "ja-jpan-jp",
+  "ko": "ko-kore-kr",
+  "pt": "pt-latn-br",
+  "sr": "sr-cyrl-rs",
+  "sr-ru": "sr-latn-ru",
+  "sv": "sv-latn-se",
+  "ta": "ta-taml-in",
+  "uk": "uk-cyrl-ua",
+  "zh": "zh-hans-cn",
+  "zh-gb": "zh-hant-gb",
+  "zh-us": "zh-hant-us",
 };
 
 const regionMatchingLangs = [
-  'az',
-  'bg',
-  'cs',
-  'de',
-  'es',
-  'fi',
-  'fr',
-  'hu',
-  'it',
-  'lt',
-  'lv',
-  'nl',
-  'pl',
-  'ro',
-  'ru',
+  "az",
+  "bg",
+  "cs",
+  "de",
+  "es",
+  "fi",
+  "fr",
+  "hu",
+  "it",
+  "lt",
+  "lv",
+  "nl",
+  "pl",
+  "ro",
+  "ru",
 ];
 
 export function getLikelySubtagsMin(loc) {

--- a/fluent-react/src/index.js
+++ b/fluent-react/src/index.js
@@ -17,8 +17,8 @@
  * components for more information.
  */
 
-export { default as LocalizationProvider } from './provider';
-export { default as withLocalization } from './with_localization';
-export { default as Localized } from './localized';
+export { default as LocalizationProvider } from "./provider";
+export { default as withLocalization } from "./with_localization";
+export { default as Localized } from "./localized";
 export { default as ReactLocalization, isReactLocalization }
-  from './localization';
+  from "./localization";

--- a/fluent-react/src/localization.js
+++ b/fluent-react/src/localization.js
@@ -1,4 +1,4 @@
-import { CachedIterable, mapContextSync } from 'fluent/compat';
+import { CachedIterable, mapContextSync } from "fluent/compat";
 
 /*
  * `ReactLocalization` handles translation formatting and fallback.

--- a/fluent-react/src/localized.js
+++ b/fluent-react/src/localized.js
@@ -1,9 +1,9 @@
-import { isValidElement, cloneElement, Component, Children } from 'react';
-import PropTypes from 'prop-types';
+import { isValidElement, cloneElement, Component, Children } from "react";
+import PropTypes from "prop-types";
 
-import { isReactLocalization } from './localization';
-import { parseMarkup } from './markup';
-import VOID_ELEMENTS from '../vendor/voidElementTags';
+import { isReactLocalization } from "./localization";
+import { parseMarkup } from "./markup";
+import VOID_ELEMENTS from "../vendor/voidElementTags";
 
 /*
  * Prepare props passed to `Localized` for formatting.
@@ -13,7 +13,7 @@ function toArguments(props) {
   const elems = {};
 
   for (const [propname, propval] of Object.entries(props)) {
-    if (propname.startsWith('$')) {
+    if (propname.startsWith("$")) {
       const name = propname.substr(1);
       args[name] = propval;
     } else if (isValidElement(propval)) {
@@ -129,7 +129,7 @@ export default class Localized extends Component {
 
     // If the message value doesn't contain any markup, insert it as the only
     // child of the wrapped component.
-    if (!messageValue.includes('<')) {
+    if (!messageValue.includes("<")) {
       return cloneElement(elem, localizedProps, messageValue);
     }
 

--- a/fluent-react/src/markup.js
+++ b/fluent-react/src/markup.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 
-const TEMPLATE = document.createElement('template');
+const TEMPLATE = document.createElement("template");
 
 export function parseMarkup(str) {
   TEMPLATE.innerHTML = str;

--- a/fluent-react/src/provider.js
+++ b/fluent-react/src/provider.js
@@ -1,7 +1,7 @@
-import { Component, Children } from 'react';
-import PropTypes from 'prop-types';
+import { Component, Children } from "react";
+import PropTypes from "prop-types";
 
-import ReactLocalization, { isReactLocalization} from './localization';
+import ReactLocalization, { isReactLocalization} from "./localization";
 
 /*
  * The Provider component for the `ReactLocalization` class.
@@ -27,11 +27,11 @@ export default class LocalizationProvider extends Component {
     const { messages } = props;
 
     if (messages === undefined) {
-      throw new Error('LocalizationProvider must receive the messages prop.');
+      throw new Error("LocalizationProvider must receive the messages prop.");
     }
 
     if (!messages[Symbol.iterator]) {
-      throw new Error('The messages prop must be an iterable.');
+      throw new Error("The messages prop must be an iterable.");
     }
 
     this.l10n = new ReactLocalization(messages);

--- a/fluent-react/src/with_localization.js
+++ b/fluent-react/src/with_localization.js
@@ -1,6 +1,6 @@
-import { createElement, Component } from 'react';
+import { createElement, Component } from "react";
 
-import { isReactLocalization } from './localization';
+import { isReactLocalization } from "./localization";
 
 export default function withLocalization(Inner) {
   class WithLocalization extends Component {
@@ -40,5 +40,5 @@ export default function withLocalization(Inner) {
 }
 
 function displayName(component) {
-  return component.displayName || component.name || 'Component';
+  return component.displayName || component.name || "Component";
 }

--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -21,7 +21,7 @@ class SyntaxNode extends BaseNode {
 export class Resource extends SyntaxNode {
   constructor(body = []) {
     super();
-    this.type = 'Resource';
+    this.type = "Resource";
     this.body = body;
   }
 }
@@ -29,7 +29,7 @@ export class Resource extends SyntaxNode {
 export class Entry extends SyntaxNode {
   constructor() {
     super();
-    this.type = 'Entry';
+    this.type = "Entry";
     this.annotations = [];
   }
 
@@ -41,7 +41,7 @@ export class Entry extends SyntaxNode {
 export class Message extends Entry {
   constructor(id, value = null, attributes = [], comment = null) {
     super();
-    this.type = 'Message';
+    this.type = "Message";
     this.id = id;
     this.value = value;
     this.attributes = attributes;
@@ -52,7 +52,7 @@ export class Message extends Entry {
 export class Term extends Entry {
   constructor(id, value, attributes = [], comment = null) {
     super();
-    this.type = 'Term';
+    this.type = "Term";
     this.id = id;
     this.value = value;
     this.attributes = attributes;
@@ -63,7 +63,7 @@ export class Term extends Entry {
 export class Pattern extends SyntaxNode {
   constructor(elements) {
     super();
-    this.type = 'Pattern';
+    this.type = "Pattern";
     this.elements = elements;
   }
 }
@@ -71,7 +71,7 @@ export class Pattern extends SyntaxNode {
 export class TextElement extends SyntaxNode {
   constructor(value) {
     super();
-    this.type = 'TextElement';
+    this.type = "TextElement";
     this.value = value;
   }
 }
@@ -79,7 +79,7 @@ export class TextElement extends SyntaxNode {
 export class Placeable extends SyntaxNode {
   constructor(expression) {
     super();
-    this.type = 'Placeable';
+    this.type = "Placeable";
     this.expression = expression;
   }
 }
@@ -87,14 +87,14 @@ export class Placeable extends SyntaxNode {
 export class Expression extends SyntaxNode {
   constructor() {
     super();
-    this.type = 'Expression';
+    this.type = "Expression";
   }
 }
 
 export class StringExpression extends Expression {
   constructor(value) {
     super();
-    this.type = 'StringExpression';
+    this.type = "StringExpression";
     this.value = value;
   }
 }
@@ -102,7 +102,7 @@ export class StringExpression extends Expression {
 export class NumberExpression extends Expression {
   constructor(value) {
     super();
-    this.type = 'NumberExpression';
+    this.type = "NumberExpression";
     this.value = value;
   }
 }
@@ -110,7 +110,7 @@ export class NumberExpression extends Expression {
 export class MessageReference extends Expression {
   constructor(id) {
     super();
-    this.type = 'MessageReference';
+    this.type = "MessageReference";
     this.id = id;
   }
 }
@@ -118,7 +118,7 @@ export class MessageReference extends Expression {
 export class ExternalArgument extends Expression {
   constructor(id) {
     super();
-    this.type = 'ExternalArgument';
+    this.type = "ExternalArgument";
     this.id = id;
   }
 }
@@ -126,7 +126,7 @@ export class ExternalArgument extends Expression {
 export class SelectExpression extends Expression {
   constructor(expression, variants) {
     super();
-    this.type = 'SelectExpression';
+    this.type = "SelectExpression";
     this.expression = expression;
     this.variants = variants;
   }
@@ -135,7 +135,7 @@ export class SelectExpression extends Expression {
 export class AttributeExpression extends Expression {
   constructor(id, name) {
     super();
-    this.type = 'AttributeExpression';
+    this.type = "AttributeExpression";
     this.id = id;
     this.name = name;
   }
@@ -144,7 +144,7 @@ export class AttributeExpression extends Expression {
 export class VariantExpression extends Expression {
   constructor(id, key) {
     super();
-    this.type = 'VariantExpression';
+    this.type = "VariantExpression";
     this.id = id;
     this.key = key;
   }
@@ -153,7 +153,7 @@ export class VariantExpression extends Expression {
 export class CallExpression extends Expression {
   constructor(callee, args = []) {
     super();
-    this.type = 'CallExpression';
+    this.type = "CallExpression";
     this.callee = callee;
     this.args = args;
   }
@@ -162,7 +162,7 @@ export class CallExpression extends Expression {
 export class Attribute extends SyntaxNode {
   constructor(id, value) {
     super();
-    this.type = 'Attribute';
+    this.type = "Attribute";
     this.id = id;
     this.value = value;
   }
@@ -171,7 +171,7 @@ export class Attribute extends SyntaxNode {
 export class Variant extends SyntaxNode {
   constructor(key, value, def = false) {
     super();
-    this.type = 'Variant';
+    this.type = "Variant";
     this.key = key;
     this.value = value;
     this.default = def;
@@ -181,7 +181,7 @@ export class Variant extends SyntaxNode {
 export class NamedArgument extends SyntaxNode {
   constructor(name, val) {
     super();
-    this.type = 'NamedArgument';
+    this.type = "NamedArgument";
     this.name = name;
     this.val = val;
   }
@@ -190,7 +190,7 @@ export class NamedArgument extends SyntaxNode {
 export class Identifier extends SyntaxNode {
   constructor(name) {
     super();
-    this.type = 'Identifier';
+    this.type = "Identifier";
     this.name = name;
   }
 }
@@ -198,14 +198,14 @@ export class Identifier extends SyntaxNode {
 export class VariantName extends Identifier {
   constructor(name) {
     super(name);
-    this.type = 'VariantName';
+    this.type = "VariantName";
   }
 }
 
 export class BaseComment extends Entry {
   constructor(content) {
     super();
-    this.type = 'BaseComment';
+    this.type = "BaseComment";
     this.content = content;
   }
 }
@@ -213,34 +213,34 @@ export class BaseComment extends Entry {
 export class Comment extends BaseComment {
   constructor(content) {
     super(content);
-    this.type = 'Comment';
+    this.type = "Comment";
   }
 }
 
 export class GroupComment extends BaseComment {
   constructor(content) {
     super(content);
-    this.type = 'GroupComment';
+    this.type = "GroupComment";
   }
 }
 export class ResourceComment extends BaseComment {
   constructor(content) {
     super(content);
-    this.type = 'ResourceComment';
+    this.type = "ResourceComment";
   }
 }
 
 export class Function extends Identifier {
   constructor(name) {
     super(name);
-    this.type = 'Function';
+    this.type = "Function";
   }
 }
 
 export class Junk extends Entry {
   constructor(content) {
     super();
-    this.type = 'Junk';
+    this.type = "Junk";
     this.content = content;
   }
 }
@@ -248,7 +248,7 @@ export class Junk extends Entry {
 export class Span extends BaseNode {
   constructor(start, end) {
     super();
-    this.type = 'Span';
+    this.type = "Span";
     this.start = start;
     this.end = end;
   }
@@ -257,7 +257,7 @@ export class Span extends BaseNode {
 export class Annotation extends SyntaxNode {
   constructor(code, args = [], message) {
     super();
-    this.type = 'Annotation';
+    this.type = "Annotation";
     this.code = code;
     this.args = args;
     this.message = message;

--- a/fluent-syntax/src/errors.js
+++ b/fluent-syntax/src/errors.js
@@ -10,54 +10,54 @@ export class ParseError extends Error {
 /* eslint-disable complexity */
 function getErrorMessage(code, args) {
   switch (code) {
-    case 'E0001':
-      return 'Generic error';
-    case 'E0002':
-      return 'Expected an entry start';
-    case 'E0003': {
+    case "E0001":
+      return "Generic error";
+    case "E0002":
+      return "Expected an entry start";
+    case "E0003": {
       const [token] = args;
       return `Expected token: "${token}"`;
     }
-    case 'E0004': {
+    case "E0004": {
       const [range] = args;
       return `Expected a character from range: "${range}"`;
     }
-    case 'E0005': {
+    case "E0005": {
       const [id] = args;
       return `Expected message "${id}" to have a value or attributes`;
     }
-    case 'E0006': {
+    case "E0006": {
       const [id] = args;
       return `Expected term "${id}" to have a value`;
     }
-    case 'E0007':
-      return 'Keyword cannot end with a whitespace';
-    case 'E0008':
-      return 'The callee has to be a simple, upper-case identifier';
-    case 'E0009':
-      return 'The key has to be a simple identifier';
-    case 'E0010':
-      return 'Expected one of the variants to be marked as default (*)';
-    case 'E0011':
+    case "E0007":
+      return "Keyword cannot end with a whitespace";
+    case "E0008":
+      return "The callee has to be a simple, upper-case identifier";
+    case "E0009":
+      return "The key has to be a simple identifier";
+    case "E0010":
+      return "Expected one of the variants to be marked as default (*)";
+    case "E0011":
       return 'Expected at least one variant after "->"';
-    case 'E0012':
-      return 'Expected value';
-    case 'E0013':
-      return 'Expected variant key';
-    case 'E0014':
-      return 'Expected literal';
-    case 'E0015':
-      return 'Only one variant can be marked as default (*)';
-    case 'E0016':
-      return 'Message references cannot be used as selectors';
-    case 'E0017':
-      return 'Variants cannot be used as selectors';
-    case 'E0018':
-      return 'Attributes of messages cannot be used as selectors';
-    case 'E0019':
-      return 'Attributes of terms cannot be used as placeables';
-    case 'E0020':
-      return 'Unterminated string expression';
+    case "E0012":
+      return "Expected value";
+    case "E0013":
+      return "Expected variant key";
+    case "E0014":
+      return "Expected literal";
+    case "E0015":
+      return "Only one variant can be marked as default (*)";
+    case "E0016":
+      return "Message references cannot be used as selectors";
+    case "E0017":
+      return "Variants cannot be used as selectors";
+    case "E0018":
+      return "Attributes of messages cannot be used as selectors";
+    case "E0019":
+      return "Attributes of terms cannot be used as placeables";
+    case "E0020":
+      return "Unterminated string expression";
     default:
       return code;
   }

--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -1,11 +1,11 @@
 /* eslint no-magic-numbers: "off" */
 
-import { ParserStream } from './stream';
-import { ParseError } from './errors';
-import { includes } from './util';
+import { ParserStream } from "./stream";
+import { ParseError } from "./errors";
+import { includes } from "./util";
 
-const INLINE_WS = [' ', '\t'];
-const SPECIAL_LINE_START_CHARS = ['}', '.', '[', '*'];
+const INLINE_WS = [" ", "\t"];
+const SPECIAL_LINE_START_CHARS = ["}", ".", "[", "*"];
 
 export class FTLParserStream extends ParserStream {
   skipInlineWS() {
@@ -31,7 +31,7 @@ export class FTLParserStream extends ParserStream {
     while (true) {
       this.peekInlineWS();
 
-      if (this.currentPeekIs('\n')) {
+      if (this.currentPeekIs("\n")) {
         this.skipToPeek();
         this.next();
       } else {
@@ -47,7 +47,7 @@ export class FTLParserStream extends ParserStream {
 
       this.peekInlineWS();
 
-      if (this.currentPeekIs('\n')) {
+      if (this.currentPeekIs("\n")) {
         this.peek();
       } else {
         this.resetPeek(lineStart);
@@ -67,18 +67,18 @@ export class FTLParserStream extends ParserStream {
       return true;
     }
 
-    if (ch === '\n') {
+    if (ch === "\n") {
       // Unicode Character 'SYMBOL FOR NEWLINE' (U+2424)
-      throw new ParseError('E0003', '\u2424');
+      throw new ParseError("E0003", "\u2424");
     }
 
-    throw new ParseError('E0003', ch);
+    throw new ParseError("E0003", ch);
   }
 
   expectIndent() {
-    this.expectChar('\n');
+    this.expectChar("\n");
     this.skipBlankLines();
-    this.expectChar(' ');
+    this.expectChar(" ");
     this.skipInlineWS();
   }
 
@@ -110,7 +110,7 @@ export class FTLParserStream extends ParserStream {
   }
 
   isEntryIDStart() {
-    if (this.currentIs('-')) {
+    if (this.currentIs("-")) {
       this.peek();
     }
 
@@ -121,7 +121,7 @@ export class FTLParserStream extends ParserStream {
   }
 
   isNumberStart() {
-    if (this.currentIs('-')) {
+    if (this.currentIs("-")) {
       this.peek();
     }
 
@@ -140,7 +140,7 @@ export class FTLParserStream extends ParserStream {
     const ch = this.currentPeek();
 
     // Inline Patterns may start with any char.
-    if (ch !== undefined && ch !== '\n') {
+    if (ch !== undefined && ch !== "\n") {
       return true;
     }
 
@@ -148,15 +148,15 @@ export class FTLParserStream extends ParserStream {
   }
 
   isPeekNextLineZeroFourStyleComment() {
-    if (!this.currentPeekIs('\n')) {
+    if (!this.currentPeekIs("\n")) {
       return false;
     }
 
     this.peek();
 
-    if (this.currentPeekIs('/')) {
+    if (this.currentPeekIs("/")) {
       this.peek();
-      if (this.currentPeekIs('/')) {
+      if (this.currentPeekIs("/")) {
         this.resetPeek();
         return true;
       }
@@ -171,7 +171,7 @@ export class FTLParserStream extends ParserStream {
   //  1 - group comment
   //  2 - resource comment
   isPeekNextLineComment(level = -1) {
-    if (!this.currentPeekIs('\n')) {
+    if (!this.currentPeekIs("\n")) {
       return false;
     }
 
@@ -179,7 +179,7 @@ export class FTLParserStream extends ParserStream {
 
     while (i <= level || (level === -1 && i < 3)) {
       this.peek();
-      if (!this.currentPeekIs('#')) {
+      if (!this.currentPeekIs("#")) {
         if (i !== level && level !== -1) {
           this.resetPeek();
           return false;
@@ -190,7 +190,7 @@ export class FTLParserStream extends ParserStream {
     }
 
     this.peek();
-    if ([' ', '\n'].includes(this.currentPeek())) {
+    if ([" ", "\n"].includes(this.currentPeek())) {
       this.resetPeek();
       return true;
     }
@@ -200,7 +200,7 @@ export class FTLParserStream extends ParserStream {
   }
 
   isPeekNextLineVariantStart() {
-    if (!this.currentPeekIs('\n')) {
+    if (!this.currentPeekIs("\n")) {
       return false;
     }
 
@@ -217,11 +217,11 @@ export class FTLParserStream extends ParserStream {
       return false;
     }
 
-    if (this.currentPeekIs('*')) {
+    if (this.currentPeekIs("*")) {
       this.peek();
     }
 
-    if (this.currentPeekIs('[') && !this.peekCharIs('[')) {
+    if (this.currentPeekIs("[") && !this.peekCharIs("[")) {
       this.resetPeek();
       return true;
     }
@@ -230,7 +230,7 @@ export class FTLParserStream extends ParserStream {
   }
 
   isPeekNextLineAttributeStart() {
-    if (!this.currentPeekIs('\n')) {
+    if (!this.currentPeekIs("\n")) {
       return false;
     }
 
@@ -247,7 +247,7 @@ export class FTLParserStream extends ParserStream {
       return false;
     }
 
-    if (this.currentPeekIs('.')) {
+    if (this.currentPeekIs(".")) {
       this.resetPeek();
       return true;
     }
@@ -257,7 +257,7 @@ export class FTLParserStream extends ParserStream {
   }
 
   isPeekNextLinePatternStart() {
-    if (!this.currentPeekIs('\n')) {
+    if (!this.currentPeekIs("\n")) {
       return false;
     }
 
@@ -285,13 +285,13 @@ export class FTLParserStream extends ParserStream {
 
   skipToNextEntryStart() {
     while (this.ch) {
-      if (this.currentIs('\n') && !this.peekCharIs('\n')) {
+      if (this.currentIs("\n") && !this.peekCharIs("\n")) {
         this.next();
         if (this.ch === undefined ||
             this.isEntryIDStart() ||
-            this.currentIs('#') ||
-            (this.currentIs('/') && this.peekCharIs('/')) ||
-            (this.currentIs('[') && this.peekCharIs('['))) {
+            this.currentIs("#") ||
+            (this.currentIs("/") && this.peekCharIs("/")) ||
+            (this.currentIs("[") && this.peekCharIs("["))) {
           break;
         }
       }
@@ -300,9 +300,9 @@ export class FTLParserStream extends ParserStream {
   }
 
   takeIDStart(allowTerm) {
-    if (allowTerm && this.currentIs('-')) {
+    if (allowTerm && this.currentIs("-")) {
       this.next();
-      return '-';
+      return "-";
     }
 
     if (this.isCharIDStart(this.ch)) {
@@ -311,8 +311,8 @@ export class FTLParserStream extends ParserStream {
       return ret;
     }
 
-    const allowedRange = allowTerm ? 'a-zA-Z-' : 'a-zA-Z';
-    throw new ParseError('E0004', allowedRange);
+    const allowedRange = allowTerm ? "a-zA-Z-" : "a-zA-Z";
+    throw new ParseError("E0004", allowedRange);
   }
 
   takeIDChar() {

--- a/fluent-syntax/src/index.js
+++ b/fluent-syntax/src/index.js
@@ -1,7 +1,7 @@
-import FluentParser from './parser';
-import FluentSerializer from './serializer';
+import FluentParser from "./parser";
+import FluentSerializer from "./serializer";
 
-export * from './ast';
+export * from "./ast";
 export { FluentParser, FluentSerializer };
 
 export function parse(source, opts) {
@@ -16,7 +16,7 @@ export function serialize(resource, opts) {
 
 export function lineOffset(source, pos) {
   // Subtract 1 to get the offset.
-  return source.substring(0, pos).split('\n').length - 1;
+  return source.substring(0, pos).split("\n").length - 1;
 }
 
 export function columnOffset(source, pos) {
@@ -24,7 +24,7 @@ export function columnOffset(source, pos) {
   // pos.  This allows us to correctly handle ths case where the character at
   // pos  is a line break as well.
   const fromIndex = pos - 1;
-  const prevLineBreak = source.lastIndexOf('\n', fromIndex);
+  const prevLineBreak = source.lastIndexOf("\n", fromIndex);
 
   // pos is a position in the first line of source.
   if (prevLineBreak === -1) {

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -1,8 +1,8 @@
 /*  eslint no-magic-numbers: [0]  */
 
-import * as AST from './ast';
-import { FTLParserStream } from './ftlstream';
-import { ParseError } from './errors';
+import * as AST from "./ast";
+import { FTLParserStream } from "./ftlstream";
+import { ParseError } from "./errors";
 
 
 function withSpan(fn) {
@@ -21,7 +21,7 @@ function withSpan(fn) {
     }
 
     // Spans of Messages and Sections should include the attached Comment.
-    if (node.type === 'Message') {
+    if (node.type === "Message") {
       if (node.comment !== null) {
         start = node.comment.span.start;
       }
@@ -42,11 +42,11 @@ export default class FluentParser {
 
     // Poor man's decorators.
     [
-      'getComment', 'getMessage', 'getAttribute', 'getIdentifier',
-      'getVariant', 'getVariantName', 'getNumber', 'getPattern',
-      'getTextElement', 'getPlaceable', 'getExpression',
-      'getSelectorExpression', 'getCallArg', 'getString', 'getLiteral',
-      'getGroupCommentFromSection'
+      "getComment", "getMessage", "getAttribute", "getIdentifier",
+      "getVariant", "getVariantName", "getNumber", "getPattern",
+      "getTextElement", "getPlaceable", "getExpression",
+      "getSelectorExpression", "getCallArg", "getString", "getLiteral",
+      "getGroupCommentFromSection"
     ].forEach(
       name => this[name] = withSpan(this[name])
     );
@@ -66,7 +66,7 @@ export default class FluentParser {
         continue;
       }
 
-      if (entry.type === 'Comment' &&
+      if (entry.type === "Comment" &&
         ps.lastCommentZeroFourSyntax && entries.length === 0) {
         const comment = new AST.ResourceComment(entry.content);
         comment.span = entry.span;
@@ -124,16 +124,16 @@ export default class FluentParser {
   getEntry(ps) {
     let comment;
 
-    if (ps.currentIs('/') || ps.currentIs('#')) {
+    if (ps.currentIs("/") || ps.currentIs("#")) {
       comment = this.getComment(ps);
 
       // The Comment content doesn't include the trailing newline. Consume
       // this newline here to be ready for the next entry.  undefined stands
       // for EOF.
-      ps.expectChar(ps.current() ? '\n' : undefined);
+      ps.expectChar(ps.current() ? "\n" : undefined);
     }
 
-    if (ps.currentIs('[')) {
+    if (ps.currentIs("[")) {
       const groupComment = this.getGroupCommentFromSection(ps, comment);
       if (comment && this.withSpans) {
         // The Group Comment should start where the section comment starts.
@@ -142,7 +142,7 @@ export default class FluentParser {
       return groupComment;
     }
 
-    if (ps.isEntryIDStart() && (!comment || comment.type === 'Comment')) {
+    if (ps.isEntryIDStart() && (!comment || comment.type === "Comment")) {
       return this.getMessage(ps, comment);
     }
 
@@ -150,28 +150,28 @@ export default class FluentParser {
       return comment;
     }
 
-    throw new ParseError('E0002');
+    throw new ParseError("E0002");
   }
 
   getZeroFourStyleComment(ps) {
-    ps.expectChar('/');
-    ps.expectChar('/');
-    ps.takeCharIf(' ');
+    ps.expectChar("/");
+    ps.expectChar("/");
+    ps.takeCharIf(" ");
 
-    let content = '';
+    let content = "";
 
     while (true) {
       let ch;
-      while ((ch = ps.takeChar(x => x !== '\n'))) {
+      while ((ch = ps.takeChar(x => x !== "\n"))) {
         content += ch;
       }
 
       if (ps.isPeekNextLineZeroFourStyleComment()) {
-        content += '\n';
+        content += "\n";
         ps.next();
-        ps.expectChar('/');
-        ps.expectChar('/');
-        ps.takeCharIf(' ');
+        ps.expectChar("/");
+        ps.expectChar("/");
+        ps.takeCharIf(" ");
       } else {
         break;
       }
@@ -183,7 +183,7 @@ export default class FluentParser {
   }
 
   getComment(ps) {
-    if (ps.currentIs('/')) {
+    if (ps.currentIs("/")) {
       return this.getZeroFourStyleComment(ps);
     }
 
@@ -191,11 +191,11 @@ export default class FluentParser {
     // 1 - group comment
     // 2 - resource comment
     let level = -1;
-    let content = '';
+    let content = "";
 
     while (true) {
       let i = -1;
-      while (ps.currentIs('#') && (i < (level === -1 ? 2 : level))) {
+      while (ps.currentIs("#") && (i < (level === -1 ? 2 : level))) {
         ps.next();
         i++;
       }
@@ -204,16 +204,16 @@ export default class FluentParser {
         level = i;
       }
 
-      if (!ps.currentIs('\n')) {
-        ps.expectChar(' ');
+      if (!ps.currentIs("\n")) {
+        ps.expectChar(" ");
         let ch;
-        while ((ch = ps.takeChar(x => x !== '\n'))) {
+        while ((ch = ps.takeChar(x => x !== "\n"))) {
           content += ch;
         }
       }
 
       if (ps.isPeekNextLineComment(level, false)) {
-        content += '\n';
+        content += "\n";
         ps.next();
       } else {
         break;
@@ -236,8 +236,8 @@ export default class FluentParser {
   }
 
   getGroupCommentFromSection(ps, comment) {
-    ps.expectChar('[');
-    ps.expectChar('[');
+    ps.expectChar("[");
+    ps.expectChar("[");
 
     ps.skipInlineWS();
 
@@ -245,8 +245,8 @@ export default class FluentParser {
 
     ps.skipInlineWS();
 
-    ps.expectChar(']');
-    ps.expectChar(']');
+    ps.expectChar("]");
+    ps.expectChar("]");
 
     if (comment) {
       return new AST.GroupComment(comment.content);
@@ -254,7 +254,7 @@ export default class FluentParser {
 
     // A Section without a comment is like an empty Group Comment. Semantically
     // it ends the previous group and starts a new one.
-    return new AST.GroupComment('');
+    return new AST.GroupComment("");
   }
 
   getMessage(ps, comment) {
@@ -267,7 +267,7 @@ export default class FluentParser {
 
     // XXX Syntax 0.4 compatibility.
     // XXX Replace with ps.expectChar('=').
-    if (ps.currentIs('=')) {
+    if (ps.currentIs("=")) {
       ps.next();
 
       if (ps.isPeekPatternStart()) {
@@ -276,32 +276,32 @@ export default class FluentParser {
       }
     }
 
-    if (id.name.startsWith('-') && pattern === undefined) {
-      throw new ParseError('E0006', id.name);
+    if (id.name.startsWith("-") && pattern === undefined) {
+      throw new ParseError("E0006", id.name);
     }
 
     if (ps.isPeekNextLineAttributeStart()) {
       attrs = this.getAttributes(ps);
     }
 
-    if (id.name.startsWith('-')) {
+    if (id.name.startsWith("-")) {
       return new AST.Term(id, pattern, attrs, comment);
     }
 
     if (pattern === undefined && attrs === undefined) {
-      throw new ParseError('E0005', id.name);
+      throw new ParseError("E0005", id.name);
     }
 
     return new AST.Message(id, pattern, attrs, comment);
   }
 
   getAttribute(ps) {
-    ps.expectChar('.');
+    ps.expectChar(".");
 
     const key = this.getIdentifier(ps);
 
     ps.skipInlineWS();
-    ps.expectChar('=');
+    ps.expectChar("=");
 
     if (ps.isPeekPatternStart()) {
       ps.skipIndent();
@@ -309,7 +309,7 @@ export default class FluentParser {
       return new AST.Attribute(key, value);
     }
 
-    throw new ParseError('E0012');
+    throw new ParseError("E0012");
   }
 
   getAttributes(ps) {
@@ -332,7 +332,7 @@ export default class FluentParser {
   }
 
   getIdentifier(ps, allowTerm = false) {
-    let name = '';
+    let name = "";
     name += ps.takeIDStart(allowTerm);
 
     let ch;
@@ -347,7 +347,7 @@ export default class FluentParser {
     const ch = ps.current();
 
     if (!ch) {
-      throw new ParseError('E0013');
+      throw new ParseError("E0013");
     }
 
     const cc = ch.charCodeAt(0);
@@ -362,20 +362,20 @@ export default class FluentParser {
   getVariant(ps, hasDefault) {
     let defaultIndex = false;
 
-    if (ps.currentIs('*')) {
+    if (ps.currentIs("*")) {
       if (hasDefault) {
-        throw new ParseError('E0015');
+        throw new ParseError("E0015");
       }
       ps.next();
       defaultIndex = true;
       hasDefault = true;
     }
 
-    ps.expectChar('[');
+    ps.expectChar("[");
 
     const key = this.getVariantKey(ps);
 
-    ps.expectChar(']');
+    ps.expectChar("]");
 
     if (ps.isPeekPatternStart()) {
       ps.skipIndent();
@@ -383,7 +383,7 @@ export default class FluentParser {
       return new AST.Variant(key, value, defaultIndex);
     }
 
-    throw new ParseError('E0012');
+    throw new ParseError("E0012");
   }
 
   getVariants(ps) {
@@ -406,14 +406,14 @@ export default class FluentParser {
     }
 
     if (!hasDefault) {
-      throw new ParseError('E0010');
+      throw new ParseError("E0010");
     }
 
     return variants;
   }
 
   getVariantName(ps) {
-    let name = '';
+    let name = "";
 
     name += ps.takeIDStart(false);
 
@@ -430,7 +430,7 @@ export default class FluentParser {
   }
 
   getDigits(ps) {
-    let num = '';
+    let num = "";
 
     let ch;
     while ((ch = ps.takeDigit())) {
@@ -438,24 +438,24 @@ export default class FluentParser {
     }
 
     if (num.length === 0) {
-      throw new ParseError('E0004', '0-9');
+      throw new ParseError("E0004", "0-9");
     }
 
     return num;
   }
 
   getNumber(ps) {
-    let num = '';
+    let num = "";
 
-    if (ps.currentIs('-')) {
-      num += '-';
+    if (ps.currentIs("-")) {
+      num += "-";
       ps.next();
     }
 
     num = `${num}${this.getDigits(ps)}`;
 
-    if (ps.currentIs('.')) {
-      num += '.';
+    if (ps.currentIs(".")) {
+      num += ".";
       ps.next();
       num = `${num}${this.getDigits(ps)}`;
     }
@@ -472,11 +472,11 @@ export default class FluentParser {
 
       // The end condition for getPattern's while loop is a newline
       // which is not followed by a valid pattern continuation.
-      if (ch === '\n' && !ps.isPeekNextLinePatternStart()) {
+      if (ch === "\n" && !ps.isPeekNextLinePatternStart()) {
         break;
       }
 
-      if (ch === '{') {
+      if (ch === "{") {
         const element = this.getPlaceable(ps);
         elements.push(element);
       } else {
@@ -489,15 +489,15 @@ export default class FluentParser {
   }
 
   getTextElement(ps) {
-    let buffer = '';
+    let buffer = "";
 
     let ch;
     while ((ch = ps.current())) {
-      if (ch === '{') {
+      if (ch === "{") {
         return new AST.TextElement(buffer);
       }
 
-      if (ch === '\n') {
+      if (ch === "\n") {
         if (!ps.isPeekNextLinePatternStart()) {
           return new AST.TextElement(buffer);
         }
@@ -510,10 +510,10 @@ export default class FluentParser {
         continue;
       }
 
-      if (ch === '\\') {
+      if (ch === "\\") {
         const ch2 = ps.next();
 
-        if (ch2 === '{' || ch2 === '"') {
+        if (ch2 === "{" || ch2 === '"') {
           buffer += ch2;
         } else {
           buffer += ch + ch2;
@@ -530,9 +530,9 @@ export default class FluentParser {
   }
 
   getPlaceable(ps) {
-    ps.expectChar('{');
+    ps.expectChar("{");
     const expression = this.getExpression(ps);
-    ps.expectChar('}');
+    ps.expectChar("}");
     return new AST.Placeable(expression);
   }
 
@@ -551,25 +551,25 @@ export default class FluentParser {
 
     ps.skipInlineWS();
 
-    if (ps.currentIs('-')) {
+    if (ps.currentIs("-")) {
       ps.peek();
 
-      if (!ps.currentPeekIs('>')) {
+      if (!ps.currentPeekIs(">")) {
         ps.resetPeek();
         return selector;
       }
 
-      if (selector.type === 'MessageReference') {
-        throw new ParseError('E0016');
+      if (selector.type === "MessageReference") {
+        throw new ParseError("E0016");
       }
 
-      if (selector.type === 'AttributeExpression' &&
-          !selector.id.name.startsWith('-')) {
-        throw new ParseError('E0018');
+      if (selector.type === "AttributeExpression" &&
+          !selector.id.name.startsWith("-")) {
+        throw new ParseError("E0018");
       }
 
-      if (selector.type === 'VariantExpression') {
-        throw new ParseError('E0017');
+      if (selector.type === "VariantExpression") {
+        throw new ParseError("E0017");
       }
 
       ps.next();
@@ -580,15 +580,15 @@ export default class FluentParser {
       const variants = this.getVariants(ps);
 
       if (variants.length === 0) {
-        throw new ParseError('E0011');
+        throw new ParseError("E0011");
       }
 
       ps.expectIndent();
 
       return new AST.SelectExpression(selector, variants);
-    } else if (selector.type === 'AttributeExpression' &&
-               selector.id.name.startsWith('-')) {
-      throw new ParseError('E0019');
+    } else if (selector.type === "AttributeExpression" &&
+               selector.id.name.startsWith("-")) {
+      throw new ParseError("E0019");
     }
 
     return selector;
@@ -597,38 +597,38 @@ export default class FluentParser {
   getSelectorExpression(ps) {
     const literal = this.getLiteral(ps);
 
-    if (literal.type !== 'MessageReference') {
+    if (literal.type !== "MessageReference") {
       return literal;
     }
 
     const ch = ps.current();
 
-    if (ch === '.') {
+    if (ch === ".") {
       ps.next();
 
       const attr = this.getIdentifier(ps);
       return new AST.AttributeExpression(literal.id, attr);
     }
 
-    if (ch === '[') {
+    if (ch === "[") {
       ps.next();
 
       const key = this.getVariantKey(ps);
 
-      ps.expectChar(']');
+      ps.expectChar("]");
 
       return new AST.VariantExpression(literal.id, key);
     }
 
-    if (ch === '(') {
+    if (ch === "(") {
       ps.next();
 
       const args = this.getCallArgs(ps);
 
-      ps.expectChar(')');
+      ps.expectChar(")");
 
       if (!/^[A-Z][A-Z_?-]*$/.test(literal.id.name)) {
-        throw new ParseError('E0008');
+        throw new ParseError("E0008");
       }
 
       return new AST.CallExpression(
@@ -645,12 +645,12 @@ export default class FluentParser {
 
     ps.skipInlineWS();
 
-    if (ps.current() !== ':') {
+    if (ps.current() !== ":") {
       return exp;
     }
 
-    if (exp.type !== 'MessageReference') {
-      throw new ParseError('E0009');
+    if (exp.type !== "MessageReference") {
+      throw new ParseError("E0009");
     }
 
     ps.next();
@@ -667,7 +667,7 @@ export default class FluentParser {
     ps.skipInlineWS();
 
     while (true) {
-      if (ps.current() === ')') {
+      if (ps.current() === ")") {
         break;
       }
 
@@ -676,7 +676,7 @@ export default class FluentParser {
 
       ps.skipInlineWS();
 
-      if (ps.current() === ',') {
+      if (ps.current() === ",") {
         ps.next();
         ps.skipInlineWS();
         continue;
@@ -693,21 +693,21 @@ export default class FluentParser {
     } else if (ps.currentIs('"')) {
       return this.getString(ps);
     }
-    throw new ParseError('E0012');
+    throw new ParseError("E0012");
   }
 
   getString(ps) {
-    let val = '';
+    let val = "";
 
     ps.expectChar('"');
 
     let ch;
-    while ((ch = ps.takeChar(x => x !== '"' && x !== '\n'))) {
+    while ((ch = ps.takeChar(x => x !== '"' && x !== "\n"))) {
       val += ch;
     }
 
-    if (ps.currentIs('\n')) {
-      throw new ParseError('E0020');
+    if (ps.currentIs("\n")) {
+      throw new ParseError("E0020");
     }
 
     ps.next();
@@ -720,10 +720,10 @@ export default class FluentParser {
     const ch = ps.current();
 
     if (!ch) {
-      throw new ParseError('E0014');
+      throw new ParseError("E0014");
     }
 
-    if (ch === '$') {
+    if (ch === "$") {
       ps.next();
       const name = this.getIdentifier(ps);
       return new AST.ExternalArgument(name);
@@ -742,6 +742,6 @@ export default class FluentParser {
       return this.getString(ps);
     }
 
-    throw new ParseError('E0014');
+    throw new ParseError("E0014");
   }
 }

--- a/fluent-syntax/src/serializer.js
+++ b/fluent-syntax/src/serializer.js
@@ -1,12 +1,12 @@
-import { includes } from './util';
+import { includes } from "./util";
 
 function indent(content) {
-  return content.split('\n').join('\n    ');
+  return content.split("\n").join("\n    ");
 }
 
 function containNewLine(elems) {
   const withNewLine = elems.filter(
-    elem => (elem.type === 'TextElement' && includes(elem.value, '\n'))
+    elem => (elem.type === "TextElement" && includes(elem.value, "\n"))
   );
   return !!withNewLine.length;
 }
@@ -20,7 +20,7 @@ export default class FluentSerializer {
   }
 
   serialize(resource) {
-    if (resource.type !== 'Resource') {
+    if (resource.type !== "Resource") {
       throw new Error(`Unknown resource type: ${resource.type}`);
     }
 
@@ -28,7 +28,7 @@ export default class FluentSerializer {
     const parts = [];
 
     for (const entry of resource.body) {
-      if (entry.type !== 'Junk' || this.withJunk) {
+      if (entry.type !== "Junk" || this.withJunk) {
         parts.push(this.serializeEntry(entry, state));
         if (!(state & HAS_ENTRIES)) {
           state |= HAS_ENTRIES;
@@ -36,30 +36,30 @@ export default class FluentSerializer {
       }
     }
 
-    return parts.join('');
+    return parts.join("");
   }
 
   serializeEntry(entry, state = 0) {
     switch (entry.type) {
-      case 'Message':
-      case 'Term':
+      case "Message":
+      case "Term":
         return serializeMessage(entry);
-      case 'Comment':
+      case "Comment":
         if (state & HAS_ENTRIES) {
           return `\n${serializeComment(entry)}\n\n`;
         }
         return `${serializeComment(entry)}\n\n`;
-      case 'GroupComment':
+      case "GroupComment":
         if (state & HAS_ENTRIES) {
           return `\n${serializeGroupComment(entry)}\n\n`;
         }
         return `${serializeGroupComment(entry)}\n\n`;
-      case 'ResourceComment':
+      case "ResourceComment":
         if (state & HAS_ENTRIES) {
           return `\n${serializeResourceComment(entry)}\n\n`;
         }
         return `${serializeResourceComment(entry)}\n\n`;
-      case 'Junk':
+      case "Junk":
         return serializeJunk(entry);
       default :
         throw new Error(`Unknown entry type: ${entry.type}`);
@@ -73,23 +73,23 @@ export default class FluentSerializer {
 
 
 function serializeComment(comment) {
-  return comment.content.split('\n').map(
-    line => line.length ? `# ${line}` : '#'
-  ).join('\n');
+  return comment.content.split("\n").map(
+    line => line.length ? `# ${line}` : "#"
+  ).join("\n");
 }
 
 
 function serializeGroupComment(comment) {
-  return comment.content.split('\n').map(
-    line => line.length ? `## ${line}` : '##'
-  ).join('\n');
+  return comment.content.split("\n").map(
+    line => line.length ? `## ${line}` : "##"
+  ).join("\n");
 }
 
 
 function serializeResourceComment(comment) {
-  return comment.content.split('\n').map(
-    line => line.length ? `### ${line}` : '###'
-  ).join('\n');
+  return comment.content.split("\n").map(
+    line => line.length ? `### ${line}` : "###"
+  ).join("\n");
 }
 
 
@@ -103,11 +103,11 @@ function serializeMessage(message) {
 
   if (message.comment) {
     parts.push(serializeComment(message.comment));
-    parts.push('\n');
+    parts.push("\n");
   }
 
   parts.push(serializeIdentifier(message.id));
-  parts.push(' =');
+  parts.push(" =");
 
   if (message.value) {
     parts.push(serializeValue(message.value));
@@ -117,8 +117,8 @@ function serializeMessage(message) {
     parts.push(serializeAttribute(attribute));
   }
 
-  parts.push('\n');
-  return parts.join('');
+  parts.push("\n");
+  return parts.join("");
 }
 
 
@@ -142,15 +142,15 @@ function serializeValue(pattern) {
 
 
 function serializePattern(pattern) {
-  return pattern.elements.map(serializeElement).join('');
+  return pattern.elements.map(serializeElement).join("");
 }
 
 
 function serializeElement(element) {
   switch (element.type) {
-    case 'TextElement':
+    case "TextElement":
       return serializeTextElement(element);
-    case 'Placeable':
+    case "Placeable":
       return serializePlaceable(element);
     default:
       throw new Error(`Unknown element type: ${element.type}`);
@@ -167,9 +167,9 @@ function serializePlaceable(placeable) {
   const expr = placeable.expression;
 
   switch (expr.type) {
-    case 'Placeable':
+    case "Placeable":
       return `{${serializePlaceable(expr)}}`;
-    case 'SelectExpression':
+    case "SelectExpression":
       // Special-case select expression to control the whitespace around the
       // opening and the closing brace.
       return expr.expression
@@ -185,21 +185,21 @@ function serializePlaceable(placeable) {
 
 function serializeExpression(expr) {
   switch (expr.type) {
-    case 'StringExpression':
+    case "StringExpression":
       return serializeStringExpression(expr);
-    case 'NumberExpression':
+    case "NumberExpression":
       return serializeNumberExpression(expr);
-    case 'MessageReference':
+    case "MessageReference":
       return serializeMessageReference(expr);
-    case 'ExternalArgument':
+    case "ExternalArgument":
       return serializeExternalArgument(expr);
-    case 'AttributeExpression':
+    case "AttributeExpression":
       return serializeAttributeExpression(expr);
-    case 'VariantExpression':
+    case "VariantExpression":
       return serializeVariantExpression(expr);
-    case 'CallExpression':
+    case "CallExpression":
       return serializeCallExpression(expr);
-    case 'SelectExpression':
+    case "SelectExpression":
       return serializeSelectExpression(expr);
     default:
       throw new Error(`Unknown expression type: ${expr.type}`);
@@ -239,8 +239,8 @@ function serializeSelectExpression(expr) {
     parts.push(serializeVariant(variant));
   }
 
-  parts.push('\n');
-  return parts.join('');
+  parts.push("\n");
+  return parts.join("");
 }
 
 
@@ -272,14 +272,14 @@ function serializeVariantExpression(expr) {
 
 function serializeCallExpression(expr) {
   const fun = serializeFunction(expr.callee);
-  const args = expr.args.map(serializeCallArgument).join(', ');
+  const args = expr.args.map(serializeCallArgument).join(", ");
   return `${fun}(${args})`;
 }
 
 
 function serializeCallArgument(arg) {
   switch (arg.type) {
-    case 'NamedArgument':
+    case "NamedArgument":
       return serializeNamedArgument(arg);
     default:
       return serializeExpression(arg);
@@ -296,9 +296,9 @@ function serializeNamedArgument(arg) {
 
 function serializeArgumentValue(argval) {
   switch (argval.type) {
-    case 'StringExpression':
+    case "StringExpression":
       return serializeStringExpression(argval);
-    case 'NumberExpression':
+    case "NumberExpression":
       return serializeNumberExpression(argval);
     default:
       throw new Error(`Unknown argument type: ${argval.type}`);
@@ -318,9 +318,9 @@ function serializeVariantName(VariantName) {
 
 function serializeVariantKey(key) {
   switch (key.type) {
-    case 'VariantName':
+    case "VariantName":
       return serializeVariantName(key);
-    case 'NumberExpression':
+    case "NumberExpression":
       return serializeNumberExpression(key);
     default:
       throw new Error(`Unknown variant key type: ${key.type}`);

--- a/fluent-web/src/index.js
+++ b/fluent-web/src/index.js
@@ -1,18 +1,18 @@
 /* eslint-env browser */
 
-import { negotiateLanguages } from 'fluent-langneg';
-import { MessageContext } from 'fluent';
-import { DOMLocalization } from '../../fluent-dom/src/index';
+import { negotiateLanguages } from "fluent-langneg";
+import { MessageContext } from "fluent";
+import { DOMLocalization } from "../../fluent-dom/src/index";
 
 function documentReady() {
   const rs = document.readyState;
-  if (rs === 'interactive' || rs === 'completed') {
+  if (rs === "interactive" || rs === "completed") {
     return Promise.resolve();
   }
 
   return new Promise(
     resolve => document.addEventListener(
-      'readystatechange', resolve, { once: true }
+      "readystatechange", resolve, { once: true }
     )
   );
 }
@@ -20,23 +20,23 @@ function documentReady() {
 function getMeta(elem) {
   return {
     available: elem.querySelector('meta[name="availableLanguages"]')
-      .getAttribute('content')
-      .split(',').map(s => s.trim()),
+      .getAttribute("content")
+      .split(",").map(s => s.trim()),
     default: elem.querySelector('meta[name="defaultLanguage"]')
-      .getAttribute('content'),
+      .getAttribute("content"),
   };
 }
 
 function getResourceLinks(elem) {
   return Array.prototype.map.call(
     elem.querySelectorAll('link[rel="localization"]'),
-    el => el.getAttribute('href')
+    el => el.getAttribute("href")
   );
 }
 
 function fetchSync(url) {
   const xhr = new XMLHttpRequest();
-  xhr.open('GET', url, false);
+  xhr.open("GET", url, false);
   xhr.send(null);
   return xhr.responseText;
 }
@@ -46,7 +46,7 @@ const sync = true;
 async function generateContext(locale, resourceIds) {
   const ctx = new MessageContext([locale]);
   for (const resourceId of resourceIds) {
-    const url = resourceId.replace('{locale}', locale);
+    const url = resourceId.replace("{locale}", locale);
     const source = sync ?
       fetchSync(url) :
       await fetch(url).then(d => d.text());
@@ -75,11 +75,11 @@ const resourceIds = getResourceLinks(document.head);
 document.l10n = new DOMLocalization(
   window, resourceIds, generateMessages
 );
-window.addEventListener('languagechange', document.l10n);
+window.addEventListener("languagechange", document.l10n);
 
 document.l10n.ready = documentReady().then(() => {
   document.l10n.connectRoot(document.documentElement);
   return document.l10n.translateRoots().then(() => {
-    document.body.style.display = 'block';
+    document.body.style.display = "block";
   });
 });

--- a/fluent/src/builtins.js
+++ b/fluent/src/builtins.js
@@ -11,12 +11,12 @@
  * `FluentType`.  Functions must return `FluentType` objects as well.
  */
 
-import { FluentNumber, FluentDateTime } from './types';
+import { FluentNumber, FluentDateTime } from "./types";
 
 export default {
-  'NUMBER': ([arg], opts) =>
+  "NUMBER": ([arg], opts) =>
     new FluentNumber(arg.valueOf(), merge(arg.opts, opts)),
-  'DATETIME': ([arg], opts) =>
+  "DATETIME": ([arg], opts) =>
     new FluentDateTime(arg.valueOf(), merge(arg.opts, opts)),
 };
 

--- a/fluent/src/cached_iterable.js
+++ b/fluent/src/cached_iterable.js
@@ -17,7 +17,7 @@ export default class CachedIterable {
     } else if (Symbol.iterator in Object(iterable)) {
       this.iterator = iterable[Symbol.iterator]();
     } else {
-      throw new TypeError('Argument must implement the iteration protocol.');
+      throw new TypeError("Argument must implement the iteration protocol.");
     }
 
     this.seen = [];

--- a/fluent/src/context.js
+++ b/fluent/src/context.js
@@ -1,5 +1,5 @@
-import resolve from './resolver';
-import parse from './parser';
+import resolve from "./resolver";
+import parse from "./parser";
 
 /**
  * Message contexts are single-language stores of translations.  They are
@@ -110,7 +110,7 @@ export class MessageContext {
   addMessages(source) {
     const [entries, errors] = parse(source);
     for (const id in entries) {
-      if (id.startsWith('-')) {
+      if (id.startsWith("-")) {
         // Identifiers starting with a dash (-) define terms. Terms are private
         // and cannot be retrieved from MessageContext.
         this._terms.set(id, entries[id]);
@@ -154,12 +154,12 @@ export class MessageContext {
    */
   format(message, args, errors) {
     // optimize entities which are simple strings with no attributes
-    if (typeof message === 'string') {
+    if (typeof message === "string") {
       return message;
     }
 
     // optimize simple-string entities with attributes
-    if (typeof message.val === 'string') {
+    if (typeof message.val === "string") {
       return message.val;
     }
 

--- a/fluent/src/index.js
+++ b/fluent/src/index.js
@@ -7,16 +7,16 @@
  *
  */
 
-export { default as _parse } from './parser';
+export { default as _parse } from "./parser";
 
-export { MessageContext } from './context';
+export { MessageContext } from "./context";
 export {
   FluentType as MessageArgument,
   FluentNumber as MessageNumberArgument,
   FluentDateTime as MessageDateTimeArgument,
-} from './types';
+} from "./types";
 
-export { default as CachedIterable } from './cached_iterable';
-export { mapContextSync, mapContextAsync } from './fallback';
+export { default as CachedIterable } from "./cached_iterable";
+export { mapContextSync, mapContextAsync } from "./fallback";
 
-export { ftl } from './util';
+export { ftl } from "./util";

--- a/fluent/src/parser.js
+++ b/fluent/src/parser.js
@@ -66,7 +66,7 @@ class RuntimeParser {
     // The index here should either be at the beginning of the file
     // or right after new line.
     if (this._index !== 0 &&
-        this._source[this._index - 1] !== '\n') {
+        this._source[this._index - 1] !== "\n") {
       throw this.error(`Expected an entry to start
         at the beginning of the file or on a new line.`);
     }
@@ -74,14 +74,14 @@ class RuntimeParser {
     const ch = this._source[this._index];
 
     // We don't care about comments or sections at runtime
-    if (ch === '/' ||
-      (ch === '#' &&
-        [' ', '#', '\n'].includes(this._source[this._index + 1]))) {
+    if (ch === "/" ||
+      (ch === "#" &&
+        [" ", "#", "\n"].includes(this._source[this._index + 1]))) {
       this.skipComment();
       return;
     }
 
-    if (ch === '[') {
+    if (ch === "[") {
       this.skipSection();
       return;
     }
@@ -96,7 +96,7 @@ class RuntimeParser {
    */
   skipSection() {
     this._index += 1;
-    if (this._source[this._index] !== '[') {
+    if (this._source[this._index] !== "[") {
       throw this.error('Expected "[[" to open a section');
     }
 
@@ -106,8 +106,8 @@ class RuntimeParser {
     this.getVariantName();
     this.skipInlineWS();
 
-    if (this._source[this._index] !== ']' ||
-        this._source[this._index + 1] !== ']') {
+    if (this._source[this._index] !== "]" ||
+        this._source[this._index + 1] !== "]") {
       throw this.error('Expected "]]" to close a section');
     }
 
@@ -125,7 +125,7 @@ class RuntimeParser {
 
     this.skipInlineWS();
 
-    if (this._source[this._index] === '=') {
+    if (this._source[this._index] === "=") {
       this._index++;
     }
 
@@ -133,27 +133,27 @@ class RuntimeParser {
 
     const val = this.getPattern();
 
-    if (id.startsWith('-') && val === null) {
-      throw this.error('Expected term to have a value');
+    if (id.startsWith("-") && val === null) {
+      throw this.error("Expected term to have a value");
     }
 
     let attrs = null;
 
-    if (this._source[this._index] === ' ') {
+    if (this._source[this._index] === " ") {
       const lineStart = this._index;
       this.skipInlineWS();
 
-      if (this._source[this._index] === '.') {
+      if (this._source[this._index] === ".") {
         this._index = lineStart;
         attrs = this.getAttributes();
       }
     }
 
-    if (attrs === null && typeof val === 'string') {
+    if (attrs === null && typeof val === "string") {
       this.entries[id] = val;
     } else {
       if (val === null && attrs === null) {
-        throw this.error('Expected message to have a value or attributes');
+        throw this.error("Expected message to have a value or attributes");
       }
 
       this.entries[id] = {};
@@ -175,7 +175,7 @@ class RuntimeParser {
    */
   skipWS() {
     let ch = this._source[this._index];
-    while (ch === ' ' || ch === '\n' || ch === '\t' || ch === '\r') {
+    while (ch === " " || ch === "\n" || ch === "\t" || ch === "\r") {
       ch = this._source[++this._index];
     }
   }
@@ -187,7 +187,7 @@ class RuntimeParser {
    */
   skipInlineWS() {
     let ch = this._source[this._index];
-    while (ch === ' ' || ch === '\t') {
+    while (ch === " " || ch === "\t") {
       ch = this._source[++this._index];
     }
   }
@@ -203,7 +203,7 @@ class RuntimeParser {
 
       this.skipInlineWS();
 
-      if (this._source[this._index] === '\n') {
+      if (this._source[this._index] === "\n") {
         this._index += 1;
       } else {
         this._index = ptr;
@@ -251,7 +251,7 @@ class RuntimeParser {
    * @private
    */
   getVariantName() {
-    let name = '';
+    let name = "";
 
     const start = this._index;
     let cc = this._source.charCodeAt(this._index);
@@ -261,7 +261,7 @@ class RuntimeParser {
         cc === 95 || cc === 32) { // _ <space>
       cc = this._source.charCodeAt(++this._index);
     } else {
-      throw this.error('Expected a keyword (starting with [a-zA-Z_])');
+      throw this.error("Expected a keyword (starting with [a-zA-Z_])");
     }
 
     while ((cc >= 97 && cc <= 122) || // a-z
@@ -281,7 +281,7 @@ class RuntimeParser {
 
     name += this._source.slice(start, this._index);
 
-    return { type: 'varname', name };
+    return { type: "varname", name };
   }
 
   /**
@@ -300,8 +300,8 @@ class RuntimeParser {
         break;
       }
 
-      if (ch === '\n') {
-        throw this.error('Unterminated string expression');
+      if (ch === "\n") {
+        throw this.error("Unterminated string expression");
       }
     }
 
@@ -323,7 +323,7 @@ class RuntimeParser {
     // Then, if either the line contains a placeable opening `{` or the
     // next line starts an indentation, we switch to complex pattern.
     const start = this._index;
-    let eol = this._source.indexOf('\n', this._index);
+    let eol = this._source.indexOf("\n", this._index);
 
     if (eol === -1) {
       eol = this._length;
@@ -332,7 +332,7 @@ class RuntimeParser {
     const firstLineContent = start !== eol ?
       this._source.slice(start, eol) : null;
 
-    if (firstLineContent && firstLineContent.includes('{')) {
+    if (firstLineContent && firstLineContent.includes("{")) {
       return this.getComplexPattern();
     }
 
@@ -340,7 +340,7 @@ class RuntimeParser {
 
     this.skipBlankLines();
 
-    if (this._source[this._index] !== ' ') {
+    if (this._source[this._index] !== " ") {
       // No indentation means we're done with this message. Callers should check
       // if the return value here is null. It may be OK for messages, but not OK
       // for terms, attributes and variants.
@@ -351,7 +351,7 @@ class RuntimeParser {
 
     this.skipInlineWS();
 
-    if (this._source[this._index] === '.') {
+    if (this._source[this._index] === ".") {
       // The pattern is followed by an attribute. Rewind _index to the first
       // column of the current line as expected by getAttributes.
       this._index = lineStart;
@@ -378,7 +378,7 @@ class RuntimeParser {
    */
   /* eslint-disable complexity */
   getComplexPattern() {
-    let buffer = '';
+    let buffer = "";
     const content = [];
     let placeables = 0;
 
@@ -387,7 +387,7 @@ class RuntimeParser {
     while (this._index < this._length) {
       // This block handles multi-line strings combining strings separated
       // by new line.
-      if (ch === '\n') {
+      if (ch === "\n") {
         this._index++;
 
         // We want to capture the start and end pointers
@@ -399,15 +399,15 @@ class RuntimeParser {
         const blankLinesEnd = this._index;
 
 
-        if (this._source[this._index] !== ' ') {
+        if (this._source[this._index] !== " ") {
           break;
         }
         this.skipInlineWS();
 
-        if (this._source[this._index] === '}' ||
-            this._source[this._index] === '[' ||
-            this._source[this._index] === '*' ||
-            this._source[this._index] === '.') {
+        if (this._source[this._index] === "}" ||
+            this._source[this._index] === "[" ||
+            this._source[this._index] === "*" ||
+            this._source[this._index] === ".") {
           this._index = blankLinesEnd;
           break;
         }
@@ -415,17 +415,17 @@ class RuntimeParser {
         buffer += this._source.substring(blankLinesStart, blankLinesEnd);
 
         if (buffer.length || content.length) {
-          buffer += '\n';
+          buffer += "\n";
         }
         ch = this._source[this._index];
         continue;
-      } else if (ch === '\\') {
+      } else if (ch === "\\") {
         const ch2 = this._source[this._index + 1];
-        if (ch2 === '"' || ch2 === '{' || ch2 === '\\') {
+        if (ch2 === '"' || ch2 === "{" || ch2 === "\\") {
           ch = ch2;
           this._index++;
         }
-      } else if (ch === '{') {
+      } else if (ch === "{") {
         // Push the buffer to content array right before placeable
         if (buffer.length) {
           content.push(buffer);
@@ -434,7 +434,7 @@ class RuntimeParser {
           throw this.error(
             `Too many placeables, maximum allowed is ${MAX_PLACEABLES}`);
         }
-        buffer = '';
+        buffer = "";
         content.push(this.getPlaceable());
 
         this._index++;
@@ -475,13 +475,13 @@ class RuntimeParser {
 
     this.skipWS();
 
-    if (this._source[this._index] === '*' ||
-       (this._source[this._index] === '[' &&
-        this._source[this._index + 1] !== ']')) {
+    if (this._source[this._index] === "*" ||
+       (this._source[this._index] === "[" &&
+        this._source[this._index + 1] !== "]")) {
       const variants = this.getVariants();
 
       return {
-        type: 'sel',
+        type: "sel",
         exp: null,
         vars: variants[0],
         def: variants[1]
@@ -498,31 +498,31 @@ class RuntimeParser {
 
     const ch = this._source[this._index];
 
-    if (ch === '}') {
-      if (selector.type === 'attr' && selector.id.name.startsWith('-')) {
+    if (ch === "}") {
+      if (selector.type === "attr" && selector.id.name.startsWith("-")) {
         throw this.error(
-          'Attributes of private messages cannot be interpolated.'
+          "Attributes of private messages cannot be interpolated."
         );
       }
 
       return selector;
     }
 
-    if (ch !== '-' || this._source[this._index + 1] !== '>') {
+    if (ch !== "-" || this._source[this._index + 1] !== ">") {
       throw this.error('Expected "}" or "->"');
     }
 
-    if (selector.type === 'ref') {
-      throw this.error('Message references cannot be used as selectors.');
+    if (selector.type === "ref") {
+      throw this.error("Message references cannot be used as selectors.");
     }
 
-    if (selector.type === 'var') {
-      throw this.error('Variants cannot be used as selectors.');
+    if (selector.type === "var") {
+      throw this.error("Variants cannot be used as selectors.");
     }
 
-    if (selector.type === 'attr' && !selector.id.name.startsWith('-')) {
+    if (selector.type === "attr" && !selector.id.name.startsWith("-")) {
       throw this.error(
-        'Attributes of public messages cannot be used as selectors.'
+        "Attributes of public messages cannot be used as selectors."
       );
     }
 
@@ -531,8 +531,8 @@ class RuntimeParser {
 
     this.skipInlineWS();
 
-    if (this._source[this._index] !== '\n') {
-      throw this.error('Variants should be listed in a new line');
+    if (this._source[this._index] !== "\n") {
+      throw this.error("Variants should be listed in a new line");
     }
 
     this.skipWS();
@@ -540,11 +540,11 @@ class RuntimeParser {
     const variants = this.getVariants();
 
     if (variants[0].length === 0) {
-      throw this.error('Expected members for the select expression');
+      throw this.error("Expected members for the select expression");
     }
 
     return {
-      type: 'sel',
+      type: "sel",
       exp: selector,
       vars: variants[0],
       def: variants[1]
@@ -560,48 +560,48 @@ class RuntimeParser {
   getSelectorExpression() {
     const literal = this.getLiteral();
 
-    if (literal.type !== 'ref') {
+    if (literal.type !== "ref") {
       return literal;
     }
 
-    if (this._source[this._index] === '.') {
+    if (this._source[this._index] === ".") {
       this._index++;
 
       const name = this.getIdentifier();
       this._index++;
       return {
-        type: 'attr',
+        type: "attr",
         id: literal,
         name
       };
     }
 
-    if (this._source[this._index] === '[') {
+    if (this._source[this._index] === "[") {
       this._index++;
 
       const key = this.getVariantKey();
       this._index++;
       return {
-        type: 'var',
+        type: "var",
         id: literal,
         key
       };
     }
 
-    if (this._source[this._index] === '(') {
+    if (this._source[this._index] === "(") {
       this._index++;
       const args = this.getCallArgs();
 
       if (!functionIdentifierRe.test(literal.name)) {
-        throw this.error('Function names must be all upper-case');
+        throw this.error("Function names must be all upper-case");
       }
 
       this._index++;
 
-      literal.type = 'fun';
+      literal.type = "fun";
 
       return {
-        type: 'call',
+        type: "call",
         fun: literal,
         args
       };
@@ -622,7 +622,7 @@ class RuntimeParser {
     while (this._index < this._length) {
       this.skipInlineWS();
 
-      if (this._source[this._index] === ')') {
+      if (this._source[this._index] === ")") {
         return args;
       }
 
@@ -630,12 +630,12 @@ class RuntimeParser {
 
       // MessageReference in this place may be an entity reference, like:
       // `call(foo)`, or, if it's followed by `:` it will be a key-value pair.
-      if (exp.type !== 'ref') {
+      if (exp.type !== "ref") {
         args.push(exp);
       } else {
         this.skipInlineWS();
 
-        if (this._source[this._index] === ':') {
+        if (this._source[this._index] === ":") {
           this._index++;
           this.skipInlineWS();
 
@@ -646,18 +646,18 @@ class RuntimeParser {
           //
           // We don't have to check here if the pattern is quote delimited
           // because that's the only type of string allowed in expressions.
-          if (typeof val === 'string' ||
+          if (typeof val === "string" ||
               Array.isArray(val) ||
-              val.type === 'num') {
+              val.type === "num") {
             args.push({
-              type: 'narg',
+              type: "narg",
               name: exp.name,
               val
             });
           } else {
-            this._index = this._source.lastIndexOf(':', this._index) + 1;
+            this._index = this._source.lastIndexOf(":", this._index) + 1;
             throw this.error(
-              'Expected string in quotes, number.');
+              "Expected string in quotes, number.");
           }
 
         } else {
@@ -667,9 +667,9 @@ class RuntimeParser {
 
       this.skipInlineWS();
 
-      if (this._source[this._index] === ')') {
+      if (this._source[this._index] === ")") {
         break;
-      } else if (this._source[this._index] === ',') {
+      } else if (this._source[this._index] === ",") {
         this._index++;
       } else {
         throw this.error('Expected "," or ")"');
@@ -686,12 +686,12 @@ class RuntimeParser {
    * @private
    */
   getNumber() {
-    let num = '';
+    let num = "";
     let cc = this._source.charCodeAt(this._index);
 
     // The number literal may start with negative sign `-`.
     if (cc === 45) {
-      num += '-';
+      num += "-";
       cc = this._source.charCodeAt(++this._index);
     }
 
@@ -724,7 +724,7 @@ class RuntimeParser {
     }
 
     return {
-      type: 'num',
+      type: "num",
       val: num
     };
   }
@@ -739,12 +739,12 @@ class RuntimeParser {
     const attrs = {};
 
     while (this._index < this._length) {
-      if (this._source[this._index] !== ' ') {
+      if (this._source[this._index] !== " ") {
         break;
       }
       this.skipInlineWS();
 
-      if (this._source[this._index] !== '.') {
+      if (this._source[this._index] !== ".") {
         break;
       }
       this._index++;
@@ -753,7 +753,7 @@ class RuntimeParser {
 
       this.skipInlineWS();
 
-      if (this._source[this._index] !== '=') {
+      if (this._source[this._index] !== "=") {
         throw this.error('Expected "="');
       }
       this._index++;
@@ -763,10 +763,10 @@ class RuntimeParser {
       const val = this.getPattern();
 
       if (val === null) {
-        throw this.error('Expected attribute to have a value');
+        throw this.error("Expected attribute to have a value");
       }
 
-      if (typeof val === 'string') {
+      if (typeof val === "string") {
         attrs[key] = val;
       } else {
         attrs[key] = {
@@ -794,16 +794,16 @@ class RuntimeParser {
     while (this._index < this._length) {
       const ch = this._source[this._index];
 
-      if ((ch !== '[' || this._source[this._index + 1] === '[') &&
-          ch !== '*') {
+      if ((ch !== "[" || this._source[this._index + 1] === "[") &&
+          ch !== "*") {
         break;
       }
-      if (ch === '*') {
+      if (ch === "*") {
         this._index++;
         defaultIndex = index;
       }
 
-      if (this._source[this._index] !== '[') {
+      if (this._source[this._index] !== "[") {
         throw this.error('Expected "["');
       }
 
@@ -816,7 +816,7 @@ class RuntimeParser {
       const val = this.getPattern();
 
       if (val === null) {
-        throw this.error('Expected variant to have a value');
+        throw this.error("Expected variant to have a value");
       }
 
       variants[index++] = {key, val};
@@ -845,7 +845,7 @@ class RuntimeParser {
       literal = this.getVariantName();
     }
 
-    if (this._source[this._index] !== ']') {
+    if (this._source[this._index] !== "]") {
       throw this.error('Expected "]"');
     }
 
@@ -865,7 +865,7 @@ class RuntimeParser {
     if (cc0 === 36) { // $
       this._index++;
       return {
-        type: 'ext',
+        type: "ext",
         name: this.getIdentifier()
       };
     }
@@ -879,7 +879,7 @@ class RuntimeParser {
     if ((cc1 >= 97 && cc1 <= 122) || // a-z
         (cc1 >= 65 && cc1 <= 90)) { // A-Z
       return {
-        type: 'ref',
+        type: "ref",
         name: this.getEntryIdentifier()
       };
     }
@@ -892,7 +892,7 @@ class RuntimeParser {
       return this.getString();
     }
 
-    throw this.error('Expected literal');
+    throw this.error("Expected literal");
   }
 
   /**
@@ -903,15 +903,15 @@ class RuntimeParser {
   skipComment() {
     // At runtime, we don't care about comments so we just have
     // to parse them properly and skip their content.
-    let eol = this._source.indexOf('\n', this._index);
+    let eol = this._source.indexOf("\n", this._index);
 
     while (eol !== -1 &&
-      ((this._source[eol + 1] === '/' && this._source[eol + 2] === '/') ||
-       (this._source[eol + 1] === '#' &&
-         [' ', '#'].includes(this._source[eol + 2])))) {
+      ((this._source[eol + 1] === "/" && this._source[eol + 2] === "/") ||
+       (this._source[eol + 1] === "#" &&
+         [" ", "#"].includes(this._source[eol + 2])))) {
       this._index = eol + 3;
 
-      eol = this._source.indexOf('\n', this._index);
+      eol = this._source.indexOf("\n", this._index);
 
       if (eol === -1) {
         break;
@@ -947,7 +947,7 @@ class RuntimeParser {
     let start = this._index;
 
     while (true) {
-      if (start === 0 || this._source[start - 1] === '\n') {
+      if (start === 0 || this._source[start - 1] === "\n") {
         const cc = this._source.charCodeAt(start);
 
         if ((cc >= 97 && cc <= 122) || // a-z
@@ -958,7 +958,7 @@ class RuntimeParser {
         }
       }
 
-      start = this._source.indexOf('\n', start);
+      start = this._source.indexOf("\n", start);
 
       if (start === -1) {
         this._index = this._length;

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -48,15 +48,15 @@
 
 
 import { FluentType, FluentNone, FluentNumber, FluentDateTime, FluentSymbol }
-  from './types';
-import builtins from './builtins';
+  from "./types";
+import builtins from "./builtins";
 
 // Prevent expansion of too long placeables.
 const MAX_PLACEABLE_LENGTH = 2500;
 
 // Unicode bidi isolation characters.
-const FSI = '\u2068';
-const PDI = '\u2069';
+const FSI = "\u2068";
+const PDI = "\u2069";
 
 
 /**
@@ -79,7 +79,7 @@ function DefaultMember(env, members, def) {
   }
 
   const { errors } = env;
-  errors.push(new RangeError('No default'));
+  errors.push(new RangeError("No default"));
   return new FluentNone();
 }
 
@@ -98,12 +98,12 @@ function DefaultMember(env, members, def) {
  */
 function MessageReference(env, {name}) {
   const { ctx, errors } = env;
-  const message = name.startsWith('-')
+  const message = name.startsWith("-")
     ? ctx._terms.get(name)
     : ctx._messages.get(name);
 
   if (!message) {
-    const err = name.startsWith('-')
+    const err = name.startsWith("-")
       ? new ReferenceError(`Unknown term: ${name}`)
       : new ReferenceError(`Unknown message: ${name}`);
     errors.push(err);
@@ -140,7 +140,7 @@ function VariantExpression(env, {id, key}) {
 
   function isVariantList(node) {
     return Array.isArray(node) &&
-      node[0].type === 'sel' &&
+      node[0].type === "sel" &&
       node[0].exp === null;
   }
 
@@ -257,7 +257,7 @@ function SelectExpression(env, {exp, vars, def}) {
 function Type(env, expr) {
   // A fast-path for strings which are the most common case, and for
   // `FluentNone` which doesn't require any additional logic.
-  if (typeof expr === 'string' || expr instanceof FluentNone) {
+  if (typeof expr === "string" || expr instanceof FluentNone) {
     return expr;
   }
 
@@ -269,29 +269,29 @@ function Type(env, expr) {
 
 
   switch (expr.type) {
-    case 'varname':
+    case "varname":
       return new FluentSymbol(expr.name);
-    case 'num':
+    case "num":
       return new FluentNumber(expr.val);
-    case 'ext':
+    case "ext":
       return ExternalArgument(env, expr);
-    case 'fun':
+    case "fun":
       return FunctionReference(env, expr);
-    case 'call':
+    case "call":
       return CallExpression(env, expr);
-    case 'ref': {
+    case "ref": {
       const message = MessageReference(env, expr);
       return Type(env, message);
     }
-    case 'attr': {
+    case "attr": {
       const attr = AttributeExpression(env, expr);
       return Type(env, attr);
     }
-    case 'var': {
+    case "var": {
       const variant = VariantExpression(env, expr);
       return Type(env, variant);
     }
-    case 'sel': {
+    case "sel": {
       const member = SelectExpression(env, expr);
       return Type(env, member);
     }
@@ -302,7 +302,7 @@ function Type(env, expr) {
       }
 
       const { errors } = env;
-      errors.push(new RangeError('No value'));
+      errors.push(new RangeError("No value"));
       return new FluentNone();
     }
     default:
@@ -339,11 +339,11 @@ function ExternalArgument(env, {name}) {
 
   // Convert the argument to a Fluent type.
   switch (typeof arg) {
-    case 'string':
+    case "string":
       return arg;
-    case 'number':
+    case "number":
       return new FluentNumber(arg);
-    case 'object':
+    case "object":
       if (arg instanceof Date) {
         return new FluentDateTime(arg);
       }
@@ -378,7 +378,7 @@ function FunctionReference(env, {name}) {
     return new FluentNone(`${name}()`);
   }
 
-  if (typeof func !== 'function') {
+  if (typeof func !== "function") {
     errors.push(new TypeError(`Function ${name}() is not callable`));
     return new FluentNone(`${name}()`);
   }
@@ -411,7 +411,7 @@ function CallExpression(env, {fun, args}) {
   const keyargs = {};
 
   for (const arg of args) {
-    if (arg.type === 'narg') {
+    if (arg.type === "narg") {
       keyargs[arg.name] = Type(env, arg.val);
     } else {
       posargs.push(Type(env, arg));
@@ -440,7 +440,7 @@ function Pattern(env, ptn) {
   const { ctx, dirty, errors } = env;
 
   if (dirty.has(ptn)) {
-    errors.push(new RangeError('Cyclic reference'));
+    errors.push(new RangeError("Cyclic reference"));
     return new FluentNone();
   }
 
@@ -449,7 +449,7 @@ function Pattern(env, ptn) {
   const result = [];
 
   for (const elem of ptn) {
-    if (typeof elem === 'string') {
+    if (typeof elem === "string") {
       result.push(elem);
       continue;
     }
@@ -463,7 +463,7 @@ function Pattern(env, ptn) {
     if (part.length > MAX_PLACEABLE_LENGTH) {
       errors.push(
         new RangeError(
-          'Too many characters in placeable ' +
+          "Too many characters in placeable " +
           `(${part.length}, max allowed is ${MAX_PLACEABLE_LENGTH})`
         )
       );
@@ -478,7 +478,7 @@ function Pattern(env, ptn) {
   }
 
   dirty.delete(ptn);
-  return result.join('');
+  return result.join("");
 }
 
 /**

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -41,13 +41,13 @@ export class FluentType {
    * @returns {string}
    */
   toString() {
-    throw new Error('Subclasses of FluentType must implement toString.');
+    throw new Error("Subclasses of FluentType must implement toString.");
   }
 }
 
 export class FluentNone extends FluentType {
   toString() {
-    return this.value || '???';
+    return this.value || "???";
   }
 }
 
@@ -116,7 +116,7 @@ export class FluentSymbol extends FluentType {
   match(ctx, other) {
     if (other instanceof FluentSymbol) {
       return this.value === other.value;
-    } else if (typeof other === 'string') {
+    } else if (typeof other === "string") {
       return this.value === other;
     } else if (other instanceof FluentNumber) {
       const pr = ctx._memoizeIntlObject(

--- a/fluent/src/util.js
+++ b/fluent/src/util.js
@@ -16,12 +16,12 @@ function countIndent(line) {
  */
 export function ftl(strings) {
   const [code] = strings;
-  const lines = code.split('\n').filter(nonBlank);
+  const lines = code.split("\n").filter(nonBlank);
   const indents = lines.map(countIndent);
   const common = Math.min(...indents);
   const indent = new RegExp(`^\\s{${common}}`);
 
   return lines.map(
-    line => line.replace(indent, '')
-  ).join('\n');
+    line => line.replace(indent, "")
+  ).join("\n");
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-register": "^6.26.0",
     "colors": "^1.1.2",
     "commander": "^2.12",
-    "eslint": "^4.15.0",
+    "eslint": "^4.18.1",
     "eslint-plugin-mocha": "^4.11.0",
     "fuzzer": "^0.2.1",
     "gh-pages": "^1.1.0",


### PR DESCRIPTION
Back in a day when I crafted the list of eslint rules we use I made a mistake - settled on single quotes.

Nobody likes that, and its incompatible with Mozilla eslinting rules. Let's fix it.

This patch exclusively focuses on quotes because that's the only incompatibility between us and mozilla-central. We may want to further align our rules with mozilla ruleset, but that'll be optional and may be worth more discussions.

I basically ran `eslint **/src --fix`.