### PR TITLE
Sync fluent-dom with Gecko - named objects in translation.attrs

### DIFF
--- a/fluent-dom/src/dom_localization.js
+++ b/fluent-dom/src/dom_localization.js
@@ -165,7 +165,7 @@ export default class DOMLocalization extends Localization {
   translateRoots() {
     const roots = Array.from(this.roots);
     return Promise.all(
-      roots.map(root => this.translateElements(this.getTranslatables(root)))
+      roots.map(root => this.translateFragment(root))
     );
   }
 
@@ -231,7 +231,6 @@ export default class DOMLocalization extends Localization {
       }
     }
   }
-
 
   /**
    * Translate a DOM element or fragment asynchronously using this

--- a/fluent-dom/src/localization.js
+++ b/fluent-dom/src/localization.js
@@ -205,13 +205,10 @@ function messageFromContext(ctx, errors, id, args) {
 
   if (msg.attrs) {
     formatted.attrs = [];
-    for (const attrName in msg.attrs) {
-      const formattedAttr = ctx.format(msg.attrs[attrName], args, errors);
-      if (formattedAttr !== null) {
-        formatted.attrs.push([
-          attrName,
-          formattedAttr
-        ]);
+    for (const name in msg.attrs) {
+      const value = ctx.format(msg.attrs[name], args, errors);
+      if (value !== null) {
+        formatted.attrs.push({ name, value });
       }
     }
   }

--- a/fluent-dom/src/overlay.js
+++ b/fluent-dom/src/overlay.js
@@ -83,9 +83,9 @@ export default function overlayElement(targetElement, translation) {
   }
 
   if (translation.attrs) {
-    for (const [name, val] of translation.attrs) {
-      if (isAttrNameLocalizable(name, targetElement, explicitlyAllowed)) {
-        targetElement.setAttribute(name, val);
+    for (const {name: attrName, value: attrValue} of translation.attrs) {
+      if (isAttrNameLocalizable(attrName, targetElement, explicitlyAllowed)) {
+        targetElement.setAttribute(attrName, attrValue);
       }
     }
   }

--- a/fluent-dom/test/overlay_test.js
+++ b/fluent-dom/test/overlay_test.js
@@ -100,7 +100,7 @@ suite('Filtering top-level attributes', function() {
     const translation = {
       value: null,
       attrs: [
-        ['title', 'FOO']
+        {name: 'title', value: 'FOO'}
       ]
     };
 
@@ -114,7 +114,7 @@ suite('Filtering top-level attributes', function() {
     const translation = {
       value: null,
       attrs: [
-        ['disabled', 'DISABLED']
+        {name: 'disabled', value: 'DISABLED'}
       ]
     };
 
@@ -274,7 +274,7 @@ suite('Retranslation', function() {
     const translationA = {
       value: 'FOO A',
       attrs: [
-        ['title', 'TITLE A']
+        {name: 'title', value: 'TITLE A'}
       ]
     };
     const translationB = {


### PR DESCRIPTION
As 61 cycle closes I finally have some time to clean up the m-c<-->fluent.js. I'll start with the minor updates to fluent, and will follow up with the introduction of `GeckoLocalization` and `GeckoDOMLocalization` in a separate PR (and bug on the m-c side).