### PR TITLE
Indentation/Whitespace in 0.7

### DIFF
--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -151,7 +151,9 @@ export class FTLParserStream extends ParserStream {
     return !includes(SPECIAL_LINE_START_CHARS, ch);
   }
 
-  isPeekValueStart() {
+  isValueStart({skip = true} = {}) {
+    if (skip === false) throw new Error("Unimplemented");
+
     this.peekBlankInline();
     const ch = this.currentPeek();
 
@@ -161,7 +163,7 @@ export class FTLParserStream extends ParserStream {
       return true;
     }
 
-    return this.isPeekNextLineValue();
+    return this.isNextLineValue();
   }
 
   // -1 - any
@@ -216,7 +218,9 @@ export class FTLParserStream extends ParserStream {
     return false;
   }
 
-  isPeekNextLineAttributeStart() {
+  isNextLineAttributeStart({skip = true} = {}) {
+    if (skip === false) throw new Error("Unimplemented");
+
     this.peekBlank();
 
     if (this.currentPeekIs(".")) {
@@ -228,7 +232,7 @@ export class FTLParserStream extends ParserStream {
     return false;
   }
 
-  isPeekNextLineValue(skipToPeek = true) {
+  isNextLineValue({skip = true} = {}) {
     if (!this.currentPeekIs("\n")) {
       return false;
     }
@@ -251,7 +255,7 @@ export class FTLParserStream extends ParserStream {
       }
     }
 
-    if (skipToPeek) {
+    if (skip) {
       this.skipToPeek();
     } else {
       this.resetPeek();

--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -4,14 +4,14 @@ import { ParserStream } from "./stream";
 import { ParseError } from "./errors";
 import { includes } from "./util";
 
-const INLINE_WS = [" "];
-const ANY_WS = [" ", "\r", "\n"];
+const INLINE_WS = " ";
+const ANY_WS = [INLINE_WS, "\n"];
 const SPECIAL_LINE_START_CHARS = ["}", ".", "[", "*"];
 
 export class FTLParserStream extends ParserStream {
   skipBlankInline() {
     while (this.ch) {
-      if (!includes(INLINE_WS, this.ch)) {
+      if (this.ch !== INLINE_WS) {
         break;
       }
       this.next();
@@ -21,7 +21,7 @@ export class FTLParserStream extends ParserStream {
   peekBlankInline() {
     let ch = this.currentPeek();
     while (ch) {
-      if (!includes(INLINE_WS, ch)) {
+      if (ch !== INLINE_WS) {
         break;
       }
       ch = this.peek();
@@ -202,21 +202,14 @@ export class FTLParserStream extends ParserStream {
       return false;
     }
 
-
     this.peekBlank();
-    const def = this.currentPeekIs("*");
 
-    if (def) {
-      this.skipToPeek();
+    if (this.currentPeekIs("*")) {
       this.peek();
     }
 
-    if (this.currentPeekIs("[") && !this.peekCharIs("[")) {
-      if (def) {
-        this.resetPeek();
-      } else {
-        this.skipToPeek();
-      }
+    if (this.currentPeekIs("[")) {
+      this.resetPeek();
       return true;
     }
     this.resetPeek();
@@ -246,14 +239,16 @@ export class FTLParserStream extends ParserStream {
 
     this.peekBlankInline();
 
-    if (this.getPeekIndex() - ptr === 0) {
-      this.resetPeek();
-      return false;
-    }
+    if (!this.currentPeekIs("{")) {
+      if (this.getPeekIndex() - ptr === 0) {
+        this.resetPeek();
+        return false;
+      }
 
-    if (!this.isCharPatternContinuation(this.currentPeek())) {
-      this.resetPeek();
-      return false;
+      if (!this.isCharPatternContinuation(this.currentPeek())) {
+        this.resetPeek();
+        return false;
+      }
     }
 
     if (skipToPeek) {

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -222,11 +222,11 @@ export default class FluentParser {
     ps.skipBlankInline();
     ps.expectChar("=");
 
-    if (ps.isPeekValueStart()) {
+    if (ps.isValueStart()) {
       var pattern = this.getPattern(ps);
     }
 
-    if (ps.isPeekNextLineAttributeStart()) {
+    if (ps.isNextLineAttributeStart()) {
       var attrs = this.getAttributes(ps);
     }
 
@@ -243,14 +243,14 @@ export default class FluentParser {
     ps.skipBlankInline();
     ps.expectChar("=");
 
-    if (ps.isPeekValueStart()) {
+    if (ps.isValueStart()) {
       ps.skipBlankInline();
       var value = this.getValue(ps);
     } else {
       throw new ParseError("E0006", id.name);
     }
 
-    if (ps.isPeekNextLineAttributeStart()) {
+    if (ps.isNextLineAttributeStart()) {
       var attrs = this.getAttributes(ps);
     }
 
@@ -265,7 +265,7 @@ export default class FluentParser {
     ps.skipBlankInline();
     ps.expectChar("=");
 
-    if (ps.isPeekValueStart()) {
+    if (ps.isValueStart()) {
       ps.skipBlankInline();
       const value = this.getPattern(ps);
       return new AST.Attribute(key, value);
@@ -281,7 +281,7 @@ export default class FluentParser {
       const attr = this.getAttribute(ps);
       attrs.push(attr);
 
-      if (!ps.isPeekNextLineAttributeStart()) {
+      if (!ps.isNextLineAttributeStart()) {
         break;
       }
     }
@@ -344,7 +344,7 @@ export default class FluentParser {
 
     ps.expectChar("]");
 
-    if (ps.isPeekValueStart()) {
+    if (ps.isValueStart()) {
       ps.skipBlankInline();
       const value = this.getValue(ps);
       return new AST.Variant(key, value, defaultIndex);
@@ -448,7 +448,7 @@ export default class FluentParser {
 
       // The end condition for getPattern's while loop is a newline
       // which is not followed by a valid pattern continuation.
-      if (ch === "\n" && !ps.isPeekNextLineValue(false)) {
+      if (ch === "\n" && !ps.isNextLineValue({skip: false})) {
         break;
       }
 
@@ -483,7 +483,7 @@ export default class FluentParser {
       }
 
       if (ch === "\n") {
-        if (!ps.isPeekNextLineValue(false)) {
+        if (!ps.isNextLineValue({skip: false})) {
           return new AST.TextElement(buffer);
         }
 

--- a/fluent-syntax/test/fixtures_behavior/attribute_starts_from_nl.ftl
+++ b/fluent-syntax/test/fixtures_behavior/attribute_starts_from_nl.ftl
@@ -1,3 +1,2 @@
 foo = Value
 .attr = Value 2
-# ~ERROR E0002, pos 12

--- a/fluent-syntax/test/fixtures_behavior/indent.ftl
+++ b/fluent-syntax/test/fixtures_behavior/indent.ftl
@@ -3,13 +3,9 @@
 
 key2 = {
 a }
-# ~ERROR E0014, pos 20
-# ~ERROR E0003, pos 23, args "="
 
 key3 = { a
 }
-# ~ERROR E0003, pos 36, args "}"
 
 key4 = {
 { a }}
-# ~ERROR E0014, pos 48

--- a/fluent-syntax/test/fixtures_behavior/placeable_in_placeable.ftl
+++ b/fluent-syntax/test/fixtures_behavior/placeable_in_placeable.ftl
@@ -8,7 +8,7 @@ key2 = {  { foo }  }
 #   }
 
 key4 = {  { foo }
-# ~ERROR E0003, pos 93, args "}"
+# ~ERROR E0003, pos 96, args "}"
 
 
 # key5 = { foo } }

--- a/fluent-syntax/test/fixtures_behavior/placeable_without_close_bracket.ftl
+++ b/fluent-syntax/test/fixtures_behavior/placeable_without_close_bracket.ftl
@@ -1,3 +1,3 @@
 key = { $num
 
-# ~ERROR E0003, pos 12, args "}"
+# ~ERROR E0003, pos 14, args "}"

--- a/fluent-syntax/test/fixtures_behavior/second_attribute_starts_from_nl.ftl
+++ b/fluent-syntax/test/fixtures_behavior/second_attribute_starts_from_nl.ftl
@@ -1,4 +1,3 @@
 key = Value
     .label = Value
 .accesskey = K
-# ~ERROR E0002, pos 31

--- a/fluent-syntax/test/fixtures_behavior/selector_expression_ends_abruptly.ftl
+++ b/fluent-syntax/test/fixtures_behavior/selector_expression_ends_abruptly.ftl
@@ -1,2 +1,2 @@
 key = { $foo ->
-# ~ERROR E0003, pos 16, args " "
+# ~ERROR E0003, pos 16, args "["

--- a/fluent-syntax/test/fixtures_behavior/unclosed_empty_placeable_error.ftl
+++ b/fluent-syntax/test/fixtures_behavior/unclosed_empty_placeable_error.ftl
@@ -1,2 +1,2 @@
 bar = Bar {
-# ~ERROR E0014, pos 11
+# ~ERROR E0014, pos 12

--- a/fluent-syntax/test/fixtures_behavior/variant_ends_abruptly.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_ends_abruptly.ftl
@@ -1,3 +1,3 @@
 key = { $foo ->
     *[
-# ~ERROR E0004, pos 22, args "a-zA-Z"
+# ~ERROR E0013, pos 23

--- a/fluent-syntax/test/fixtures_behavior/variant_lists.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_lists.ftl
@@ -1,10 +1,10 @@
-# ~ERROR E0014, pos 16
+# ~ERROR E0014, pos 25
 message1 =
     {
         *[one] One
     }
 
-# ~ERROR E0023, pos 118
+# ~ERROR E0023, pos 123
 message2 =
     { $sel ->
         *[one] {
@@ -24,7 +24,7 @@ message2 =
          }
     }
 
-# ~ERROR E0023, pos 313
+# ~ERROR E0023, pos 318
 -term3 =
     { $sel ->
         *[one] {

--- a/fluent-syntax/test/fixtures_behavior/variant_starts_from_nl.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_starts_from_nl.ftl
@@ -1,4 +1,3 @@
 -term = {
 *[one] Value
     }
-# ~ERROR E0014, pos 9

--- a/fluent-syntax/test/fixtures_behavior/variant_with_leading_space_in_name.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_with_leading_space_in_name.ftl
@@ -1,4 +1,3 @@
 -term = {
         *[  one] Foo
     }
-# ~ERROR E0004, pos 20, args "a-zA-Z"

--- a/fluent-syntax/test/fixtures_behavior/variant_with_symbol_with_space.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_with_symbol_with_space.ftl
@@ -1,4 +1,4 @@
-# ~ERROR E0003, pos 23, args "]"
+# ~ERROR E0003, pos 24, args "]"
 -term = {
         *[New York] Nowy Jork
     }

--- a/fluent-syntax/test/fixtures_reference/call_expressions.ftl
+++ b/fluent-syntax/test/fixtures_reference/call_expressions.ftl
@@ -30,8 +30,6 @@ empty-multiline-call = {FUN(
     )}
 
 
-## Syntax errors for multiline call expressions
-
 unindented-arg-number = {FUN(
 1)}
 
@@ -94,8 +92,6 @@ sparse-named-arg = {FUN(
         3
     )}
 
-
-## Syntax errors for named arguments
 
 unindented-colon = {FUN(
         x

--- a/fluent-syntax/test/fixtures_reference/call_expressions.json
+++ b/fluent-syntax/test/fixtures_reference/call_expressions.json
@@ -431,48 +431,276 @@
             "comment": null
         },
         {
-            "type": "GroupComment",
-            "content": "Syntax errors for multiline call expressions"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-arg-number"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [
+                                {
+                                    "type": "NumberLiteral",
+                                    "value": "1"
+                                }
+                            ],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-arg-number = {FUN(\n1)}\n"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-arg-string"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [
+                                {
+                                    "type": "StringLiteral",
+                                    "value": "a"
+                                }
+                            ],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-arg-string = {FUN(\n\"a\")}\n"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-arg-msg-ref"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [
+                                {
+                                    "type": "MessageReference",
+                                    "id": {
+                                        "type": "Identifier",
+                                        "name": "msg"
+                                    }
+                                }
+                            ],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-arg-msg-ref = {FUN(\nmsg)}\n"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-arg-term-ref"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [
+                                {
+                                    "type": "TermReference",
+                                    "id": {
+                                        "type": "Identifier",
+                                        "name": "-msg"
+                                    }
+                                }
+                            ],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-arg-term-ref = {FUN(\n-msg)}\n"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-arg-var-ref"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [
+                                {
+                                    "type": "VariableReference",
+                                    "id": {
+                                        "type": "Identifier",
+                                        "name": "var"
+                                    }
+                                }
+                            ],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-arg-var-ref = {FUN(\n$var)}\n"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-arg-call"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [
+                                {
+                                    "type": "CallExpression",
+                                    "callee": {
+                                        "type": "Function",
+                                        "name": "OTHER"
+                                    },
+                                    "positional": [],
+                                    "named": []
+                                }
+                            ],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-arg-call = {FUN(\nOTHER())}\n"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-named-arg"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [],
+                            "named": [
+                                {
+                                    "type": "NamedArgument",
+                                    "name": {
+                                        "type": "Identifier",
+                                        "name": "x"
+                                    },
+                                    "value": {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-named-arg = {FUN(\nx:1)}\n"
-        },
-        {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-closing-paren = {FUN(\n    x\n)}\n"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-closing-paren"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [
+                                {
+                                    "type": "MessageReference",
+                                    "id": {
+                                        "type": "Identifier",
+                                        "name": "x"
+                                    }
+                                }
+                            ],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
             "type": "GroupComment",
@@ -731,18 +959,80 @@
             "comment": null
         },
         {
-            "type": "GroupComment",
-            "content": "Syntax errors for named arguments"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-colon"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [],
+                            "named": [
+                                {
+                                    "type": "NamedArgument",
+                                    "name": {
+                                        "type": "Identifier",
+                                        "name": "x"
+                                    },
+                                    "value": {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         },
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-colon = {FUN(\n        x\n:1)}\n"
-        },
-        {
-            "type": "Junk",
-            "annotations": [],
-            "content": "unindented-value = {FUN(\n        x:\n1)}\n"
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "unindented-value"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "Function",
+                                "name": "FUN"
+                            },
+                            "positional": [],
+                            "named": [
+                                {
+                                    "type": "NamedArgument",
+                                    "name": {
+                                        "type": "Identifier",
+                                        "name": "x"
+                                    },
+                                    "value": {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         }
     ]
 }

--- a/fluent-syntax/test/fixtures_reference/crlf.ftl
+++ b/fluent-syntax/test/fixtures_reference/crlf.ftl
@@ -1,0 +1,7 @@
+key01 = Value 01
+key02 =
+    Value 02
+    Continued
+
+# ERROR (Missing value or attributes)
+key03

--- a/fluent-syntax/test/fixtures_reference/crlf.json
+++ b/fluent-syntax/test/fixtures_reference/crlf.json
@@ -1,0 +1,50 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key01"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value 01"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key02"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value 02\nContinued"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR (Missing value or attributes)"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "key03\n"
+        }
+    ]
+}

--- a/fluent-syntax/test/fixtures_reference/leading_dots.ftl
+++ b/fluent-syntax/test/fixtures_reference/leading_dots.ftl
@@ -35,7 +35,7 @@ key11 =
 key12 =
     .accesskey =
     A
-    
+
 key13 =
     .attribute = .Value
 
@@ -63,3 +63,14 @@ key17 =
        *[one] Value
            .Continued
     }
+
+# JUNK (attr .Value must have a value)
+key18 =
+.Value
+
+key19 =
+.attribute = Value
+    Continued
+
+key20 =
+{"."}Value

--- a/fluent-syntax/test/fixtures_reference/leading_dots.json
+++ b/fluent-syntax/test/fixtures_reference/leading_dots.json
@@ -350,7 +350,7 @@
                                 {
                                     "type": "Variant",
                                     "key": {
-                                        "type": "VariantName",
+                                        "type": "Identifier",
                                         "name": "one"
                                     },
                                     "value": {
@@ -367,7 +367,7 @@
                                 {
                                     "type": "Variant",
                                     "key": {
-                                        "type": "VariantName",
+                                        "type": "Identifier",
                                         "name": "other"
                                     },
                                     "value": {
@@ -413,6 +413,67 @@
             "type": "Junk",
             "annotations": [],
             "content": "key17 =\n    { 1 ->\n       *[one] Value\n           .Continued\n    }\n"
+        },
+        {
+            "type": "Comment",
+            "content": "JUNK (attr .Value must have a value)"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "key18 =\n.Value\n"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key19"
+            },
+            "value": null,
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attribute"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Value\nContinued"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key20"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "StringLiteral",
+                            "value": "."
+                        }
+                    },
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         }
     ]
 }

--- a/fluent-syntax/test/fixtures_reference/mixed_entries.ftl
+++ b/fluent-syntax/test/fixtures_reference/mixed_entries.ftl
@@ -17,3 +17,8 @@ key02 = Value
 
 # Standalone Comment
     .attr = Dangling attribute
+
+# There are 5 spaces on the line between key03 and key04.
+key03 = Value 03
+     
+key04 = Value 04

--- a/fluent-syntax/test/fixtures_reference/mixed_entries.json
+++ b/fluent-syntax/test/fixtures_reference/mixed_entries.json
@@ -92,6 +92,45 @@
             "type": "Junk",
             "annotations": [],
             "content": "    .attr = Dangling attribute\n"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key03"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value 03"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "There are 5 spaces on the line between key03 and key04."
+            }
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key04"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value 04"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         }
     ]
 }

--- a/fluent-syntax/test/fixtures_reference/select_expressions.ftl
+++ b/fluent-syntax/test/fixtures_reference/select_expressions.ftl
@@ -6,7 +6,7 @@ new-messages =
 
 valid-selector =
     { -term.case ->
-       *[    many     words    ] value
+       *[key] value
     }
 
 # ERROR

--- a/fluent-syntax/test/fixtures_reference/select_expressions.json
+++ b/fluent-syntax/test/fixtures_reference/select_expressions.json
@@ -44,7 +44,7 @@
                                 {
                                     "type": "Variant",
                                     "key": {
-                                        "type": "VariantName",
+                                        "type": "Identifier",
                                         "name": "other"
                                     },
                                     "value": {
@@ -104,8 +104,8 @@
                                 {
                                     "type": "Variant",
                                     "key": {
-                                        "type": "VariantName",
-                                        "name": "many     words"
+                                        "type": "Identifier",
+                                        "name": "key"
                                     },
                                     "value": {
                                         "type": "Pattern",
@@ -156,7 +156,7 @@
                                 {
                                     "type": "Variant",
                                     "key": {
-                                        "type": "VariantName",
+                                        "type": "Identifier",
                                         "name": "one"
                                     },
                                     "value": {
@@ -202,7 +202,7 @@
                                 {
                                     "type": "Variant",
                                     "key": {
-                                        "type": "VariantName",
+                                        "type": "Identifier",
                                         "name": "one"
                                     },
                                     "value": {
@@ -220,7 +220,7 @@
                                                         {
                                                             "type": "Variant",
                                                             "key": {
-                                                                "type": "VariantName",
+                                                                "type": "Identifier",
                                                                 "name": "two"
                                                             },
                                                             "value": {

--- a/fluent-syntax/test/fixtures_reference/select_indent.ftl
+++ b/fluent-syntax/test/fixtures_reference/select_indent.ftl
@@ -1,0 +1,95 @@
+select-1tbs-inline = { $selector ->
+   *[key] Value
+}
+
+select-1tbs-newline = {
+$selector ->
+   *[key] Value
+}
+
+select-1tbs-indent = {
+    $selector ->
+   *[key] Value
+}
+
+select-allman-inline =
+{ $selector ->
+   *[key] Value
+}
+
+select-allman-newline =
+{
+$selector ->
+   *[key] Value
+}
+
+select-allman-indent =
+{
+    $selector ->
+   *[key] Value
+}
+
+select-gnu-inline =
+   { $selector ->
+      *[key] Value
+   }
+
+select-gnu-newline =
+   {
+$selector ->
+      *[key] Value
+   }
+
+select-gnu-indent =
+   {
+       $selector ->
+      *[key] Value
+   }
+
+select-no-indent =
+{
+$selector ->
+*[key] Value
+[other] Other
+}
+
+select-no-indent-multiline =
+{
+$selector ->
+*[key] Value
+       Continued
+[other]
+    Other
+    Multiline
+}
+
+# ERROR (Multiline text must be indented)
+select-no-indent-multiline = { $selector ->
+   *[key] Value
+Continued without indent.
+}
+
+select-flat =
+{
+$selector
+->
+*[
+key
+] Value
+[
+other
+] Other
+}
+
+# Each line ends with 5 spaces.
+select-flat-with-trailing-spaces =
+{     
+$selector     
+->     
+*[     
+key     
+] Value     
+[     
+other     
+] Other     
+}     

--- a/fluent-syntax/test/fixtures_reference/select_indent.json
+++ b/fluent-syntax/test/fixtures_reference/select_indent.json
@@ -1,0 +1,683 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-1tbs-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-1tbs-newline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-1tbs-indent"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-allman-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-allman-newline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-allman-indent"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-gnu-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-gnu-newline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-gnu-indent"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-no-indent"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                },
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "other"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Other"
+                                            }
+                                        ]
+                                    },
+                                    "default": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-no-indent-multiline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value\nContinued"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                },
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "other"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Other\nMultiline"
+                                            }
+                                        ]
+                                    },
+                                    "default": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR (Multiline text must be indented)"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "select-no-indent-multiline = { $selector ->\n   *[key] Value\nContinued without indent.\n}\n"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-flat"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                },
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "other"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Other"
+                                            }
+                                        ]
+                                    },
+                                    "default": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "select-flat-with-trailing-spaces"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "selector"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                },
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "other"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Other"
+                                            }
+                                        ]
+                                    },
+                                    "default": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "Each line ends with 5 spaces."
+            }
+        }
+    ]
+}

--- a/fluent-syntax/test/fixtures_reference/tab.ftl
+++ b/fluent-syntax/test/fixtures_reference/tab.ftl
@@ -1,0 +1,14 @@
+# OK (tab after = is part of the value)
+key01 =	Value 01
+
+# Error (tab before =)
+key02	= Value 02
+
+# Error (tab is not a valid indent)
+key03 =
+	This line isn't properly indented.
+
+# Partial Error (tab is not a valid indent)
+key04 =
+    This line is indented by 4 spaces,
+	whereas this line by 1 tab.

--- a/fluent-syntax/test/fixtures_reference/tab.json
+++ b/fluent-syntax/test/fixtures_reference/tab.json
@@ -1,0 +1,70 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key01"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "\tValue 01"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "OK (tab after = is part of the value)"
+            }
+        },
+        {
+            "type": "Comment",
+            "content": "Error (tab before =)"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "key02\t= Value 02\n"
+        },
+        {
+            "type": "Comment",
+            "content": "Error (tab is not a valid indent)"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "key03 =\n\tThis line isn't properly indented.\n"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key04"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "This line is indented by 4 spaces,"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "Partial Error (tab is not a valid indent)"
+            }
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "\twhereas this line by 1 tab.\n"
+        }
+    ]
+}

--- a/fluent-syntax/test/fixtures_reference/variant_keys.ftl
+++ b/fluent-syntax/test/fixtures_reference/variant_keys.ftl
@@ -1,0 +1,37 @@
+-simple-identifier =
+    {
+       *[key] value
+    }
+
+-identifier-surrounded-by-whitespace =
+    {
+       *[     key     ] value
+    }
+
+-int-number =
+    {
+       *[1] value
+    }
+
+-float-number =
+    {
+       *[3.14] value
+    }
+
+# ERROR
+-invalid-identifier =
+    {
+       *[two words] value
+    }
+
+# ERROR
+-invalid-int =
+    {
+       *[1 apple] value
+    }
+
+# ERROR
+-invalid-int =
+    {
+       *[3.14 apples] value
+    }

--- a/fluent-syntax/test/fixtures_reference/variant_keys.json
+++ b/fluent-syntax/test/fixtures_reference/variant_keys.json
@@ -1,0 +1,156 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "-simple-identifier"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "key"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "-identifier-surrounded-by-whitespace"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "key"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "-int-number"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "NumberLiteral",
+                            "value": "1"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "-float-number"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "NumberLiteral",
+                            "value": "3.14"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "-invalid-identifier =\n    {\n       *[two words] value\n    }\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "-invalid-int =\n    {\n       *[1 apple] value\n    }\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "-invalid-int =\n    {\n       *[3.14 apples] value\n    }\n"
+        }
+    ]
+}

--- a/fluent-syntax/test/fixtures_reference/variant_lists.json
+++ b/fluent-syntax/test/fixtures_reference/variant_lists.json
@@ -13,7 +13,7 @@
                     {
                         "type": "Variant",
                         "key": {
-                            "type": "VariantName",
+                            "type": "Identifier",
                             "name": "key"
                         },
                         "value": {
@@ -105,7 +105,7 @@
                     {
                         "type": "Variant",
                         "key": {
-                            "type": "VariantName",
+                            "type": "Identifier",
                             "name": "one"
                         },
                         "value": {
@@ -114,7 +114,7 @@
                                 {
                                     "type": "Variant",
                                     "key": {
-                                        "type": "VariantName",
+                                        "type": "Identifier",
                                         "name": "two"
                                     },
                                     "value": {
@@ -149,7 +149,7 @@
                     {
                         "type": "Variant",
                         "key": {
-                            "type": "VariantName",
+                            "type": "Identifier",
                             "name": "one"
                         },
                         "value": {
@@ -167,7 +167,7 @@
                                             {
                                                 "type": "Variant",
                                                 "key": {
-                                                    "type": "VariantName",
+                                                    "type": "Identifier",
                                                     "name": "two"
                                                 },
                                                 "value": {

--- a/fluent-syntax/test/fixtures_reference/variants_indent.ftl
+++ b/fluent-syntax/test/fixtures_reference/variants_indent.ftl
@@ -1,0 +1,19 @@
+-variants-1tbs = {
+   *[key] Value
+}
+
+-variants-allman =
+{
+   *[key] Value
+}
+
+-variants-gnu =
+   {
+      *[key] Value
+   }
+
+-variants-no-indent =
+{
+*[key] Value
+[other] Other
+}

--- a/fluent-syntax/test/fixtures_reference/variants_indent.json
+++ b/fluent-syntax/test/fixtures_reference/variants_indent.json
@@ -1,0 +1,146 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "-variants-1tbs"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "key"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "Value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "-variants-allman"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "key"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "Value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "-variants-gnu"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "key"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "Value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "-variants-no-indent"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "key"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "Value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    },
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "other"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "Other"
+                                }
+                            ]
+                        },
+                        "default": false
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        }
+    ]
+}

--- a/fluent-syntax/test/fixtures_reference/whitespace_in_value.ftl
+++ b/fluent-syntax/test/fixtures_reference/whitespace_in_value.ftl
@@ -1,0 +1,10 @@
+# Caution, lines 6 and 7 contain white-space-only lines
+key =
+  first line
+
+
+  
+  
+
+
+  last line

--- a/fluent-syntax/test/fixtures_reference/whitespace_in_value.json
+++ b/fluent-syntax/test/fixtures_reference/whitespace_in_value.json
@@ -1,0 +1,26 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "first line\n\n\n\n\n\n\nlast line"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "Caution, lines 6 and 7 contain white-space-only lines"
+            }
+        }
+    ]
+}

--- a/fluent-syntax/test/fixtures_structure/elements_indent.json
+++ b/fluent-syntax/test/fixtures_structure/elements_indent.json
@@ -31,34 +31,49 @@
           "end": 9
         }
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "type": "Attribute",
+          "id": {
+            "type": "Identifier",
+            "name": "attr",
+            "span": {
+              "type": "Span",
+              "start": 11,
+              "end": 15
+            }
+          },
+          "value": {
+            "type": "Pattern",
+            "elements": [
+              {
+                "type": "TextElement",
+                "value": "Foo Attr",
+                "span": {
+                  "type": "Span",
+                  "start": 18,
+                  "end": 26
+                }
+              }
+            ],
+            "span": {
+              "type": "Span",
+              "start": 18,
+              "end": 26
+            }
+          },
+          "span": {
+            "type": "Span",
+            "start": 10,
+            "end": 26
+          }
+        }
+      ],
       "comment": null,
       "span": {
         "type": "Span",
         "start": 0,
-        "end": 9
-      }
-    },
-    {
-      "type": "Junk",
-      "annotations": [
-        {
-          "type": "Annotation",
-          "code": "E0002",
-          "args": [],
-          "message": "Expected an entry start",
-          "span": {
-            "type": "Span",
-            "start": 10,
-            "end": 10
-          }
-        }
-      ],
-      "content": ".attr = Foo Attr\n\n",
-      "span": {
-        "type": "Span",
-        "start": 10,
-        "end": 28
+        "end": 26
       }
     },
     {
@@ -127,35 +142,49 @@
             "start": 42,
             "end": 61
           }
+        },
+        {
+          "type": "Attribute",
+          "id": {
+            "type": "Identifier",
+            "name": "attr2",
+            "span": {
+              "type": "Span",
+              "start": 63,
+              "end": 68
+            }
+          },
+          "value": {
+            "type": "Pattern",
+            "elements": [
+              {
+                "type": "TextElement",
+                "value": "Bar Attr 2",
+                "span": {
+                  "type": "Span",
+                  "start": 71,
+                  "end": 81
+                }
+              }
+            ],
+            "span": {
+              "type": "Span",
+              "start": 71,
+              "end": 81
+            }
+          },
+          "span": {
+            "type": "Span",
+            "start": 62,
+            "end": 81
+          }
         }
       ],
       "comment": null,
       "span": {
         "type": "Span",
         "start": 28,
-        "end": 61
-      }
-    },
-    {
-      "type": "Junk",
-      "annotations": [
-        {
-          "type": "Annotation",
-          "code": "E0002",
-          "args": [],
-          "message": "Expected an entry start",
-          "span": {
-            "type": "Span",
-            "start": 62,
-            "end": 62
-          }
-        }
-      ],
-      "content": ".attr2 = Bar Attr 2\n",
-      "span": {
-        "type": "Span",
-        "start": 62,
-        "end": 82
+        "end": 81
       }
     }
   ],

--- a/fluent-syntax/test/fixtures_structure/message_with_empty_pattern.json
+++ b/fluent-syntax/test/fixtures_structure/message_with_empty_pattern.json
@@ -46,8 +46,8 @@
           "message": "Expected message \"key2\" to have a value or attributes",
           "span": {
             "type": "Span",
-            "start": 344,
-            "end": 344
+            "start": 343,
+            "end": 343
           }
         }
       ],

--- a/fluent-syntax/test/reference_test.js
+++ b/fluent-syntax/test/reference_test.js
@@ -22,14 +22,6 @@ readdir(fixtures, function(err, filenames) {
     // The following fixtures produce different ASTs in the tooling parser than
     // in the reference parser. Skip them for now.
     const skips = [
-      // Call arguments edge-cases.
-      "call_expressions.ftl",
-
-      // The tooling parser rejects variant keys which contain leading whitespace.
-      // There's even a behavior fixture for this; it must have been a
-      // deliberate decision.
-      "select_expressions.ftl",
-
       // Broken Attributes break the entire Entry right now.
       // https://github.com/projectfluent/fluent.js/issues/237
       "leading_dots.ftl",


### PR DESCRIPTION
This PR supersets #272. It covers all of the 0.7 indentation changes I could find, aligning the parser with the grammar.mjs as close I dared.

I *think* all the resulting test changes make sense as well. :)