### PR TITLE
Call expr 0.6

### DIFF
--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -151,11 +151,12 @@ export class VariantExpression extends Expression {
 }
 
 export class CallExpression extends Expression {
-  constructor(callee, args = []) {
+  constructor(callee, positional = [], named = []) {
     super();
     this.type = "CallExpression";
     this.callee = callee;
-    this.args = args;
+    this.positional = positional;
+    this.named = named;
   }
 }
 

--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -91,18 +91,18 @@ export class Expression extends SyntaxNode {
   }
 }
 
-export class StringExpression extends Expression {
+export class StringLiteral extends Expression {
   constructor(value) {
     super();
-    this.type = "StringExpression";
+    this.type = "StringLiteral";
     this.value = value;
   }
 }
 
-export class NumberExpression extends Expression {
+export class NumberLiteral extends Expression {
   constructor(value) {
     super();
-    this.type = "NumberExpression";
+    this.type = "NumberLiteral";
     this.value = value;
   }
 }
@@ -115,10 +115,10 @@ export class MessageReference extends Expression {
   }
 }
 
-export class ExternalArgument extends Expression {
+export class VariableExpression extends Expression {
   constructor(id) {
     super();
-    this.type = "ExternalArgument";
+    this.type = "VariableExpression";
     this.id = id;
   }
 }

--- a/fluent-syntax/src/ast.js
+++ b/fluent-syntax/src/ast.js
@@ -115,10 +115,10 @@ export class MessageReference extends Expression {
   }
 }
 
-export class VariableExpression extends Expression {
+export class VariableReference extends Expression {
   constructor(id) {
     super();
-    this.type = "VariableExpression";
+    this.type = "VariableReference";
     this.id = id;
   }
 }

--- a/fluent-syntax/src/errors.js
+++ b/fluent-syntax/src/errors.js
@@ -58,6 +58,10 @@ function getErrorMessage(code, args) {
       return "Attributes of terms cannot be used as placeables";
     case "E0020":
       return "Unterminated string expression";
+    case "E0021":
+      return "Positional arguments must not follow named arguments";
+    case "E0022":
+      return "Named arguments must be unique";
     default:
       return code;
   }

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -733,7 +733,7 @@ export default class FluentParser {
     if (ch === "$") {
       ps.next();
       const name = this.getIdentifier(ps);
-      return new AST.VariableExpression(name);
+      return new AST.VariableReference(name);
     }
 
     if (ps.isEntryIDStart()) {

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -670,6 +670,7 @@ export default class FluentParser {
 
   getCallArgs(ps) {
     const args = [];
+    const argumentNames = new Set();
 
     ps.skipInlineWS();
 
@@ -679,6 +680,14 @@ export default class FluentParser {
       }
 
       const arg = this.getCallArg(ps);
+      if (arg.type === "NamedArgument") {
+        if (argumentNames.has(arg.name.name)) {
+          throw new ParseError("E0022");
+        }
+        argumentNames.add(arg.name.name);
+      } else if (argumentNames.size > 0) {
+        throw new ParseError("E0021");
+      }
       args.push(arg);
 
       ps.skipInlineWS();

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -462,7 +462,7 @@ export default class FluentParser {
       num = `${num}${this.getDigits(ps)}`;
     }
 
-    return new AST.NumberExpression(num);
+    return new AST.NumberLiteral(num);
   }
 
   getPattern(ps) {
@@ -719,7 +719,7 @@ export default class FluentParser {
 
     ps.next();
 
-    return new AST.StringExpression(val);
+    return new AST.StringLiteral(val);
 
   }
 
@@ -733,7 +733,7 @@ export default class FluentParser {
     if (ch === "$") {
       ps.next();
       const name = this.getIdentifier(ps);
-      return new AST.ExternalArgument(name);
+      return new AST.VariableExpression(name);
     }
 
     if (ps.isEntryIDStart()) {

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -640,7 +640,8 @@ export default class FluentParser {
 
       return new AST.CallExpression(
         func,
-        args
+        args.positional,
+        args.named,
       );
     }
 
@@ -669,7 +670,8 @@ export default class FluentParser {
   }
 
   getCallArgs(ps) {
-    const args = [];
+    const positional = [];
+    const named = [];
     const argumentNames = new Set();
 
     ps.skipInlineWS();
@@ -684,11 +686,13 @@ export default class FluentParser {
         if (argumentNames.has(arg.name.name)) {
           throw new ParseError("E0022");
         }
+        named.push(arg);
         argumentNames.add(arg.name.name);
       } else if (argumentNames.size > 0) {
         throw new ParseError("E0021");
+      } else {
+        positional.push(arg);
       }
-      args.push(arg);
 
       ps.skipInlineWS();
 
@@ -700,7 +704,10 @@ export default class FluentParser {
         break;
       }
     }
-    return args;
+    return {
+      positional,
+      named
+    };
   }
 
   getArgVal(ps) {

--- a/fluent-syntax/src/serializer.js
+++ b/fluent-syntax/src/serializer.js
@@ -277,18 +277,14 @@ function serializeVariantExpression(expr) {
 
 function serializeCallExpression(expr) {
   const fun = serializeFunction(expr.callee);
-  const args = expr.args.map(serializeCallArgument).join(", ");
-  return `${fun}(${args})`;
-}
-
-
-function serializeCallArgument(arg) {
-  switch (arg.type) {
-    case "NamedArgument":
-      return serializeNamedArgument(arg);
-    default:
-      return serializeExpression(arg);
+  const positional = expr.positional.map(serializeExpression).join(", ");
+  const named = expr.named.map(serializeNamedArgument).join(", ");
+  if (expr.positional.length > 0 && expr.named.length > 0) {
+    return `${fun}(${positional}, ${named})`;
+  } else if (expr.positional.length > 0) {
+    return `${fun}(${positional})`;
   }
+  return `${fun}(${named})`;
 }
 
 

--- a/fluent-syntax/src/serializer.js
+++ b/fluent-syntax/src/serializer.js
@@ -190,14 +190,14 @@ function serializePlaceable(placeable) {
 
 function serializeExpression(expr) {
   switch (expr.type) {
-    case "StringExpression":
-      return serializeStringExpression(expr);
-    case "NumberExpression":
-      return serializeNumberExpression(expr);
+    case "StringLiteral":
+      return serializeStringLiteral(expr);
+    case "NumberLiteral":
+      return serializeNumberLiteral(expr);
     case "MessageReference":
       return serializeMessageReference(expr);
-    case "ExternalArgument":
-      return serializeExternalArgument(expr);
+    case "VariableExpression":
+      return serializeVariableExpression(expr);
     case "AttributeExpression":
       return serializeAttributeExpression(expr);
     case "VariantExpression":
@@ -212,12 +212,12 @@ function serializeExpression(expr) {
 }
 
 
-function serializeStringExpression(expr) {
+function serializeStringLiteral(expr) {
   return `"${expr.value}"`;
 }
 
 
-function serializeNumberExpression(expr) {
+function serializeNumberLiteral(expr) {
   return expr.value;
 }
 
@@ -227,7 +227,7 @@ function serializeMessageReference(expr) {
 }
 
 
-function serializeExternalArgument(expr) {
+function serializeVariableExpression(expr) {
   return `$${serializeIdentifier(expr.id)}`;
 }
 
@@ -301,10 +301,10 @@ function serializeNamedArgument(arg) {
 
 function serializeArgumentValue(argval) {
   switch (argval.type) {
-    case "StringExpression":
-      return serializeStringExpression(argval);
-    case "NumberExpression":
-      return serializeNumberExpression(argval);
+    case "StringLiteral":
+      return serializeStringLiteral(argval);
+    case "NumberLiteral":
+      return serializeNumberLiteral(argval);
     default:
       throw new Error(`Unknown argument type: ${argval.type}`);
   }
@@ -325,8 +325,8 @@ function serializeVariantKey(key) {
   switch (key.type) {
     case "VariantName":
       return serializeVariantName(key);
-    case "NumberExpression":
-      return serializeNumberExpression(key);
+    case "NumberLiteral":
+      return serializeNumberLiteral(key);
     default:
       throw new Error(`Unknown variant key type: ${key.type}`);
   }

--- a/fluent-syntax/src/serializer.js
+++ b/fluent-syntax/src/serializer.js
@@ -196,8 +196,8 @@ function serializeExpression(expr) {
       return serializeNumberLiteral(expr);
     case "MessageReference":
       return serializeMessageReference(expr);
-    case "VariableExpression":
-      return serializeVariableExpression(expr);
+    case "VariableReference":
+      return serializeVariableReference(expr);
     case "AttributeExpression":
       return serializeAttributeExpression(expr);
     case "VariantExpression":
@@ -227,7 +227,7 @@ function serializeMessageReference(expr) {
 }
 
 
-function serializeVariableExpression(expr) {
+function serializeVariableReference(expr) {
   return `$${serializeIdentifier(expr.id)}`;
 }
 

--- a/fluent-syntax/test/fixtures_structure/leading_dots.json
+++ b/fluent-syntax/test/fixtures_structure/leading_dots.json
@@ -97,7 +97,7 @@
           {
             "type": "Placeable",
             "expression": {
-              "type": "StringExpression",
+              "type": "StringLiteral",
               "value": ".",
               "span": {
                 "type": "Span",
@@ -153,7 +153,7 @@
           {
             "type": "Placeable",
             "expression": {
-              "type": "StringExpression",
+              "type": "StringLiteral",
               "value": ".",
               "span": {
                 "type": "Span",
@@ -218,7 +218,7 @@
           {
             "type": "Placeable",
             "expression": {
-              "type": "StringExpression",
+              "type": "StringLiteral",
               "value": ".",
               "span": {
                 "type": "Span",
@@ -283,7 +283,7 @@
           {
             "type": "Placeable",
             "expression": {
-              "type": "StringExpression",
+              "type": "StringLiteral",
               "value": ".",
               "span": {
                 "type": "Span",
@@ -469,7 +469,7 @@
           {
             "type": "Placeable",
             "expression": {
-              "type": "StringExpression",
+              "type": "StringLiteral",
               "value": ".",
               "span": {
                 "type": "Span",
@@ -654,7 +654,7 @@
               {
                 "type": "Placeable",
                 "expression": {
-                  "type": "StringExpression",
+                  "type": "StringLiteral",
                   "value": ".",
                   "span": {
                     "type": "Span",
@@ -718,7 +718,7 @@
             "expression": {
               "type": "SelectExpression",
               "expression": {
-                "type": "NumberExpression",
+                "type": "NumberLiteral",
                 "value": "1",
                 "span": {
                   "type": "Span",
@@ -781,7 +781,7 @@
                       {
                         "type": "Placeable",
                         "expression": {
-                          "type": "StringExpression",
+                          "type": "StringLiteral",
                           "value": ".",
                           "span": {
                             "type": "Span",

--- a/fluent-syntax/test/fixtures_structure/variant_with_empty_pattern.json
+++ b/fluent-syntax/test/fixtures_structure/variant_with_empty_pattern.json
@@ -21,7 +21,7 @@
             "expression": {
               "type": "SelectExpression",
               "expression": {
-                "type": "NumberExpression",
+                "type": "NumberLiteral",
                 "value": "1",
                 "span": {
                   "type": "Span",
@@ -47,7 +47,7 @@
                       {
                         "type": "Placeable",
                         "expression": {
-                          "type": "StringExpression",
+                          "type": "StringLiteral",
                           "value": "",
                           "span": {
                             "type": "Span",

--- a/fluent-syntax/test/serializer_test.js
+++ b/fluent-syntax/test/serializer_test.js
@@ -481,7 +481,7 @@ suite('Serialize resource', function() {
 
   test('call expression with positional and named arguments', function() {
     const input = ftl`
-      foo = { FOO(bar, baz: "baz", 1) }
+      foo = { FOO(bar, 1, baz: "baz") }
     `;
     assert.equal(pretty(input), input);
   });


### PR DESCRIPTION
Addresses two items from #206 list:

- Named arguments to CallExpression must now follow all positional ones.
- Forbid duplicate named arguments to CallExpressions.