### PR TITLE
Refactor the overlay sanitization methods into separate functions

### DIFF
--- a/fluent-dom/src/localization.js
+++ b/fluent-dom/src/localization.js
@@ -61,11 +61,11 @@ export default class Localization {
   }
 
   /**
-   * Format translations into {value, attrs} objects.
+   * Format translations into {value, attributes} objects.
    *
    * The fallback logic is the same as in `formatValues` but the argument type
-   * is stricter (an array of arrays) and it returns {value, attrs} objects
-   * which are suitable for the translation of DOM elements.
+   * is stricter (an array of arrays) and it returns {value, attributes}
+   * objects which are suitable for the translation of DOM elements.
    *
    *     docL10n.formatMessages([
    *       ['hello', { who: 'Mary' }],
@@ -73,14 +73,14 @@ export default class Localization {
    *     ]).then(console.log);
    *
    *     // [
-   *     //   { value: 'Hello, Mary!', attrs: null },
-   *     //   { value: 'Welcome!', attrs: { title: 'Hello' } }
+   *     //   { value: 'Hello, Mary!', attributes: null },
+   *     //   { value: 'Welcome!', attributes: { title: 'Hello' } }
    *     // ]
    *
    * Returns a Promise resolving to an array of the translation strings.
    *
    * @param   {Array<Array>} keys
-   * @returns {Promise<Array<{value: string, attrs: Object}>>}
+   * @returns {Promise<Array<{value: string, attributes: Object}>>}
    * @private
    */
   formatMessages(keys) {
@@ -174,7 +174,7 @@ function valueFromContext(ctx, errors, id, args) {
 }
 
 /**
- * Format all public values of a message into a { value, attrs } object.
+ * Format all public values of a message into a {value, attributes} object.
  *
  * This function is passed as a method to `keysFromContext` and resolve
  * a single L10n Entity using provided `MessageContext`.
@@ -183,7 +183,7 @@ function valueFromContext(ctx, errors, id, args) {
  * entity.
  *
  * If the function fails to retrieve the entity, the value is set to the ID of
- * an entity, and attrs to `null`. If formatting fails, it will return
+ * an entity, and attributes to `null`. If formatting fails, it will return
  * a partially resolved value and attributes.
  *
  * In both cases, an error is being added to the errors array.
@@ -243,7 +243,7 @@ function messageFromContext(ctx, errors, id, args) {
  * @param {Function}       method
  * @param {MessageContext} ctx
  * @param {Array<string>}  keys
- * @param {{Array<{value: string, attrs: Object}>}} translations
+ * @param {{Array<{value: string, attributes: Object}>}} translations
  *
  * @returns {Set<string>}
  * @private

--- a/fluent-dom/src/overlay.js
+++ b/fluent-dom/src/overlay.js
@@ -62,7 +62,7 @@ const LOCALIZABLE_ATTRIBUTES = {
  * @private
  */
 export default function translateElement(element, translation) {
-  const value = translation.value;
+  const {value} = translation;
 
   if (typeof value === "string") {
     if (!reOverlay.test(value)) {
@@ -99,7 +99,29 @@ function overlayChildNodes(fromElement, toElement) {
   const content = toElement.ownerDocument.createDocumentFragment();
 
   for (const childNode of fromElement.childNodes) {
-    content.appendChild(sanitizeUsing(toElement, childNode));
+    if (childNode.nodeType === childNode.TEXT_NODE) {
+      content.appendChild(childNode.cloneNode(false));
+      continue;
+    }
+
+    if (childNode.hasAttribute("data-l10n-name")) {
+      content.appendChild(namedChildFrom(toElement, childNode));
+      continue;
+    }
+
+    if (isElementAllowed(childNode)) {
+      content.appendChild(allowedChild(childNode));
+      continue;
+    }
+
+    console.warn(
+      `An element of forbidden type "${childNode.localName}" was found in ` +
+      "the translation. Only elements with data-l10n-name can be overlaid " +
+      "onto source elements of the same data-l10n-name."
+    );
+
+    // If all else fails, convert the element to its text content.
+    content.appendChild(textNode(childNode));
   }
 
   toElement.textContent = "";
@@ -145,75 +167,79 @@ function overlayAttributes(fromElement, toElement) {
 }
 
 /**
- * Sanitize a child node created by the translation.
+ * Sanitize a child element created by the translation.
  *
- * If childNode has the data-l10n-name attribute, try to find a corresponding
- * child in sourceElement and use it as the base for the sanitization. This
- * will preserve functional attribtues defined on the child element in the
- * source HTML.
- *
- * This function must return new nodes or clones in all code paths. The
- * returned nodes are immediately appended to the intermediate DocumentFragment
- * which also _removes_ them from the constructed <template> containing the
- * translation, which in turn breaks the for…of iteration over its child nodes.
+ * Try to find a corresponding child in sourceElement and use it as the base
+ * for the sanitization. This will preserve functional attribtues defined on
+ * the child element in the source HTML.
  *
  * @param   {Element} sourceElement - The source for data-l10n-name lookups.
- * @param   {Element} childNode - The child node to be sanitized.
+ * @param   {Element} translatedChild - The translated child to be sanitized.
  * @returns {Element}
  * @private
  */
-function sanitizeUsing(sourceElement, childNode) {
-  if (childNode.nodeType === childNode.TEXT_NODE) {
-    return childNode.cloneNode(false);
-  }
-
-  if (childNode.hasAttribute("data-l10n-name")) {
-    const childName = childNode.getAttribute("data-l10n-name");
-    const sourceChild = sourceElement.querySelector(
-      `[data-l10n-name="${childName}"]`
-    );
-
-    if (!sourceChild) {
-      console.warn(
-        `An element named "${childName}" wasn't found in the source.`
-      );
-    } else if (sourceChild.localName !== childNode.localName) {
-      console.warn(
-        `An element named "${childName}" was found in the translation ` +
-        `but its type ${childNode.localName} didn't match the element ` +
-        `found in the source (${sourceChild.localName}).`
-      );
-    } else {
-      // Remove it from sourceElement so that the translation cannot use
-      // the same reference name again.
-      sourceElement.removeChild(sourceChild);
-      // We can't currently guarantee that a translation won't remove
-      // sourceChild from the element completely, which could break the app if
-      // it relies on an event handler attached to the sourceChild. Let's make
-      // this limitation explicit for now by breaking the identitiy of the
-      // sourceChild by cloning it. This will destroy all event handlers
-      // attached to sourceChild via addEventListener and via on<name>
-      // properties.
-      const clone = sourceChild.cloneNode(false);
-      return shallowPopulateUsing(childNode, clone);
-    }
-  }
-
-  if (isElementAllowed(childNode)) {
-    // Start with an empty element of the same type to remove nested children
-    // and non-localizable attributes defined by the translation.
-    const clone = childNode.ownerDocument.createElement(childNode.localName);
-    return shallowPopulateUsing(childNode, clone);
-  }
-
-  console.warn(
-    `An element of forbidden type "${childNode.localName}" was found in ` +
-    "the translation. Only elements with data-l10n-name can be overlaid " +
-    "onto source elements of the same data-l10n-name."
+function namedChildFrom(sourceElement, translatedChild) {
+  const childName = translatedChild.getAttribute("data-l10n-name");
+  const sourceChild = sourceElement.querySelector(
+    `[data-l10n-name="${childName}"]`
   );
 
-  // If all else fails, convert the element to its text content.
-  return childNode.ownerDocument.createTextNode(childNode.textContent);
+  if (!sourceChild) {
+    console.warn(
+      `An element named "${childName}" wasn't found in the source.`
+    );
+    return textNode(translatedChild);
+  }
+
+  if (sourceChild.localName !== translatedChild.localName) {
+    console.warn(
+      `An element named "${childName}" was found in the translation ` +
+      `but its type ${translatedChild.localName} didn't match the ` +
+      `element found in the source (${sourceChild.localName}).`
+    );
+    return textNode(translatedChild);
+  }
+
+  // Remove it from sourceElement so that the translation cannot use
+  // the same reference name again.
+  sourceElement.removeChild(sourceChild);
+  // We can't currently guarantee that a translation won't remove
+  // sourceChild from the element completely, which could break the app if
+  // it relies on an event handler attached to the sourceChild. Let's make
+  // this limitation explicit for now by breaking the identitiy of the
+  // sourceChild by cloning it. This will destroy all event handlers
+  // attached to sourceChild via addEventListener and via on<name>
+  // properties.
+  const clone = sourceChild.cloneNode(false);
+  return shallowPopulateUsing(translatedChild, clone);
+}
+
+/**
+ * Sanitize an allowed element.
+ *
+ * Text-level elements allowed in translations may only use safe attributes
+ * and will have any nested markup stripped to text content.
+ *
+ * @param   {Element} element - The element to be sanitized.
+ * @returns {Element}
+ * @private
+ */
+function allowedChild(element) {
+  // Start with an empty element of the same type to remove nested children
+  // and non-localizable attributes defined by the translation.
+  const clone = element.ownerDocument.createElement(element.localName);
+  return shallowPopulateUsing(element, clone);
+}
+
+/**
+ * Convert an element to a text node.
+ *
+ * @param   {Element} element - The element to be sanitized.
+ * @returns {Node}
+ * @private
+ */
+function textNode(element) {
+  return element.ownerDocument.createTextNode(element.textContent);
 }
 
 /**

--- a/fluent-dom/test/extra_text_markup_test.js
+++ b/fluent-dom/test/extra_text_markup_test.js
@@ -7,7 +7,7 @@ suite('Localized text markup', function() {
     const element = elem('div')`Foo`;
     const translation = {
       value: 'FOO <em>BAR</em> BAZ',
-      attrs: null
+      attributes: null
     };
 
     translateElement(element, translation);
@@ -18,7 +18,7 @@ suite('Localized text markup', function() {
     const element = elem('div')`Foo`;
     const translation = {
       value: 'FOO <img src="img.png" />',
-      attrs: null
+      attributes: null
     };
 
     translateElement(element, translation);
@@ -29,7 +29,7 @@ suite('Localized text markup', function() {
     const element = elem('div')`Foo`;
     const translation = {
       value: 'FOO <button>BUTTON</button>',
-      attrs: null
+      attributes: null
     };
 
     translateElement(element, translation);
@@ -40,7 +40,7 @@ suite('Localized text markup', function() {
     const element = elem('div')`Foo`;
     const translation = {
       value: 'FOO <em><strong>BAR</strong></em> BAZ',
-      attrs: null
+      attributes: null
     };
 
     translateElement(element, translation);
@@ -53,7 +53,7 @@ suite('Attributes of localized text markup', function() {
     const element = elem('div')`Foo Bar`;
     const translation = {
       value: 'FOO <em title="BAR">BAR</em>',
-      attrs: null,
+      attributes: null,
     };
 
     translateElement(element, translation);
@@ -65,7 +65,7 @@ suite('Attributes of localized text markup', function() {
     const element = elem('div')`Foo Bar`;
     const translation = {
       value: 'FOO <em class="BAR" title="BAR">BAR</em>',
-      attrs: null,
+      attributes: null,
     };
 
     translateElement(element, translation);
@@ -78,7 +78,7 @@ suite('Attributes of localized text markup', function() {
       <em title="Foo">Foo</a>`;
     const translation = {
       value: '<em>FOO</em>',
-      attrs: null
+      attributes: null
     };
 
     translateElement(element, translation);

--- a/fluent-dom/test/overlay_text_children_test.js
+++ b/fluent-dom/test/overlay_text_children_test.js
@@ -29,7 +29,7 @@ suite('Text-semantic argument elements', function() {
     translateElement(element, translation);
     assert.equal(
       element.innerHTML,
-      '<em title="FOO">FOO</em>'
+      'FOO'
     );
   });
 


### PR DESCRIPTION
This PR addresses the feedback from https://github.com/projectfluent/fluent.js/pull/168#pullrequestreview-109650068.

  - I factored out the sanitization methods into separate functions. The logic of choosing them is now inside of the loop which iterates over the translated child nodes.
  - I removed the intermediate `DocumentFragment` and instead I was able to sanitize translated child node in place and then replace the whole contents of the source element in one go.
  - I made a few more `attrs` to `attributes` renames which I missed in #168.