### PR TITLE
make acceptedLanguages order the header by q values descending

### DIFF
--- a/fluent-langneg/src/accepted_languages.js
+++ b/fluent-langneg/src/accepted_languages.js
@@ -1,7 +1,24 @@
-export default function acceptedLanguages(string = "") {
-  if (typeof string !== "string") {
+export default function acceptedLanguages(acceptLanguageHeader = "") {
+  if (typeof acceptLanguageHeader !== "string") {
     throw new TypeError("Argument must be a string");
   }
-  const tokens = string.split(",").map(t => t.trim());
-  return tokens.filter(t => t !== "").map(t => t.split(";")[0]);
+  const tokens = acceptLanguageHeader.split(",").map(t => t.trim());
+  const langsWithQ = [];
+  tokens.filter(t => t !== "").forEach((t, index) => {
+    const langWithQ = t.split(";").map(u => u.trim());
+    if (langWithQ[0].length > 0) {
+      let q = 1.0;
+      if (langWithQ.length > 1) {
+        const qVal = langWithQ[1].split("=").map(u => u.trim());
+        if (qVal.length === 2 && qVal[0].toLowerCase() === "q") {
+          const qn = Number(qVal[1]);
+          q = !isNaN(qn) ? qn : q;
+        }
+      }
+      langsWithQ.push({ index: index, lang: langWithQ[0], q });
+    }
+  });
+  // order by q descending, keeping the header order for equal weights
+  langsWithQ.sort((a, b) => a.q === b.q ? a.index - b.index : b.q - a.q);
+  return langsWithQ.map(t => t.lang);
 }

--- a/fluent-langneg/test/headers_test.js
+++ b/fluent-langneg/test/headers_test.js
@@ -29,6 +29,53 @@ suite('parse headers', () => {
     );
   });
 
+  test('with out of order quality values', () => {
+    assert.deepStrictEqual(
+      acceptedLanguages('en;q=0.8, fr;q=0.9, de;q=0.7, *;q=0.5, fr-CH'), [
+        'fr-CH',
+        'fr',
+        'en',
+        'de',
+        '*'
+      ]
+    );
+  });
+
+  test('with equal q values', () => {
+    assert.deepStrictEqual(
+      acceptedLanguages('en;q=0.1, fr;q=0.1, de;q=0.1, *;q=0.1'), [
+        'en',
+        'fr',
+        'de',
+        '*'
+      ]
+    );
+  });
+
+  test('with duff q values', () => {
+    assert.deepStrictEqual(
+      acceptedLanguages('en;q=no, fr;z=0.9, de;q=0.7;q=9, *;q=0.5, fr-CH;q=a=0.1'), [
+        'en',
+        'fr',
+        'fr-CH',
+        'de',
+        '*'
+      ]
+    );
+  });
+
+  test('with empty entries', () => {
+    assert.deepStrictEqual(
+      acceptedLanguages('en;q=0.8,,, fr;q=0.9,, de;q=0.7, *;q=0.5, fr-CH'), [
+        'fr-CH',
+        'fr',
+        'en',
+        'de',
+        '*'
+      ]
+    );
+  });
+
   test('edge cases', () => {
     const args = [
       null,


### PR DESCRIPTION
I'm not sure if anything actually sends this header with languages listed out of descending preference order, but according to the [specification](https://tools.ietf.org/html/rfc7231#section-5.3.5) you can't rely on it.