### PR TITLE
Include the line end in spans of Messages and Terms

### DIFF
--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -84,6 +84,15 @@ export class FTLParserStream extends ParserStream {
     this.skipInlineWS();
   }
 
+  expectLineEnd() {
+    if (this.ch) {
+      return this.expectChar("\n");
+    }
+
+    // EOF is a valid line end in Fluent.
+    return true;
+  }
+
   takeChar(f) {
     const ch = this.ch;
     if (ch !== undefined && f(ch)) {

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -241,6 +241,7 @@ export default class FluentParser {
       throw new ParseError("E0005", id.name);
     }
 
+    ps.expectLineEnd();
     return new AST.Message(id, pattern, attrs);
   }
 
@@ -261,6 +262,7 @@ export default class FluentParser {
       var attrs = this.getAttributes(ps);
     }
 
+    ps.expectLineEnd();
     return new AST.Term(id, value, attrs);
   }
 

--- a/fluent-syntax/test/fixtures_structure/elements_indent.json
+++ b/fluent-syntax/test/fixtures_structure/elements_indent.json
@@ -37,7 +37,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 9
+        "end": 10
       }
     },
     {
@@ -135,7 +135,7 @@
       "span": {
         "type": "Span",
         "start": 28,
-        "end": 61
+        "end": 62
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/escape_sequences.json
+++ b/fluent-syntax/test/fixtures_structure/escape_sequences.json
@@ -37,7 +37,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 48
+        "end": 49
       }
     },
     {
@@ -76,7 +76,7 @@
       "span": {
         "type": "Span",
         "start": 49,
-        "end": 97
+        "end": 98
       }
     },
     {
@@ -115,7 +115,7 @@
       "span": {
         "type": "Span",
         "start": 98,
-        "end": 121
+        "end": 122
       }
     },
     {
@@ -154,7 +154,7 @@
       "span": {
         "type": "Span",
         "start": 122,
-        "end": 147
+        "end": 148
       }
     },
     {
@@ -211,7 +211,7 @@
       "span": {
         "type": "Span",
         "start": 171,
-        "end": 195
+        "end": 196
       }
     },
     {
@@ -258,7 +258,7 @@
       "span": {
         "type": "Span",
         "start": 196,
-        "end": 224
+        "end": 225
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/expressions_call_args.json
+++ b/fluent-syntax/test/fixtures_structure/expressions_call_args.json
@@ -108,7 +108,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 43
+        "end": 44
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/leading_dots.json
+++ b/fluent-syntax/test/fixtures_structure/leading_dots.json
@@ -37,7 +37,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 14
+        "end": 15
       }
     },
     {
@@ -76,7 +76,7 @@
       "span": {
         "type": "Span",
         "start": 15,
-        "end": 29
+        "end": 30
       }
     },
     {
@@ -132,7 +132,7 @@
       "span": {
         "type": "Span",
         "start": 30,
-        "end": 48
+        "end": 49
       }
     },
     {
@@ -188,7 +188,7 @@
       "span": {
         "type": "Span",
         "start": 49,
-        "end": 71
+        "end": 72
       }
     },
     {
@@ -253,7 +253,7 @@
       "span": {
         "type": "Span",
         "start": 73,
-        "end": 105
+        "end": 106
       }
     },
     {
@@ -318,7 +318,7 @@
       "span": {
         "type": "Span",
         "start": 107,
-        "end": 140
+        "end": 141
       }
     },
     {
@@ -478,7 +478,7 @@
       "span": {
         "type": "Span",
         "start": 350,
-        "end": 414
+        "end": 415
       }
     },
     {
@@ -534,7 +534,7 @@
       "span": {
         "type": "Span",
         "start": 416,
-        "end": 484
+        "end": 485
       }
     },
     {
@@ -592,7 +592,7 @@
       "span": {
         "type": "Span",
         "start": 486,
-        "end": 516
+        "end": 517
       }
     },
     {
@@ -650,7 +650,7 @@
       "span": {
         "type": "Span",
         "start": 522,
-        "end": 553
+        "end": 554
       }
     },
     {
@@ -725,7 +725,7 @@
       "span": {
         "type": "Span",
         "start": 555,
-        "end": 599
+        "end": 600
       }
     },
     {
@@ -873,7 +873,7 @@
       "span": {
         "type": "Span",
         "start": 601,
-        "end": 685
+        "end": 686
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/message_with_empty_pattern.json
+++ b/fluent-syntax/test/fixtures_structure/message_with_empty_pattern.json
@@ -114,7 +114,7 @@
       "span": {
         "type": "Span",
         "start": 346,
-        "end": 369
+        "end": 370
       }
     },
     {
@@ -172,7 +172,7 @@
       "span": {
         "type": "Span",
         "start": 371,
-        "end": 395
+        "end": 396
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/multiline-comment.json
+++ b/fluent-syntax/test/fixtures_structure/multiline-comment.json
@@ -47,7 +47,7 @@
       "span": {
         "type": "Span",
         "start": 50,
-        "end": 61
+        "end": 62
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/placeable_at_eol.json
+++ b/fluent-syntax/test/fixtures_structure/placeable_at_eol.json
@@ -71,7 +71,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 131
+        "end": 132
       }
     },
     {
@@ -135,7 +135,7 @@
       "span": {
         "type": "Span",
         "start": 133,
-        "end": 184
+        "end": 185
       }
     },
     {
@@ -199,7 +199,7 @@
       "span": {
         "type": "Span",
         "start": 186,
-        "end": 234
+        "end": 235
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/simple_message.json
+++ b/fluent-syntax/test/fixtures_structure/simple_message.json
@@ -37,7 +37,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 9
+        "end": 10
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/sparse-messages.json
+++ b/fluent-syntax/test/fixtures_structure/sparse-messages.json
@@ -37,7 +37,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 17
+        "end": 18
       }
     },
     {
@@ -95,7 +95,7 @@
       "span": {
         "type": "Span",
         "start": 19,
-        "end": 49
+        "end": 50
       }
     },
     {
@@ -171,7 +171,7 @@
       "span": {
         "type": "Span",
         "start": 52,
-        "end": 127
+        "end": 128
       }
     },
     {
@@ -210,7 +210,7 @@
       "span": {
         "type": "Span",
         "start": 130,
-        "end": 144
+        "end": 145
       }
     },
     {
@@ -349,7 +349,7 @@
       "span": {
         "type": "Span",
         "start": 146,
-        "end": 209
+        "end": 210
       }
     },
     {
@@ -416,7 +416,7 @@
       "span": {
         "type": "Span",
         "start": 211,
-        "end": 252
+        "end": 253
       }
     },
     {
@@ -483,7 +483,7 @@
       "span": {
         "type": "Span",
         "start": 254,
-        "end": 294
+        "end": 295
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/standalone_comment.json
+++ b/fluent-syntax/test/fixtures_structure/standalone_comment.json
@@ -37,7 +37,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 11
+        "end": 12
       }
     },
     {

--- a/fluent-syntax/test/fixtures_structure/term.json
+++ b/fluent-syntax/test/fixtures_structure/term.json
@@ -139,7 +139,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 108
+        "end": 109
       }
     },
     {
@@ -229,7 +229,7 @@
       "span": {
         "type": "Span",
         "start": 110,
-        "end": 171
+        "end": 172
       }
     },
     {
@@ -506,7 +506,7 @@
       "span": {
         "type": "Span",
         "start": 173,
-        "end": 437
+        "end": 438
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/variant_with_empty_pattern.json
+++ b/fluent-syntax/test/fixtures_structure/variant_with_empty_pattern.json
@@ -100,7 +100,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 42
+        "end": 43
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/whitespace_leading.json
+++ b/fluent-syntax/test/fixtures_structure/whitespace_leading.json
@@ -46,7 +46,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 46
+        "end": 47
       }
     },
     {
@@ -94,7 +94,7 @@
       "span": {
         "type": "Span",
         "start": 48,
-        "end": 84
+        "end": 85
       }
     },
     {
@@ -150,7 +150,7 @@
       "span": {
         "type": "Span",
         "start": 86,
-        "end": 111
+        "end": 112
       }
     },
     {
@@ -206,7 +206,7 @@
       "span": {
         "type": "Span",
         "start": 112,
-        "end": 137
+        "end": 138
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/whitespace_trailing.json
+++ b/fluent-syntax/test/fixtures_structure/whitespace_trailing.json
@@ -46,7 +46,7 @@
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 53
+        "end": 54
       }
     },
     {
@@ -94,7 +94,7 @@
       "span": {
         "type": "Span",
         "start": 55,
-        "end": 96
+        "end": 97
       }
     },
     {
@@ -167,7 +167,7 @@
       "span": {
         "type": "Span",
         "start": 98,
-        "end": 136
+        "end": 137
       }
     },
     {
@@ -223,7 +223,7 @@
       "span": {
         "type": "Span",
         "start": 137,
-        "end": 164
+        "end": 165
       }
     }
   ],


### PR DESCRIPTION
This is similar to the change made to Comments except here it doesn't
affect the values, just the spans.

The EBNF defines Message and Term as:

    Message             ::= Comment? Identifier inline_space? "=" inline_space? ((Pattern Attribute*) | (Attribute+)) line_end
    Term ::= Comment? TermIdentifier inline_space? "=" inline_space? Value Attribute* line_end