### PR TITLE
Support Unicode escape sequences in both parsers

### DIFF
--- a/fluent-syntax/src/errors.js
+++ b/fluent-syntax/src/errors.js
@@ -66,6 +66,14 @@ function getErrorMessage(code, args) {
       return "VariantLists are only allowed inside of other VariantLists.";
     case "E0024":
       return "Cannot access variants of a message.";
+    case "E0025": {
+      const [char] = args;
+      return `Unknown escape sequence: \\${char}.`;
+    }
+    case "E0026": {
+      const [char] = args;
+      return `Invalid Unicode escape sequence: \\u${char}.`;
+    }
     default:
       return code;
   }

--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -88,14 +88,6 @@ export class FTLParserStream extends ParserStream {
     this.skipInlineWS();
   }
 
-  takeCharIf(ch) {
-    if (this.ch === ch) {
-      this.next();
-      return true;
-    }
-    return false;
-  }
-
   takeChar(f) {
     const ch = this.ch;
     if (ch !== undefined && f(ch)) {
@@ -323,6 +315,17 @@ export class FTLParserStream extends ParserStream {
     const closure = ch => {
       const cc = ch.charCodeAt(0);
       return (cc >= 48 && cc <= 57); // 0-9
+    };
+
+    return this.takeChar(closure);
+  }
+
+  takeHexDigit() {
+    const closure = ch => {
+      const cc = ch.charCodeAt(0);
+      return (cc >= 48 && cc <= 57) // 0-9
+        || (cc >= 65 && cc <= 70) // A-F
+        || (cc >= 97 && cc <= 102); // a-f
     };
 
     return this.takeChar(closure);

--- a/fluent-syntax/test/fixtures_behavior/escape_sequences.ftl
+++ b/fluent-syntax/test/fixtures_behavior/escape_sequences.ftl
@@ -1,0 +1,10 @@
+#~ ERROR E0025, pos 8, args "A"
+key1 = \A
+
+#~ ERROR E0026, pos 23, args "000z"
+key2 = \u000z
+
+key3 = \{Escaped}
+key4 = {"Escaped \" quote"}
+key5 = \u0041
+key6 = \\u0041

--- a/fluent-syntax/test/fixtures_structure/escape_sequences.ftl
+++ b/fluent-syntax/test/fixtures_structure/escape_sequences.ftl
@@ -1,0 +1,9 @@
+backslash = Value with \\ (an escaped backslash)
+closing-brace = Value with \{ (an opening brace)
+unicode-escape = \u0041
+escaped-unicode = \\u0041
+
+## String Expressions
+quote-in-string = {"\""}
+backslash-in-string = {"\\"}
+mismatched-quote = {"\\""}

--- a/fluent-syntax/test/fixtures_structure/escape_sequences.json
+++ b/fluent-syntax/test/fixtures_structure/escape_sequences.json
@@ -1,0 +1,294 @@
+{
+  "type": "Resource",
+  "body": [
+    {
+      "type": "Message",
+      "annotations": [],
+      "id": {
+        "type": "Identifier",
+        "name": "backslash",
+        "span": {
+          "type": "Span",
+          "start": 0,
+          "end": 9
+        }
+      },
+      "value": {
+        "type": "Pattern",
+        "elements": [
+          {
+            "type": "TextElement",
+            "value": "Value with \\\\ (an escaped backslash)",
+            "span": {
+              "type": "Span",
+              "start": 12,
+              "end": 48
+            }
+          }
+        ],
+        "span": {
+          "type": "Span",
+          "start": 12,
+          "end": 48
+        }
+      },
+      "attributes": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 0,
+        "end": 48
+      }
+    },
+    {
+      "type": "Message",
+      "annotations": [],
+      "id": {
+        "type": "Identifier",
+        "name": "closing-brace",
+        "span": {
+          "type": "Span",
+          "start": 49,
+          "end": 62
+        }
+      },
+      "value": {
+        "type": "Pattern",
+        "elements": [
+          {
+            "type": "TextElement",
+            "value": "Value with \\{ (an opening brace)",
+            "span": {
+              "type": "Span",
+              "start": 65,
+              "end": 97
+            }
+          }
+        ],
+        "span": {
+          "type": "Span",
+          "start": 65,
+          "end": 97
+        }
+      },
+      "attributes": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 49,
+        "end": 97
+      }
+    },
+    {
+      "type": "Message",
+      "annotations": [],
+      "id": {
+        "type": "Identifier",
+        "name": "unicode-escape",
+        "span": {
+          "type": "Span",
+          "start": 98,
+          "end": 112
+        }
+      },
+      "value": {
+        "type": "Pattern",
+        "elements": [
+          {
+            "type": "TextElement",
+            "value": "\\u0041",
+            "span": {
+              "type": "Span",
+              "start": 115,
+              "end": 121
+            }
+          }
+        ],
+        "span": {
+          "type": "Span",
+          "start": 115,
+          "end": 121
+        }
+      },
+      "attributes": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 98,
+        "end": 121
+      }
+    },
+    {
+      "type": "Message",
+      "annotations": [],
+      "id": {
+        "type": "Identifier",
+        "name": "escaped-unicode",
+        "span": {
+          "type": "Span",
+          "start": 122,
+          "end": 137
+        }
+      },
+      "value": {
+        "type": "Pattern",
+        "elements": [
+          {
+            "type": "TextElement",
+            "value": "\\\\u0041",
+            "span": {
+              "type": "Span",
+              "start": 140,
+              "end": 147
+            }
+          }
+        ],
+        "span": {
+          "type": "Span",
+          "start": 140,
+          "end": 147
+        }
+      },
+      "attributes": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 122,
+        "end": 147
+      }
+    },
+    {
+      "type": "GroupComment",
+      "annotations": [],
+      "content": "String Expressions\n",
+      "span": {
+        "type": "Span",
+        "start": 149,
+        "end": 170
+      }
+    },
+    {
+      "type": "Message",
+      "annotations": [],
+      "id": {
+        "type": "Identifier",
+        "name": "quote-in-string",
+        "span": {
+          "type": "Span",
+          "start": 171,
+          "end": 186
+        }
+      },
+      "value": {
+        "type": "Pattern",
+        "elements": [
+          {
+            "type": "Placeable",
+            "expression": {
+              "type": "StringLiteral",
+              "value": "\\\"",
+              "span": {
+                "type": "Span",
+                "start": 190,
+                "end": 194
+              }
+            },
+            "span": {
+              "type": "Span",
+              "start": 189,
+              "end": 195
+            }
+          }
+        ],
+        "span": {
+          "type": "Span",
+          "start": 189,
+          "end": 195
+        }
+      },
+      "attributes": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 171,
+        "end": 195
+      }
+    },
+    {
+      "type": "Message",
+      "annotations": [],
+      "id": {
+        "type": "Identifier",
+        "name": "backslash-in-string",
+        "span": {
+          "type": "Span",
+          "start": 196,
+          "end": 215
+        }
+      },
+      "value": {
+        "type": "Pattern",
+        "elements": [
+          {
+            "type": "Placeable",
+            "expression": {
+              "type": "StringLiteral",
+              "value": "\\\\",
+              "span": {
+                "type": "Span",
+                "start": 219,
+                "end": 223
+              }
+            },
+            "span": {
+              "type": "Span",
+              "start": 218,
+              "end": 224
+            }
+          }
+        ],
+        "span": {
+          "type": "Span",
+          "start": 218,
+          "end": 224
+        }
+      },
+      "attributes": [],
+      "comment": null,
+      "span": {
+        "type": "Span",
+        "start": 196,
+        "end": 224
+      }
+    },
+    {
+      "type": "Junk",
+      "annotations": [
+        {
+          "type": "Annotation",
+          "code": "E0003",
+          "args": [
+            "}"
+          ],
+          "message": "Expected token: \"}\"",
+          "span": {
+            "type": "Span",
+            "start": 249,
+            "end": 249
+          }
+        }
+      ],
+      "content": "mismatched-quote = {\"\\\\\"\"}\n",
+      "span": {
+        "type": "Span",
+        "start": 225,
+        "end": 252
+      }
+    }
+  ],
+  "span": {
+    "type": "Span",
+    "start": 0,
+    "end": 252
+  }
+}

--- a/fluent-syntax/test/serializer_test.js
+++ b/fluent-syntax/test/serializer_test.js
@@ -614,4 +614,25 @@ suite('Serialize padding around comments', function() {
     assert.equal(pretty(input), input);
     assert.equal(pretty(input), input);
   });
+
+  test('Escaped special char in TextElement', function() {
+    const input = ftl`
+      foo = \\{Escaped}
+    `;
+    assert.equal(pretty(input), input);
+  });
+
+  test('Escaped special char in StringLiteral', function() {
+    const input = ftl`
+      foo = { "Escaped \\" quote" }
+    `;
+    assert.equal(pretty(input), input);
+  });
+
+  test('Unicode escape sequence', function() {
+    const input = ftl`
+      foo = \\u0065
+    `;
+    assert.equal(pretty(input), input);
+  });
 });

--- a/fluent/test/fixtures_behavior/escape_sequences.json
+++ b/fluent/test/fixtures_behavior/escape_sequences.json
@@ -1,0 +1,14 @@
+{
+  "key3": {
+    "value": true
+  },
+  "key4": {
+    "value": true
+  },
+  "key5": {
+    "value": true
+  },
+  "key6": {
+    "value": true
+  }
+}

--- a/fluent/test/fixtures_structure/escape_sequences.json
+++ b/fluent/test/fixtures_structure/escape_sequences.json
@@ -1,0 +1,16 @@
+{
+  "backslash": "Value with \\ (an escaped backslash)",
+  "closing-brace": "Value with { (an opening brace)",
+  "unicode-escape": "A",
+  "escaped-unicode": "\\u0041",
+  "quote-in-string": {
+    "val": [
+      "\""
+    ]
+  },
+  "backslash-in-string": {
+    "val": [
+      "\\"
+    ]
+  }
+}


### PR DESCRIPTION
Unicode sequences and other valid escaped characters are kept verbatim in the tooling AST. The runtime parser unescapes them.