### PR TITLE
Parse Comments as standalone if they're attached to Junk

### DIFF
--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -28,15 +28,21 @@ export class FTLParserStream extends ParserStream {
   }
 
   skipBlankLines() {
+    // Many Parser methods leave the cursor at the line break
+    // without going into the next line. We want to count fully blank lines in
+    // this case. Starting the count at -1 will give the right number.
+    let lineCount = this.currentIs("\n") ? -1 : 0;
+
     while (true) {
       this.peekInlineWS();
 
       if (this.currentPeekIs("\n")) {
         this.skipToPeek();
         this.next();
+        lineCount++;
       } else {
         this.resetPeek();
-        break;
+        return lineCount;
       }
     }
   }

--- a/fluent-syntax/test/entry_test.js
+++ b/fluent-syntax/test/entry_test.js
@@ -5,7 +5,7 @@ import { FluentParser, FluentSerializer } from '../src';
 
 suite('Parse entry', function() {
   setup(function() {
-    this.parser = new FluentParser();
+    this.parser = new FluentParser({withSpans: false});
   });
 
   test('simple message', function() {
@@ -14,42 +14,136 @@ suite('Parse entry', function() {
     `;
     const output = {
       "comment": null,
-      "span": {
-        "start": 0,
-        "end": 9,
-        "type": "Span"
-      },
       "value": {
         "elements": [
           {
             "type": "TextElement",
-            "value": "Foo",
-            "span": {
-              "start": 6,
-              "end": 9,
-              "type": "Span"
-            }
+            "value": "Foo"
           }
         ],
-        "type": "Pattern",
-        "span": {
-          "start": 6,
-          "end": 9,
-          "type": "Span"
-        }
+        "type": "Pattern"
       },
       "annotations": [],
       "attributes": [],
       "type": "Message",
       "id": {
         "type": "Identifier",
-        "name": "foo",
-        "span": {
-          "start": 0,
-          "end": 3,
-          "type": "Span"
-        }
+        "name": "foo"
       }
+    };
+
+    const message = this.parser.parseEntry(input)
+    assert.deepEqual(message, output)
+  });
+
+  test('ignore attached comment', function() {
+    const input = ftl`
+      # Attached Comment
+      foo = Foo
+    `;
+    const output = {
+      "comment": null,
+      "value": {
+        "elements": [
+          {
+            "type": "TextElement",
+            "value": "Foo"
+          }
+        ],
+        "type": "Pattern"
+      },
+      "annotations": [],
+      "attributes": [],
+      "type": "Message",
+      "id": {
+        "type": "Identifier",
+        "name": "foo"
+      }
+    };
+
+    const message = this.parser.parseEntry(input)
+    assert.deepEqual(message, output)
+  });
+
+  test('return junk', function() {
+    const input = ftl`
+      # Attached Comment
+      junk
+    `;
+    const output = {
+      "content": "junk\n",
+      "annotations": [
+        {
+          "args": ["="],
+          "code": "E0003",
+          "message": "Expected token: \"=\"",
+          "span": {
+            "end": 23,
+            "start": 23,
+            "type": "Span"
+          },
+          "type": "Annotation"
+        }
+      ],
+      "type": "Junk"
+    };
+
+    const message = this.parser.parseEntry(input)
+    assert.deepEqual(message, output)
+  });
+
+  test('ignore all valid comments', function() {
+    const input = ftl`
+      # Attached Comment
+      ## Group Comment
+      ### Resource Comment
+      foo = Foo
+    `;
+    const output = {
+      "comment": null,
+      "value": {
+        "elements": [
+          {
+            "type": "TextElement",
+            "value": "Foo"
+          }
+        ],
+        "type": "Pattern"
+      },
+      "annotations": [],
+      "attributes": [],
+      "type": "Message",
+      "id": {
+        "type": "Identifier",
+        "name": "foo"
+      }
+    };
+
+    const message = this.parser.parseEntry(input)
+    assert.deepEqual(message, output)
+  });
+
+  test('do not ignore invalid comments', function() {
+    const input = ftl`
+      # Attached Comment
+      ##Invalid Comment
+    `;
+    const output = {
+      "content": "##Invalid Comment\n",
+      "annotations": [
+        {
+          "args": [" "],
+          "code": "E0003",
+          "message": "Expected token: \" \"",
+          "span": {
+            "end": 21,
+            "start": 21,
+            "type": "Span"
+          },
+          "type": "Annotation"
+        }
+      ],
+      "type": "Junk"
     };
 
     const message = this.parser.parseEntry(input)
@@ -66,11 +160,6 @@ suite('Serialize entry', function() {
   test('simple message', function() {
     const input = {
       "comment": null,
-      "span": {
-        "start": 0,
-        "end": 9,
-        "type": "Span"
-      },
       "value": {
         "elements": [
           {
@@ -78,24 +167,14 @@ suite('Serialize entry', function() {
             "value": "Foo"
           }
         ],
-        "type": "Pattern",
-        "span": {
-          "start": 6,
-          "end": 9,
-          "type": "Span"
-        }
+        "type": "Pattern"
       },
       "annotations": [],
       "attributes": [],
       "type": "Message",
       "id": {
         "type": "Identifier",
-        "name": "foo",
-        "span": {
-          "start": 0,
-          "end": 3,
-          "type": "Span"
-        }
+        "name": "foo"
       }
     };
     const output = ftl`

--- a/fluent-syntax/test/fixtures_structure/leading_dots.json
+++ b/fluent-syntax/test/fixtures_structure/leading_dots.json
@@ -322,6 +322,16 @@
       }
     },
     {
+      "type": "Comment",
+      "annotations": [],
+      "content": "ERROR (attr .Continued must have a value)",
+      "span": {
+        "type": "Span",
+        "start": 142,
+        "end": 185
+      }
+    },
+    {
       "type": "Junk",
       "annotations": [
         {
@@ -338,11 +348,21 @@
           }
         }
       ],
-      "content": "# ERROR (attr .Continued must have a value)\nkey07 = Value\n    .Continued\n\n",
+      "content": "key07 = Value\n    .Continued\n\n",
       "span": {
         "type": "Span",
-        "start": 142,
+        "start": 186,
         "end": 216
+      }
+    },
+    {
+      "type": "Comment",
+      "annotations": [],
+      "content": "ERROR (attr .Value must have a value)",
+      "span": {
+        "type": "Span",
+        "start": 216,
+        "end": 255
       }
     },
     {
@@ -362,11 +382,21 @@
           }
         }
       ],
-      "content": "# ERROR (attr .Value must have a value)\nkey08 =\n    .Value\n\n",
+      "content": "key08 =\n    .Value\n\n",
       "span": {
         "type": "Span",
-        "start": 216,
+        "start": 256,
         "end": 276
+      }
+    },
+    {
+      "type": "Comment",
+      "annotations": [],
+      "content": "ERROR (attr .Value must have a value)",
+      "span": {
+        "type": "Span",
+        "start": 276,
+        "end": 315
       }
     },
     {
@@ -386,10 +416,10 @@
           }
         }
       ],
-      "content": "# ERROR (attr .Value must have a value)\nkey09 =\n    .Value\n    Continued\n\n",
+      "content": "key09 =\n    .Value\n    Continued\n\n",
       "span": {
         "type": "Span",
-        "start": 276,
+        "start": 316,
         "end": 350
       }
     },
@@ -847,6 +877,16 @@
       }
     },
     {
+      "type": "Comment",
+      "annotations": [],
+      "content": "ERROR (variant must have a value)",
+      "span": {
+        "type": "Span",
+        "start": 687,
+        "end": 722
+      }
+    },
+    {
       "type": "Junk",
       "annotations": [
         {
@@ -861,11 +901,21 @@
           }
         }
       ],
-      "content": "# ERROR (variant must have a value)\nkey16 =\n    { 1 ->\n       *[one]\n           .Value\n    }\n\n",
+      "content": "key16 =\n    { 1 ->\n       *[one]\n           .Value\n    }\n\n",
       "span": {
         "type": "Span",
-        "start": 687,
+        "start": 723,
         "end": 781
+      }
+    },
+    {
+      "type": "Comment",
+      "annotations": [],
+      "content": "ERROR (unclosed placeable)",
+      "span": {
+        "type": "Span",
+        "start": 781,
+        "end": 809
       }
     },
     {
@@ -885,10 +935,10 @@
           }
         }
       ],
-      "content": "# ERROR (unclosed placeable)\nkey17 =\n    { 1 ->\n       *[one] Value\n           .Continued\n    }\n",
+      "content": "key17 =\n    { 1 ->\n       *[one] Value\n           .Continued\n    }\n",
       "span": {
         "type": "Span",
-        "start": 781,
+        "start": 810,
         "end": 877
       }
     }


### PR DESCRIPTION
Syntax 0.6 changes the parsing logic of `Comments`. `Comments` attached to what ends up being `Junk` are not part of `Junk` anymore. Instead, they end up as standalone `Comments` in the final `Resource`.

This PR also changes the behavior of `FluentParser.parseEntry()` to ignore all valid comments and only start parsing when a `Message` or a `Term` is encountered. `Comments` with syntax errors are not skipped, however.