### PR TITLE
Define the browser support matrix

### DIFF
--- a/babel_config.js
+++ b/babel_config.js
@@ -6,16 +6,28 @@ export default {
       modules: false,
       targets: {
         browsers: [
-          ">1%",
-          "last 4 versions",
-          "Firefox ESR",
-          "not ie < 9"
-        ]
-      }
+          "Firefox >= 52",
+          "FirefoxAndroid >= 52",
+          "Chrome >= 55",
+          "ChromeAndroid >= 55",
+          "Edge >= 15",
+          "Safari >= 10.1",
+          "iOS >= 10.3",
+        ],
+        node: "8.9",
+      },
+      exclude: [
+        // Exclude regeneratorRuntime explicitly because babel-preset-env
+        // incorrectly transpiles async functions for Firefox 52.
+        // See https://github.com/babel/babel/issues/8086.
+        "transform-regenerator"
+      ],
     }]
   ],
   plugins: [
+    // Shipped in Firefox 57, Chrome 63
     "@babel/plugin-proposal-async-generator-functions",
+    // Shipped in Firefox 55, Chrome 60
     "@babel/plugin-proposal-object-rest-spread"
   ]
 };

--- a/fluent-dom/CHANGELOG.md
+++ b/fluent-dom/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
 ## Unreleased
-  - …
+
+  - Drop support for IE and old evergreen browsers. (#133)
+
+    Currently supported are: Firefox 52+, Chrome 55+, Edge 15+, Safari 10.1+,
+    iOS Safari 10.3+ and node 8.9+.
 
 ## fluent-dom 0.3.0
+
   - Refactor the overlay sanitization methods into separate functions. (#189)
   - Separate out CachedIterable and CachedAsyncIterable, and add a param to touchNext. (#191)
   - Localization.formatValues should accept an array of objects. (#198)

--- a/fluent-intl-polyfill/CHANGELOG.md
+++ b/fluent-intl-polyfill/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+  - Drop support for IE and old evergreen browsers. (#133)
+
+    Currently supported are: Firefox 52+, Chrome 55+, Edge 15+, Safari 10.1+,
+    iOS Safari 10.3+ and node 8.9+.
+
   - The compat build is now transpiled using rollup-plugin-babel.
 
     This ensures that the "use strict" pragma is scoped to the UMD wrapper.  It

--- a/fluent-langneg/CHANGELOG.md
+++ b/fluent-langneg/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-  - …
+  - Drop support for IE and old evergreen browsers. (#133)
+
+    Currently supported are: Firefox 52+, Chrome 55+, Edge 15+, Safari 10.1+,
+    iOS Safari 10.3+ and node 8.9+.
 
 ## fluent-langneg 0.1.0 (August 17, 2017)
 

--- a/fluent-react/CHANGELOG.md
+++ b/fluent-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+  - Drop support for IE and old evergreen browsers. (#133)
+
+    Currently supported are: Firefox 52+, Chrome 55+, Edge 15+, Safari 10.1+,
+    iOS Safari 10.3+ and node 8.9+.
+
 ## fluent-react 0.7.0 (May 18, 2018)
 
   - Protect void elements against translated text content. (#174)

--- a/fluent-syntax/CHANGELOG.md
+++ b/fluent-syntax/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+  - Drop support for IE and old evergreen browsers. (#133)
+
+    Currently supported are: Firefox 52+, Chrome 55+, Edge 15+, Safari 10.1+,
+    iOS Safari 10.3+ and node 8.9+.
+
 ## fluent-syntax 0.7.0 (April 17, 2018)
 
   - Add the `ref` field to `VariantExpression`.

--- a/fluent-web/CHANGELOG.md
+++ b/fluent-web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+  - Drop support for IE and old evergreen browsers. (#133)
+
+    Currently supported are: Firefox 52+, Chrome 55+, Edge 15+, Safari 10.1+,
+    iOS Safari 10.3+ and node 8.9+.
+
 ## fluent-web 0.0.1
 
   - The initial release.

--- a/fluent/CHANGELOG.md
+++ b/fluent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+  - Drop support for IE and old evergreen browsers. (#133)
+
+    Currently supported are: Firefox 52+, Chrome 55+, Edge 15+, Safari 10.1+,
+    iOS Safari 10.3+ and node 8.9+.
+
 ## fluent 0.6.4 (April 11, 2018)
 
   - Minor optimization to bidirectionality isolation


### PR DESCRIPTION
Fluent's `compat` builds will from now on work in all browsers which support async functions. 

Fix #133.