### PR TITLE
adds handling of CRLF to the FTL parser

### DIFF
--- a/fluent-syntax/src/stream.js
+++ b/fluent-syntax/src/stream.js
@@ -1,7 +1,8 @@
 export class ParserStream {
   constructor(string) {
-    this.string = string;
-    this.iter = string[Symbol.iterator]();
+    this.string = string.indexOf("\r") !== -1 ?
+      string.replace(/(?:\r\n)/g, "\n") : string;
+    this.iter = this.string[Symbol.iterator]();
     this.buf = [];
     this.peekIndex = 0;
     this.index = 0;

--- a/fluent-syntax/test/behavior_test.js
+++ b/fluent-syntax/test/behavior_test.js
@@ -72,6 +72,8 @@ readdir(fixtures, function(err, filenames) {
       const filepath = join(fixtures, filename);
       test(filename, function() {
         return readfile(filepath).then(file => {
+          file = file.indexOf("\r") !== -1 ?
+            file.replace(/(?:\r\n)/g, "\n") : file;
           const { directives, source } = preprocess(file);
           const expected = directives.join('\n') + '\n';
           const ast = parse(source);

--- a/fluent/src/parser.js
+++ b/fluent/src/parser.js
@@ -30,7 +30,8 @@ class RuntimeParser {
    * @returns {Array<Object, Array>}
    */
   getResource(string) {
-    this._source = string;
+    this._source = string.indexOf("\r") !== -1 ?
+      string.replace(/(?:\r\n)/g, "\n") : string;
     this._index = 0;
     this._length = string.length;
     this.entries = {};


### PR DESCRIPTION
Currently '\r' characters appear if the FTL file has CRLF line endings -- this makes the parser check for them, and strip them out which is useful for FTL files edited on Windows