### PR TITLE
Report an error when attempting to override an existing message or term.

### DIFF
--- a/fluent/src/context.js
+++ b/fluent/src/context.js
@@ -113,8 +113,16 @@ export class MessageContext {
       if (id.startsWith("-")) {
         // Identifiers starting with a dash (-) define terms. Terms are private
         // and cannot be retrieved from MessageContext.
+        if (this._terms.has(id)) {
+          errors.push(`Attempt to override an existing term: "${id}"`);
+          continue;
+        }
         this._terms.set(id, entries[id]);
       } else {
+        if (this._messages.has(id)) {
+          errors.push(`Attempt to override an existing message: "${id}"`);
+          continue;
+        }
         this._messages.set(id, entries[id]);
       }
     }

--- a/fluent/test/context_test.js
+++ b/fluent/test/context_test.js
@@ -53,16 +53,19 @@ suite('Context', function() {
     });
 
 
-    test('overwrites existing messages if the ids are the same', function() {
-      ctx.addMessages(ftl`
+    test('does not overwrite existing messages if the ids are the same', function() {
+      const errors = ctx.addMessages(ftl`
         foo = New Foo
       `);
+
+      // Attempt to overwrite error reported
+      assert.equal(errors.length, 1);
 
       assert.equal(ctx._messages.size, 2);
 
       const msg = ctx.getMessage('foo');
       const val = ctx.format(msg, args, errs);
-      assert.equal(val, 'New Foo');
+      assert.equal(val, 'Foo');
       assert.equal(errs.length, 0);
     });
   });


### PR DESCRIPTION
It's a pure developer productivity improvement. In our experience there has never been a case where overwriting an ID in the same context was intentional and useful, but it can be a really hard to debug and can lead to a very entangled code if someone accidentally starts depending on it.

Let's cut it short early. No overrides.