### PR TITLE
Improve error debugging and recovery on missing messages

### DIFF
--- a/fluent-dom/src/dom_localization.js
+++ b/fluent-dom/src/dom_localization.js
@@ -282,7 +282,9 @@ export default class DOMLocalization extends Localization {
     this.pauseObserving();
 
     for (let i = 0; i < elements.length; i++) {
-      overlayElement(elements[i], translations[i]);
+      if (translations[i] !== undefined) {
+        overlayElement(elements[i], translations[i]);
+      }
     }
 
     this.resumeObserving();

--- a/fluent-dom/src/localization.js
+++ b/fluent-dom/src/localization.js
@@ -249,7 +249,7 @@ function messageFromContext(ctx, errors, id, args) {
  */
 function keysFromContext(method, ctx, keys, translations) {
   const messageErrors = [];
-  let missingIds = null;
+  const missingIds = new Set();
 
   keys.forEach((key, i) => {
     if (translations[i] !== undefined) {
@@ -261,9 +261,6 @@ function keysFromContext(method, ctx, keys, translations) {
       translations[i] = method(ctx, messageErrors, key[0], key[1]);
       // XXX: Report resolver errors
     } else {
-      if (missingIds === null) {
-        missingIds = new Set();
-      }
       missingIds.add(key[0]);
     }
   });

--- a/fluent-dom/test/dom_localization_test.js
+++ b/fluent-dom/test/dom_localization_test.js
@@ -1,0 +1,46 @@
+import assert from "assert";
+import { MessageContext } from "../../fluent/src/index";
+import DOMLocalization from "../src/dom_localization";
+
+function* mockGenerateMessages(resourceIds) {
+  const mc = new MessageContext(["en-US"]);
+  mc.addMessages("key1 = Key 1");
+  yield mc;
+}
+
+const mockWindow = {
+  MutationObserver: class MutationObserver {
+    takeRecords() {return new Set();}
+    disconnect() {}
+  }
+};
+
+suite("translateFragment", function() {
+  test("translates a node", async function() {
+    const domLoc = new DOMLocalization(mockWindow, ["test.ftl"], mockGenerateMessages);
+
+    const frag = document.createDocumentFragment();
+    const elem = document.createElement("p");
+    domLoc.setAttributes(elem, "key1");
+    frag.appendChild(elem);
+
+    await domLoc.translateFragment(frag);
+
+    assert.equal(elem.textContent, "Key 1");
+  });
+
+  test("does not inject content into a node with missing translation", async function() {
+    const domLoc = new DOMLocalization(mockWindow, ["test.ftl"], mockGenerateMessages);
+
+    const frag = document.createDocumentFragment();
+    const elem = document.createElement("p");
+    domLoc.setAttributes(elem, "missing_key");
+    elem.textContent = "Original Value";
+    frag.appendChild(elem);
+
+    await domLoc.translateFragment(frag);
+
+    assert.equal(elem.textContent, "Original Value");
+  });
+
+});

--- a/fluent-dom/test/localization_test.js
+++ b/fluent-dom/test/localization_test.js
@@ -1,0 +1,27 @@
+import assert from "assert";
+import { MessageContext } from "../../fluent/src/index";
+import Localization from "../src/localization";
+
+function* mockGenerateMessages(resourceIds) {
+  const mc = new MessageContext(["en-US"]);
+  mc.addMessages("key1 = Key 1");
+  yield mc;
+}
+
+suite("formatMessages", function() {
+  test("returns a translation", async function() {
+    const loc = new Localization(["test.ftl"], mockGenerateMessages);
+    const translations = await loc.formatMessages([["key1"]]);
+
+    assert.equal(translations[0].value, "Key 1");
+  });
+
+  test("returns undefined for a missing translation", async function() {
+    const loc = new Localization(["test.ftl"], mockGenerateMessages);
+    const translations = await loc.formatMessages([["missing_key"]]);
+
+    // Make sure that the returned value here is `undefined`.
+    // This allows bindings to handle missing translations.
+    assert.equal(translations[1], undefined);
+  });
+});


### PR DESCRIPTION
The current error reporting for errors from Fluent is very limited. While we do plan a more complete rework of the developer experience in Q2, I started receiving feedback that this is impacting people's first experience of working with Fluent in Firefox right now. I believe it's worth landing a smaller fix that fixes the most noticeable issues.

This PR aims to fix three scenarios:

- Overreporting missing strings when falling back (see https://bugzilla.mozilla.org/show_bug.cgi?id=1438608 )
 - Not falling back on message id as last resort (see https://bugzilla.mozilla.org/show_bug.cgi?id=1410849 ) 
 - Not reporting untranslated strings

This does not address reporting errors out of resolver and I see it more as a simple imminent fix that vastly improves experience of engineers trying to work with Fluent today, rather than a long term solution.
I'd like to this in a minor release, and leave a more complete overhaul for stas' planned refactor (see https://bugzilla.mozilla.org/show_bug.cgi?id=1410857 )