### PR TITLE
BaseNode.equals support, and other ast goodness from python-fluent

### DIFF
--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -51,6 +51,23 @@ class BaseNode {
     }
     return true;
   }
+
+  clone() {
+    function visit(value) {
+      if (value instanceof BaseNode) {
+        return value.clone();
+      }
+      if (Array.isArray(value)) {
+        return value.map(visit);
+      }
+      return value;
+    }
+    const clone = Object.create(this);
+    for (const prop of Object.keys(this)) {
+      clone[prop] = visit(this[prop]);
+    }
+    return clone;
+  }
 }
 
 function scalars_equal(thisVal, otherVal, ignoredFields) {

--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -5,7 +5,7 @@
  * Annotation.
  *
  */
-class BaseNode {
+export class BaseNode {
   constructor() {}
 
   equals(other, ignoredFields = ["span"]) {

--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -33,19 +33,12 @@ export class BaseNode {
         if (thisVal.length !== otherVal.length) {
           return false;
         }
-        // Sort elements of order-agnostic fields to ensure the
-        // comparison is order-agnostic as well. Annotations should be
-        // here too but they don't have sorting keys.
-        if (["attributes", "variants"].indexOf(fieldName) >= 0) {
-          thisVal.sort(sorting_key_compare);
-          otherVal.sort(sorting_key_compare);
-        }
-        for (let i = 0, ii = thisVal.length; i < ii; ++i) {
-          if (!scalars_equal(thisVal[i], otherVal[i], ignoredFields)) {
+        for (let i = 0; i < thisVal.length; ++i) {
+          if (!scalarsEqual(thisVal[i], otherVal[i], ignoredFields)) {
             return false;
           }
         }
-      } else if (!scalars_equal(thisVal, otherVal, ignoredFields)) {
+      } else if (!scalarsEqual(thisVal, otherVal, ignoredFields)) {
         return false;
       }
     }
@@ -62,7 +55,7 @@ export class BaseNode {
       }
       return value;
     }
-    const clone = Object.create(this);
+    const clone = Object.create(this.constructor.prototype);
     for (const prop of Object.keys(this)) {
       clone[prop] = visit(this[prop]);
     }
@@ -70,21 +63,11 @@ export class BaseNode {
   }
 }
 
-function scalars_equal(thisVal, otherVal, ignoredFields) {
+function scalarsEqual(thisVal, otherVal, ignoredFields) {
   if (thisVal instanceof BaseNode) {
     return thisVal.equals(otherVal, ignoredFields);
   }
   return thisVal === otherVal;
-}
-
-function sorting_key_compare(left, right) {
-  if (left.sorting_key < right.sorting_key) {
-    return -1;
-  }
-  if (left.sorting_key === right.sorting_key) {
-    return 0;
-  }
-  return 1;
 }
 
 /*
@@ -267,7 +250,7 @@ export class Attribute extends SyntaxNode {
     this.value = value;
   }
 
-  get sorting_key() {
+  get sortingKey() {
     return this.id.name;
   }
 }
@@ -281,7 +264,7 @@ export class Variant extends SyntaxNode {
     this.default = def;
   }
 
-  get sorting_key() {
+  get sortingKey() {
     if (this.key instanceof NumberLiteral) {
       return this.key.value;
     }

--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -249,10 +249,6 @@ export class Attribute extends SyntaxNode {
     this.id = id;
     this.value = value;
   }
-
-  get sortingKey() {
-    return this.id.name;
-  }
 }
 
 export class Variant extends SyntaxNode {
@@ -262,13 +258,6 @@ export class Variant extends SyntaxNode {
     this.key = key;
     this.value = value;
     this.default = def;
-  }
-
-  get sortingKey() {
-    if (this.key instanceof NumberLiteral) {
-      return this.key.value;
-    }
-    return this.key.name;
   }
 }
 

--- a/fluent-syntax/src/index.js
+++ b/fluent-syntax/src/index.js
@@ -3,6 +3,7 @@ import FluentSerializer from "./serializer";
 
 export * from "./ast";
 export { FluentParser, FluentSerializer };
+export * from "./visitor";
 
 export function parse(source, opts) {
   const parser = new FluentParser(opts);

--- a/fluent-syntax/src/visitor.js
+++ b/fluent-syntax/src/visitor.js
@@ -12,12 +12,11 @@ export class Visitor {
     if (!(node instanceof BaseNode)) {
       return;
     }
-    const nodename = node.type;
-    const visit = this[`visit_${nodename}`] || this.generic_visit;
+    const visit = this[`visit${node.type}`] || this.genericVisit;
     visit.call(this, node);
   }
 
-  generic_visit(node) {
+  genericVisit(node) {
     for (const propname of Object.keys(node)) {
       this.visit(node[propname]);
     }
@@ -32,12 +31,11 @@ export class Transformer extends Visitor {
     if (!(node instanceof BaseNode)) {
       return node;
     }
-    const nodename = node.type;
-    const visit = this[`visit_${nodename}`] || this.generic_visit;
+    const visit = this[`visit${node.type}`] || this.genericVisit;
     return visit.call(this, node);
   }
 
-  generic_visit(node) {
+  genericVisit(node) {
     for (const propname of Object.keys(node)) {
       const propvalue = node[propname];
       if (Array.isArray(propvalue)) {

--- a/fluent-syntax/src/visitor.js
+++ b/fluent-syntax/src/visitor.js
@@ -1,0 +1,60 @@
+import { BaseNode } from "./ast";
+
+/*
+ * Abstract Visitor pattern
+ */
+export class Visitor {
+  visit(node) {
+    if (Array.isArray(node)) {
+      node.forEach(child => this.visit(child));
+      return;
+    }
+    if (!(node instanceof BaseNode)) {
+      return;
+    }
+    const nodename = node.type;
+    const visit = this[`visit_${nodename}`] || this.generic_visit;
+    visit.call(this, node);
+  }
+
+  generic_visit(node) {
+    for (const propname of Object.keys(node)) {
+      this.visit(node[propname]);
+    }
+  }
+}
+
+/*
+ * Abstract Transformer pattern
+ */
+export class Transformer extends Visitor {
+  visit(node) {
+    if (!(node instanceof BaseNode)) {
+      return node;
+    }
+    const nodename = node.type;
+    const visit = this[`visit_${nodename}`] || this.generic_visit;
+    return visit.call(this, node);
+  }
+
+  generic_visit(node) {
+    for (const propname of Object.keys(node)) {
+      const propvalue = node[propname];
+      if (Array.isArray(propvalue)) {
+        const newvals = propvalue
+          .map(child => this.visit(child))
+          .filter(newchild => newchild !== undefined);
+        node[propname] = newvals;
+      }
+      if (propvalue instanceof BaseNode) {
+        const new_val = this.visit(propvalue);
+        if (new_val === undefined) {
+          delete node[propname];
+        } else {
+          node[propname] = new_val;
+        }
+      }
+    }
+    return node;
+  }
+}

--- a/fluent-syntax/test/ast_test.js
+++ b/fluent-syntax/test/ast_test.js
@@ -1,0 +1,73 @@
+"use strict";
+
+import assert from "assert";
+import { ftl } from "./util";
+import { FluentParser } from "../src";
+import * as AST from "../src/ast";
+
+suite("BaseNode.equals", function() {
+  setup(function() {
+    this.parser = new FluentParser();
+  });
+  test("Identifier.equals", function() {
+    const thisNode = new AST.Identifier("name");
+    const otherNode = new AST.Identifier("name");
+    assert.strictEqual(thisNode.equals(otherNode), true);
+  });
+  test("Node.type", function() {
+    const thisNode = new AST.Identifier("name");
+    const otherNode = new AST.StringLiteral("name");
+    assert.strictEqual(thisNode.equals(otherNode), false);
+  });
+  test("Array children", function() {
+    const thisNode = new AST.Pattern([
+      new AST.TextElement("one"),
+      new AST.TextElement("two"),
+      new AST.TextElement("three"),
+    ]);
+    let otherNode = new AST.Pattern([
+      new AST.TextElement("one"),
+      new AST.TextElement("two"),
+      new AST.TextElement("three"),
+    ]);
+    assert.strictEqual(thisNode.equals(otherNode), true);
+  });
+  test("Variants", function() {
+      const thisRes = this.parser.parse(ftl`
+          msg = { $val ->
+              [few] things
+              [1] one
+             *[other] default
+            }
+      `);
+      const otherRes = this.parser.parse(ftl`
+          # a comment
+          msg = { $val ->
+              [few] things
+             *[other] default
+              [1] one
+            }
+      `);
+      const thisNode = thisRes.body[0];
+      const otherNode = otherRes.body[0];
+      assert.strictEqual(thisNode.equals(otherNode), false);
+      assert.strictEqual(thisNode.equals(otherNode, ['span', 'comment']), true);
+      assert.strictEqual(thisNode.value.equals(otherNode.value), true);
+      assert.strictEqual(thisNode.value.equals(otherNode.value, []), false);
+  });
+  test("Attributes without order", function() {
+      const thisRes = this.parser.parse(ftl`
+          msg =
+            .attr1 = one
+            .attr2 = two
+      `);
+      const otherRes = this.parser.parse(ftl`
+          msg =
+            .attr2 = two
+            .attr1 = one
+      `);
+      const thisNode = thisRes.body[0];
+      const otherNode = otherRes.body[0];
+      assert.strictEqual(thisNode.equals(otherNode), true);
+  });
+});

--- a/fluent-syntax/test/ast_test.js
+++ b/fluent-syntax/test/ast_test.js
@@ -12,6 +12,7 @@ suite("BaseNode.equals", function() {
   test("Identifier.equals", function() {
     const thisNode = new AST.Identifier("name");
     const otherNode = new AST.Identifier("name");
+    assert.ok(thisNode.clone() instanceof AST.Identifier);
     assert.strictEqual(thisNode.equals(otherNode), true);
     assert.strictEqual(thisNode.equals(thisNode.clone()), true);
     assert.notStrictEqual(thisNode, thisNode.clone());
@@ -34,7 +35,7 @@ suite("BaseNode.equals", function() {
     ]);
     assert.strictEqual(thisNode.equals(otherNode), true);
   });
-  test("Variants", function() {
+  test("Variant order matters", function() {
       const thisRes = this.parser.parse(ftl`
           msg = { $val ->
               [few] things
@@ -43,7 +44,6 @@ suite("BaseNode.equals", function() {
             }
       `);
       const otherRes = this.parser.parse(ftl`
-          # a comment
           msg = { $val ->
               [few] things
              *[other] default
@@ -53,13 +53,10 @@ suite("BaseNode.equals", function() {
       const thisNode = thisRes.body[0];
       const otherNode = otherRes.body[0];
       assert.strictEqual(thisNode.equals(otherNode), false);
-      assert.strictEqual(thisNode.equals(otherNode, ['span', 'comment']), true);
-      assert.strictEqual(thisNode.value.equals(otherNode.value), true);
-      assert.strictEqual(thisNode.value.equals(otherNode.value, []), false);
       assert.strictEqual(thisRes.equals(thisRes.clone(), []), true);
       assert.notStrictEqual(thisRes, thisRes.clone());
   });
-  test("Attributes without order", function() {
+  test("Attribute order matters", function() {
       const thisRes = this.parser.parse(ftl`
           msg =
             .attr1 = one
@@ -72,6 +69,6 @@ suite("BaseNode.equals", function() {
       `);
       const thisNode = thisRes.body[0];
       const otherNode = otherRes.body[0];
-      assert.strictEqual(thisNode.equals(otherNode), true);
+      assert.strictEqual(thisNode.equals(otherNode), false);
   });
 });

--- a/fluent-syntax/test/ast_test.js
+++ b/fluent-syntax/test/ast_test.js
@@ -13,6 +13,8 @@ suite("BaseNode.equals", function() {
     const thisNode = new AST.Identifier("name");
     const otherNode = new AST.Identifier("name");
     assert.strictEqual(thisNode.equals(otherNode), true);
+    assert.strictEqual(thisNode.equals(thisNode.clone()), true);
+    assert.notStrictEqual(thisNode, thisNode.clone());
   });
   test("Node.type", function() {
     const thisNode = new AST.Identifier("name");
@@ -54,6 +56,8 @@ suite("BaseNode.equals", function() {
       assert.strictEqual(thisNode.equals(otherNode, ['span', 'comment']), true);
       assert.strictEqual(thisNode.value.equals(otherNode.value), true);
       assert.strictEqual(thisNode.value.equals(otherNode.value, []), false);
+      assert.strictEqual(thisRes.equals(thisRes.clone(), []), true);
+      assert.notStrictEqual(thisRes, thisRes.clone());
   });
   test("Attributes without order", function() {
       const thisRes = this.parser.parse(ftl`

--- a/fluent-syntax/test/visitor_test.js
+++ b/fluent-syntax/test/visitor_test.js
@@ -1,0 +1,118 @@
+"use strict";
+
+import assert from "assert";
+import { ftl } from "./util";
+import { FluentParser, Visitor, Transformer } from "../src";
+
+suite("Visitor", function() {
+  setup(function() {
+    const parser = new FluentParser();
+    this.resource = parser.parse(ftl`
+        one = Message
+        # Comment
+        two = Messages
+        three = Messages with
+            .an = Attribute
+    `);
+  });
+  test("Mock Visitor", function() {
+    class MockVisitor extends Visitor {
+      constructor() {
+        super();
+        this.calls = {};
+        this.pattern_calls = 0;
+      }
+      generic_visit(node) {
+        const nodename = node.type;
+        if (nodename in this.calls) {
+          this.calls[nodename]++;
+        } else {
+          this.calls[nodename] = 1;
+        }
+        super.generic_visit(node);
+      }
+      visit_Pattern(node) {
+        this.pattern_calls++;
+      }
+    }
+    const mv = new MockVisitor();
+    mv.visit(this.resource);
+    assert.strictEqual(mv.pattern_calls, 4);
+    assert.deepStrictEqual(
+      mv.calls,
+      {
+        'Resource': 1,
+        'Comment': 1,
+        'Message': 3,
+        'Identifier': 4,
+        'Attribute': 1,
+        'Span': 10,
+      }
+    )
+  });
+  test("WordCount", function() {
+    class VisitorCounter extends Visitor {
+      constructor() {
+        super();
+        this.word_count = 0;
+      }
+      generic_visit(node) {
+        switch (node.type) {
+          case 'Span':
+          case 'Annotation':            
+            break;
+          default:
+            super.generic_visit(node);
+        }
+      }
+      visit_TextElement(node) {
+        this.word_count += node.value.split(/\s+/).length;
+      }
+    }
+    const vc = new VisitorCounter();
+    vc.visit(this.resource);
+    assert.strictEqual(vc.word_count, 5);
+  })
+});
+
+suite("Transformer", function() {
+  setup(function() {
+    const parser = new FluentParser();
+    this.resource = parser.parse(ftl`
+        one = Message
+        # Comment
+        two = Messages
+        three = Messages with
+            .an = Attribute
+    `);
+  });
+  test("ReplaceTransformer", function() {
+    class ReplaceTransformer extends Transformer {
+      constructor(before, after) {
+        super();
+        this.before = before;
+        this.after = after;
+      }
+      generic_visit(node) {
+        switch (node.type) {
+          case 'Span':
+          case 'Annotation':
+            return node;
+            break;
+          default:
+            return super.generic_visit(node);
+        }
+      }
+      visit_TextElement(node) {
+        node.value = node.value.replace(this.before, this.after);
+        return node;
+      }
+    }
+    const resource = this.resource.clone()
+    const transformed = new ReplaceTransformer('Message', 'Term').visit(resource);
+    assert.notStrictEqual(resource, this.resource);
+    assert.strictEqual(resource, transformed);
+    assert.strictEqual(this.resource.equals(transformed), false);
+    assert.strictEqual(transformed.body[1].value.elements[0].value, 'Terms');
+  });
+});

--- a/fluent-syntax/test/visitor_test.js
+++ b/fluent-syntax/test/visitor_test.js
@@ -22,16 +22,16 @@ suite("Visitor", function() {
         this.calls = {};
         this.pattern_calls = 0;
       }
-      generic_visit(node) {
+      genericVisit(node) {
         const nodename = node.type;
         if (nodename in this.calls) {
           this.calls[nodename]++;
         } else {
           this.calls[nodename] = 1;
         }
-        super.generic_visit(node);
+        super.genericVisit(node);
       }
-      visit_Pattern(node) {
+      visitPattern(node) {
         this.pattern_calls++;
       }
     }
@@ -56,16 +56,16 @@ suite("Visitor", function() {
         super();
         this.word_count = 0;
       }
-      generic_visit(node) {
+      genericVisit(node) {
         switch (node.type) {
           case 'Span':
           case 'Annotation':            
             break;
           default:
-            super.generic_visit(node);
+            super.genericVisit(node);
         }
       }
-      visit_TextElement(node) {
+      visitTextElement(node) {
         this.word_count += node.value.split(/\s+/).length;
       }
     }
@@ -93,17 +93,17 @@ suite("Transformer", function() {
         this.before = before;
         this.after = after;
       }
-      generic_visit(node) {
+      genericVisit(node) {
         switch (node.type) {
           case 'Span':
           case 'Annotation':
             return node;
             break;
           default:
-            return super.generic_visit(node);
+            return super.genericVisit(node);
         }
       }
-      visit_TextElement(node) {
+      visitTextElement(node) {
         node.value = node.value.replace(this.before, this.after);
         return node;
       }


### PR DESCRIPTION
This is basically a port of
https://github.com/projectfluent/python-fluent/blob/90301381e9b4d56b317bd6f15adf38936569f023/fluent/syntax/ast.py#L76-L120

Creating a PR early on to ensure that node 6 and 8 pass on the js features. For example, the use of `Object.keys`, which is rumored to be OK per http://node.green/#ES2015-misc-Object-static-methods-accept-primitives-Object-keys.