### PR TITLE
Add transformation options to MessageContext

### DIFF
--- a/fluent/src/context.js
+++ b/fluent/src/context.js
@@ -43,17 +43,24 @@ export class MessageContext {
    *   - `useIsolating` - boolean specifying whether to use Unicode isolation
    *                    marks (FSI, PDI) for bidi interpolations.
    *
+   *   - `transform` - a function used to transform string parts of patterns.
+   *
    * @param   {string|Array<string>} locales - Locale or locales of the context
    * @param   {Object} [options]
    * @returns {MessageContext}
    */
-  constructor(locales, { functions = {}, useIsolating = true } = {}) {
+  constructor(locales, {
+    functions = {},
+    useIsolating = true,
+    transform = v => v
+  } = {}) {
     this.locales = Array.isArray(locales) ? locales : [locales];
 
     this._terms = new Map();
     this._messages = new Map();
     this._functions = functions;
     this._useIsolating = useIsolating;
+    this._transform = transform;
     this._intls = new WeakMap();
   }
 
@@ -163,12 +170,12 @@ export class MessageContext {
   format(message, args, errors) {
     // optimize entities which are simple strings with no attributes
     if (typeof message === "string") {
-      return message;
+      return this._transform(message);
     }
 
     // optimize simple-string entities with attributes
     if (typeof message.val === "string") {
-      return message.val;
+      return this._transform(message.val);
     }
 
     // optimize entities with null values

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -257,7 +257,10 @@ function SelectExpression(env, {exp, vars, def}) {
 function Type(env, expr) {
   // A fast-path for strings which are the most common case, and for
   // `FluentNone` which doesn't require any additional logic.
-  if (typeof expr === "string" || expr instanceof FluentNone) {
+  if (typeof expr === "string") {
+    return env.ctx._transform(expr);
+  }
+  if (expr instanceof FluentNone) {
     return expr;
   }
 
@@ -454,7 +457,7 @@ function Pattern(env, ptn) {
 
   for (const elem of ptn) {
     if (typeof elem === "string") {
-      result.push(elem);
+      result.push(ctx._transform(elem));
       continue;
     }
 

--- a/fluent/test/transform_test.js
+++ b/fluent/test/transform_test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+import assert from 'assert';
+
+import { MessageContext } from '../src/context';
+import { ftl } from '../src/util';
+
+suite('Transformations', function(){
+  let ctx, errs;
+
+  suiteSetup(function() {
+    ctx = new MessageContext('en-US', {
+      transform: v => v.replace(/a/g, "A") 
+    });
+    ctx.addMessages(ftl`
+      foo = Faa
+          .bar = Bar { $foo } Baz
+    `);
+  });
+
+  setup(function() {
+    errs = [];
+  });
+
+  test('transforms strings', function(){
+    const msg = ctx.getMessage('foo');
+    const val = ctx.format(msg, {}, errs);
+    const attr = ctx.format(msg.attrs["bar"], {foo: "arg"}, errs);
+    assert(val.includes("FAA"));
+    assert(attr.includes("BAr"));
+    assert(attr.includes("BAz"));
+    assert.equal(errs.length, 0);
+  });
+});


### PR DESCRIPTION
Based on the work in https://bugzilla.mozilla.org/show_bug.cgi?id=1450781 this adds the `transform` option to `MessageContext` which can be used to provide pseudolocalization capabilities.

This may be replaced later with internal pseudolocalization, once we gain more experience with testing this in Firefox.