### PR TITLE
Skip placing FSI/PDI if a placeable is the only element in the Pattern

### DIFF
--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -448,6 +448,10 @@ function Pattern(env, ptn) {
   dirty.add(ptn);
   const result = [];
 
+  // Wrap interpolations with Directional Isolate Formatting characters
+  // only when the pattern has more than one element.
+  const useIsolating = ctx._useIsolating && ptn.length > 1;
+
   for (const elem of ptn) {
     if (typeof elem === "string") {
       result.push(elem);
@@ -456,7 +460,7 @@ function Pattern(env, ptn) {
 
     const part = Type(env, elem).toString(ctx);
 
-    if (ctx._useIsolating) {
+    if (useIsolating) {
       result.push(FSI);
     }
 
@@ -472,7 +476,7 @@ function Pattern(env, ptn) {
       result.push(part);
     }
 
-    if (ctx._useIsolating) {
+    if (useIsolating) {
       result.push(PDI);
     }
   }

--- a/fluent/test/isolating_test.js
+++ b/fluent/test/isolating_test.js
@@ -68,3 +68,26 @@ suite('Isolating interpolations', function(){
     assert.equal(errs.length, 0);
   });
 });
+
+suite('Skip isolation cases', function(){
+  let ctx, args, errs;
+
+  suiteSetup(function() {
+    ctx = new MessageContext('en-US');
+    ctx.addMessages(ftl`
+      -brand-short-name = Amaya
+      foo = { -brand-short-name }
+    `);
+  });
+
+  setup(function() {
+    errs = [];
+  });
+
+  test('skips isolation if the only element is a placeable', function(){
+    const msg = ctx.getMessage('foo');
+    const val = ctx.format(msg, args, errs);
+    assert.equal(val, `Amaya`);
+    assert.equal(errs.length, 0);
+  });
+});


### PR DESCRIPTION
Currently we wrap every placeable in FSI/PDI to help layout work with bidi code.
This is unnecessary in cases where the placeble is the only element in the Pattern like:

```
key1 = { -brand-short-name }

key2 =
    {  PLATFORM() ->
        [windows] Foo
       *[other] Faa
    }
```

This patch optimizes that scenario.