### PR TITLE
add jsdom as a peer dependency

### DIFF
--- a/fluent-react/package.json
+++ b/fluent-react/package.json
@@ -50,6 +50,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
+    "jsdom": "^10.0.0 || ^11.0.0",
     "react": "^0.14.9 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
@@ -57,7 +58,7 @@
     "babel-plugin-transform-rename-import": "^2.2.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "jsdom": "^11.6.2",
+    "jsdom": "^11.10.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "sinon": "^4.2.2"

--- a/fluent-react/src/markup.js
+++ b/fluent-react/src/markup.js
@@ -1,6 +1,12 @@
-/* eslint-env browser */
-
-const TEMPLATE = document.createElement("template");
+/* global window, require */
+let doc = null;
+if (typeof(window) === "undefined" || !window || !window.document) {
+  const jsdom = require("jsdom");
+  doc = new jsdom.JSDOM("<html><body></body></html>").window.document;
+} else {
+  doc = window.document;
+}
+const TEMPLATE = doc.createElement("template");
 
 export function parseMarkup(str) {
   TEMPLATE.innerHTML = str;


### PR DESCRIPTION
This adds jsdom as a peer dependency, and in fluent-react uses it when not running in a browser environment.  This is useful for SSR as the get the code to work all that you need to do is to install jsdom.