### PR TITLE
WIP ReactLocalization: Accept async iterables of contexts

### DIFF
--- a/fluent-react/examples/fallback-async/package.json
+++ b/fluent-react/examples/fallback-async/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fluent-react-example-fallback-async",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "react-scripts": "1.1.0"
+  },
+  "dependencies": {
+    "babel-polyfill": "^6.26.0",
+    "fluent": "file:../../../fluent",
+    "fluent-intl-polyfill": "file:../../../fluent-intl-polyfill",
+    "fluent-react": "file:../../../fluent-react",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/fluent-react/examples/fallback-async/public/index.html
+++ b/fluent-react/examples/fallback-async/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Fallback Async - a fluent-react example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/fluent-react/examples/fallback-async/src/App.js
+++ b/fluent-react/examples/fallback-async/src/App.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Localized } from 'fluent-react/compat';
+
+export default function App() {
+  return (
+    <div>
+      <p>
+        <em>This example is hardcoded to use <code>['pl', 'en-US']</code>.</em>
+      </p>
+
+      <Localized id="foo">
+        <p>Foo</p>
+      </Localized>
+
+      <Localized id="bar">
+        <p>Bar</p>
+      </Localized>
+
+      <Localized id="baz">
+        <p>Baz is missing from all locales</p>
+      </Localized>
+
+      <Localized id="qux" $baz="Baz">
+        <p>{'Qux is like { $baz }: missing from all locales.'}</p>
+      </Localized>
+    </div>
+  );
+}

--- a/fluent-react/examples/fallback-async/src/index.js
+++ b/fluent-react/examples/fallback-async/src/index.js
@@ -1,0 +1,14 @@
+import 'babel-polyfill';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { LocalizationProvider } from 'fluent-react/compat';
+
+import { generateMessages } from './l10n';
+import App from './App';
+
+ReactDOM.render(
+  <LocalizationProvider messages={generateMessages()}>
+    <App />
+  </LocalizationProvider>,
+  document.getElementById('root')
+);

--- a/fluent-react/examples/fallback-async/src/l10n.js
+++ b/fluent-react/examples/fallback-async/src/l10n.js
@@ -1,0 +1,45 @@
+import 'fluent-intl-polyfill/compat';
+import { MessageContext } from 'fluent/compat';
+
+const MESSAGES_ALL = {
+  'pl': `
+foo = Foo po polsku
+  `,
+  'en-US': `
+foo = Foo in English
+bar = Bar in English
+  `,
+};
+
+
+// create-react-app is rather outdated at this point when it comes to modern JS
+// support. It's not configured to understand async generators. The function
+// below is equivalent to the following generator function:
+//
+//     export async function* generateMessages() {
+//       for (const locale of ['pl', 'en-US']) {
+//         const cx = new MessageContext(locale);
+//         cx.addMessages(MESSAGES_ALL[locale]);
+//         yield cx;
+//       }
+//    }
+
+export function generateMessages() {
+  const locales = ["pl", "en-US"];
+  return {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    async next() {
+      const locale = locales.shift();
+
+      if (locale === undefined) {
+        return {value: undefined, done: true};
+      }
+
+      const cx = new MessageContext(locale);
+      cx.addMessages(MESSAGES_ALL[locale]);
+      return {value: cx, done: false};
+    }
+  };
+}

--- a/fluent-react/makefile
+++ b/fluent-react/makefile
@@ -1,6 +1,6 @@
 PACKAGE := fluent-react
 GLOBAL  := FluentReact
-DEPS    := fluent:Fluent,react:React,prop-types:PropTypes
+DEPS    := fluent:Fluent,cached-iterable:CachedIterable,react:React,prop-types:PropTypes
 
 include ../common.mk
 

--- a/fluent-react/src/cached_async_iterable.js
+++ b/fluent-react/src/cached_async_iterable.js
@@ -1,0 +1,86 @@
+/*
+ * CachedAsyncIterable caches the elements yielded by an async iterable.
+ *
+ * It can be used to iterate over an iterable many times without depleting the
+ * iterable.
+ */
+export default class CachedAsyncIterable {
+    /**
+     * Create an `CachedAsyncIterable` instance.
+     *
+     * @param {Iterable} iterable
+     * @returns {CachedAsyncIterable}
+     */
+    constructor(iterable) {
+        if (Symbol.asyncIterator in Object(iterable)) {
+            this.iterator = iterable[Symbol.asyncIterator]();
+        } else if (Symbol.iterator in Object(iterable)) {
+            this.iterator = iterable[Symbol.iterator]();
+        } else {
+            throw new TypeError("Argument must implement the iteration protocol.");
+        }
+
+        this.seen = [];
+    }
+
+    /**
+     * Synchronous iterator over the cached elements.
+     *
+     * Return a generator object implementing the iterator protocol over the
+     * cached elements of the original (async or sync) iterable.
+     */
+    [Symbol.iterator]() {
+        const {seen} = this;
+        let cur = 0;
+
+        return {
+            next() {
+                if (seen.length === cur) {
+                    return {value: undefined, done: true};
+                }
+                return seen[cur++];
+            }
+        };
+    }
+
+    /**
+     * Asynchronous iterator caching the yielded elements.
+     *
+     * Elements yielded by the original iterable will be cached and available
+     * synchronously. Returns an async generator object implementing the
+     * iterator protocol over the elements of the original (async or sync)
+     * iterable.
+     */
+    [Symbol.asyncIterator]() {
+        const { seen, iterator } = this;
+        let cur = 0;
+
+        return {
+            async next() {
+                if (seen.length <= cur) {
+                    seen.push(await iterator.next());
+                }
+                return seen[cur++];
+            }
+        };
+    }
+
+    /**
+     * This method allows user to consume the next element from the iterator
+     * into the cache.
+     *
+     * @param {number} count - number of elements to consume
+     */
+    async touchNext(count = 1) {
+        const { seen, iterator } = this;
+        let idx = 0;
+        while (idx++ < count) {
+            if (seen.length === 0 || seen[seen.length - 1].done === false) {
+                seen.push(await iterator.next());
+            }
+        }
+        // Return the last cached {value, done} object to allow the calling
+        // code to decide if it needs to call touchNext again.
+        return seen[seen.length - 1];
+    }
+}

--- a/fluent-react/src/provider.js
+++ b/fluent-react/src/provider.js
@@ -30,7 +30,7 @@ export default class LocalizationProvider extends Component {
       throw new Error("LocalizationProvider must receive the messages prop.");
     }
 
-    if (!messages[Symbol.iterator]) {
+    if (!messages[Symbol.iterator] && !messages[Symbol.asyncIterator]) {
       throw new Error("The messages prop must be an iterable.");
     }
 
@@ -69,6 +69,10 @@ function isIterable(props, propName, componentName) {
   const prop = props[propName];
 
   if (Symbol.iterator in Object(prop)) {
+    return null;
+  }
+
+  if (Symbol.asyncIterator in Object(prop)) {
     return null;
   }
 


### PR DESCRIPTION
This is a WIP with a proposed fix to #100. It requires https://github.com/projectfluent/cached-iterable/pull/1 to land in `cached-iterable`. In order to make testing easier, I included the `cached_async_iterable.js` file in `fluent-react/src`.

All tests fail for now because the rendering now takes more than one even loop cycle. This also needs more tests. I added an example webapp in `examples/fallback-async` which I was able to test this on. (It worked.)