### PR TITLE
WIP Broken Attributes should not break the whole Entry 

### DIFF
--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -287,9 +287,16 @@ export default class FluentParser {
     const attrs = [];
 
     while (true) {
+      const lineStart = ps.getIndex() + 1;
       ps.expectIndent();
-      const attr = this.getAttribute(ps);
-      attrs.push(attr);
+
+      try {
+        const attr = this.getAttribute(ps);
+        attrs.push(attr);
+      } catch (err) {
+        ps.setIndex(lineStart);
+        return attrs;
+      }
 
       if (!ps.isPeekNextLineAttributeStart()) {
         break;

--- a/fluent-syntax/src/stream.js
+++ b/fluent-syntax/src/stream.js
@@ -86,6 +86,10 @@ export class ParserStream {
     return this.index;
   }
 
+  setIndex(idx) {
+    return this.index = idx;
+  }
+
   getPeekIndex() {
     return this.peekIndex;
   }

--- a/fluent-syntax/test/reference_test.js
+++ b/fluent-syntax/test/reference_test.js
@@ -34,11 +34,6 @@ readdir(fixtures, function(err, filenames) {
       // There's even a behavior fixture for this; it must have been a
       // deliberate decision.
       "select_expressions.ftl",
-
-      // Broken Attributes break the entire Entry right now.
-      // https://github.com/projectfluent/fluent.js/issues/237
-      "leading_dots.ftl",
-      "variant_lists.ftl"
     ];
 
     for (const filename of ftlnames) {


### PR DESCRIPTION
_This is a WIP._ Fix #237.

To do:

- [ ] Runtime parser.
- [ ] Report the proper error.