### PR TITLE
Break iteration in formatWithFallback if no missing string reported.

### DIFF
--- a/fluent-dom/src/localization.js
+++ b/fluent-dom/src/localization.js
@@ -46,6 +46,10 @@ export default class Localization {
       }
       const missingIds = keysFromContext(method, ctx, keys, translations);
 
+      if (missingIds.size === 0) {
+        break;
+      }
+
       if (typeof console !== "undefined") {
         const locale = ctx.locales[0];
         const ids = Array.from(missingIds).join(", ");


### PR DESCRIPTION
In #160 I ended up removing the early return from the iterator in case no missing ids are left.