### PR TITLE
Fix span.start for Messages/Terms with Comments, fixes #255

### DIFF
--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -14,20 +14,13 @@ function withSpan(fn) {
       return fn.call(this, ps, ...args);
     }
 
-    let start = ps.getIndex();
+    const start = ps.getIndex();
     const node = fn.call(this, ps, ...args);
 
     // Don't re-add the span if the node already has it.  This may happen when
     // one decorated function calls another decorated function.
     if (node.span) {
       return node;
-    }
-
-    // Spans of Messages should include the attached Comment.
-    if (node.type === "Message") {
-      if (node.comment !== null) {
-        start = node.comment.span.start;
-      }
     }
 
     const end = ps.getIndex();
@@ -80,6 +73,9 @@ export default class FluentParser {
       if (lastComment) {
         if (entry.type === "Message" || entry.type === "Term") {
           entry.comment = lastComment;
+          if (this.withSpans) {
+            entry.span.start = entry.comment.span.start;
+          }
         } else {
           entries.push(lastComment);
         }

--- a/fluent-syntax/test/fixtures_structure/whitespace_leading.json
+++ b/fluent-syntax/test/fixtures_structure/whitespace_leading.json
@@ -45,7 +45,7 @@
       },
       "span": {
         "type": "Span",
-        "start": 21,
+        "start": 0,
         "end": 46
       }
     },
@@ -93,7 +93,7 @@
       },
       "span": {
         "type": "Span",
-        "start": 65,
+        "start": 48,
         "end": 84
       }
     },

--- a/fluent-syntax/test/fixtures_structure/whitespace_trailing.json
+++ b/fluent-syntax/test/fixtures_structure/whitespace_trailing.json
@@ -45,7 +45,7 @@
       },
       "span": {
         "type": "Span",
-        "start": 27,
+        "start": 0,
         "end": 53
       }
     },
@@ -93,7 +93,7 @@
       },
       "span": {
         "type": "Span",
-        "start": 77,
+        "start": 55,
         "end": 96
       }
     },


### PR DESCRIPTION
Move the message.span.start logic from the wrapper to the point
where the comment is hooked up to the message.
As the message already has the span when it gets there, the
wrapper refuses to do it again.

Back-porting a similar fix I have for python.