### PR TITLE
Fix Comment span to include the terminal line break

### DIFF
--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -28,11 +28,7 @@ export class FTLParserStream extends ParserStream {
   }
 
   skipBlankLines() {
-    // Many Parser methods leave the cursor at the line break
-    // without going into the next line. We want to count fully blank lines in
-    // this case. Starting the count at -1 will give the right number.
-    let lineCount = this.currentIs("\n") ? -1 : 0;
-
+    let lineCount = 0;
     while (true) {
       this.peekInlineWS();
 

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -190,18 +190,20 @@ export default class FluentParser {
         }
       }
 
-      if (!ps.currentIs(undefined)) {
-        content += "\n";
-      } else {
-        break;
-      }
-
       if (ps.isPeekNextLineComment(level)) {
+        content += ps.current();
         ps.next();
       } else {
         break;
       }
     }
+
+    // Add the terminal line break.
+    if (!ps.currentIs(undefined)) {
+      content += ps.current();
+      ps.next();
+    }
+
 
     let Comment;
     switch (level) {

--- a/fluent-syntax/test/fixtures_structure/escape_sequences.json
+++ b/fluent-syntax/test/fixtures_structure/escape_sequences.json
@@ -164,7 +164,7 @@
       "span": {
         "type": "Span",
         "start": 149,
-        "end": 170
+        "end": 171
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/leading_dots.json
+++ b/fluent-syntax/test/fixtures_structure/leading_dots.json
@@ -328,7 +328,7 @@
       "span": {
         "type": "Span",
         "start": 142,
-        "end": 185
+        "end": 186
       }
     },
     {
@@ -362,7 +362,7 @@
       "span": {
         "type": "Span",
         "start": 216,
-        "end": 255
+        "end": 256
       }
     },
     {
@@ -396,7 +396,7 @@
       "span": {
         "type": "Span",
         "start": 276,
-        "end": 315
+        "end": 316
       }
     },
     {
@@ -883,7 +883,7 @@
       "span": {
         "type": "Span",
         "start": 687,
-        "end": 722
+        "end": 723
       }
     },
     {
@@ -915,7 +915,7 @@
       "span": {
         "type": "Span",
         "start": 781,
-        "end": 809
+        "end": 810
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/message_with_empty_multiline_pattern.json
+++ b/fluent-syntax/test/fixtures_structure/message_with_empty_multiline_pattern.json
@@ -8,7 +8,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 316
+        "end": 317
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/message_with_empty_pattern.json
+++ b/fluent-syntax/test/fixtures_structure/message_with_empty_pattern.json
@@ -8,7 +8,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 327
+        "end": 328
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/multiline-comment.json
+++ b/fluent-syntax/test/fixtures_structure/multiline-comment.json
@@ -8,7 +8,7 @@
       "span": {
         "type": "Span",
         "start": 1,
-        "end": 48
+        "end": 49
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/resource_comment.json
+++ b/fluent-syntax/test/fixtures_structure/resource_comment.json
@@ -8,7 +8,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 54
+        "end": 55
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/resource_comment_trailing_line.json
+++ b/fluent-syntax/test/fixtures_structure/resource_comment_trailing_line.json
@@ -8,7 +8,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 55
+        "end": 56
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/standalone_comment.json
+++ b/fluent-syntax/test/fixtures_structure/standalone_comment.json
@@ -47,7 +47,7 @@
       "span": {
         "type": "Span",
         "start": 13,
-        "end": 43
+        "end": 44
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/whitespace_leading.json
+++ b/fluent-syntax/test/fixtures_structure/whitespace_leading.json
@@ -40,7 +40,7 @@
         "span": {
           "type": "Span",
           "start": 0,
-          "end": 20
+          "end": 21
         }
       },
       "span": {
@@ -88,7 +88,7 @@
         "span": {
           "type": "Span",
           "start": 48,
-          "end": 64
+          "end": 65
         }
       },
       "span": {

--- a/fluent-syntax/test/fixtures_structure/whitespace_trailing.json
+++ b/fluent-syntax/test/fixtures_structure/whitespace_trailing.json
@@ -40,7 +40,7 @@
         "span": {
           "type": "Span",
           "start": 0,
-          "end": 26
+          "end": 27
         }
       },
       "span": {
@@ -88,7 +88,7 @@
         "span": {
           "type": "Span",
           "start": 55,
-          "end": 76
+          "end": 77
         }
       },
       "span": {


### PR DESCRIPTION
Comments' content includes the terminal line break and the span should
reflect it. The end span should be the offset of the beginning of the
next line following the Comment, not the offset of the Comment's
terminal line break.

This also means that we can remvoe the special case in skipBlankLines.
The meaning changes slightly: skipBlankLines now return the number of
all line breaks skipped, regardless of whether they belonged to
fully-blank lines or not. This is OK for our use-case, however.