### PR TITLE
Export FluentResource from fluent

### DIFF
--- a/fluent/src/context.js
+++ b/fluent/src/context.js
@@ -14,7 +14,7 @@ import FluentResource from "./resource";
  * context's language. See the documentation of the Fluent syntax for more
  * information.
  */
-export class FluentBundle {
+export default class FluentBundle {
 
   /**
    * Create an instance of `FluentBundle`.
@@ -122,10 +122,10 @@ export class FluentBundle {
   /**
    * Add a translation resource to the context.
    *
-   * The translation resource must be a proper FluentResource
-   * parsed by `FluentBundle.parseResource`.
+   * The translation resource must be an instance of FluentResource,
+   * e.g. parsed by `FluentResource.fromString`.
    *
-   *     let res = FluentBundle.parseResource("foo = Foo");
+   *     let res = FluentResource.fromString("foo = Foo");
    *     bundle.addResource(res);
    *     bundle.getMessage('foo');
    *

--- a/fluent/src/index.js
+++ b/fluent/src/index.js
@@ -7,8 +7,6 @@
  *
  */
 
-export { default as _parse } from "./parser";
-
 export { default as FluentBundle } from "./context";
 export { default as FluentResource } from "./resource";
 export { FluentType, FluentNumber, FluentDateTime } from "./types";

--- a/fluent/src/index.js
+++ b/fluent/src/index.js
@@ -9,7 +9,8 @@
 
 export { default as _parse } from "./parser";
 
-export { FluentBundle } from "./context";
+export { default as FluentBundle } from "./context";
+export { default as FluentResource } from "./resource";
 export { FluentType, FluentNumber, FluentDateTime } from "./types";
 
 export { ftl } from "./util";

--- a/fluent/test/arguments_test.js
+++ b/fluent/test/arguments_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { FluentType } from '../src/types';
 import { ftl } from '../src/util';
 

--- a/fluent/test/attributes_test.js
+++ b/fluent/test/attributes_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Attributes', function() {

--- a/fluent/test/bomb_test.js
+++ b/fluent/test/bomb_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Reference bombs', function() {

--- a/fluent/test/constructor_test.js
+++ b/fluent/test/constructor_test.js
@@ -3,7 +3,7 @@
 import assert from 'assert';
 import sinon from 'sinon';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('FluentBundle constructor', function() {

--- a/fluent/test/context_test.js
+++ b/fluent/test/context_test.js
@@ -2,7 +2,8 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
+import FluentResource from '../src/resource';
 import { ftl } from '../src/util';
 
 suite('Bundle', function() {
@@ -67,6 +68,24 @@ suite('Bundle', function() {
       const val = bundle.format(msg, args, errs);
       assert.equal(val, 'Foo');
       assert.equal(errs.length, 0);
+    });
+  });
+
+  suite('addResource', function(){
+    suiteSetup(function() {
+      bundle = new FluentBundle('en-US', { useIsolating: false });
+      let resource = FluentResource.fromString(ftl`
+        foo = Foo
+        -bar = Bar
+      `);
+      bundle.addResource(resource);
+    });
+
+    test('adds messages', function() {
+      assert.equal(bundle._messages.has('foo'), true);
+      assert.equal(bundle._terms.has('foo'), false);
+      assert.equal(bundle._messages.has('-bar'), false);
+      assert.equal(bundle._terms.has('-bar'), true);
     });
   });
 

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Built-in functions', function() {

--- a/fluent/test/functions_runtime_test.js
+++ b/fluent/test/functions_runtime_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Runtime-specific functions', function() {

--- a/fluent/test/functions_test.js
+++ b/fluent/test/functions_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Functions', function() {

--- a/fluent/test/isolating_test.js
+++ b/fluent/test/isolating_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 // Unicode bidi isolation characters.

--- a/fluent/test/patterns_test.js
+++ b/fluent/test/patterns_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Patterns', function(){

--- a/fluent/test/primitives_test.js
+++ b/fluent/test/primitives_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Primitives', function() {

--- a/fluent/test/select_expressions_test.js
+++ b/fluent/test/select_expressions_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Select expressions', function() {

--- a/fluent/test/transform_test.js
+++ b/fluent/test/transform_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Transformations', function(){

--- a/fluent/test/values_format_test.js
+++ b/fluent/test/values_format_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Formatting values', function(){

--- a/fluent/test/values_ref_test.js
+++ b/fluent/test/values_ref_test.js
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 
-import { FluentBundle } from '../src/context';
+import FluentBundle from '../src/context';
 import { ftl } from '../src/util';
 
 suite('Referencing values', function(){

--- a/tools/perf/benchmark.d8.js
+++ b/tools/perf/benchmark.d8.js
@@ -16,7 +16,7 @@ var resource = FluentSyntax.parse(ftlCode);
 times.ftlParseEnd = Date.now();
 
 times.ftlEntriesParseStart = Date.now();
-var [entries] = Fluent._parse(ftlCode);
+var resource = Fluent.FluentResource.fromString(ftlCode);
 times.ftlEntriesParseEnd = Date.now();
 
 var bundle = new Fluent.FluentBundle('en-US');

--- a/tools/perf/benchmark.jsshell.js
+++ b/tools/perf/benchmark.jsshell.js
@@ -16,7 +16,7 @@ var resource = FluentSyntax.parse(ftlCode);
 times.ftlParseEnd = dateNow();
 
 times.ftlEntriesParseStart = dateNow();
-var [entries] = Fluent._parse(ftlCode);
+var resource = Fluent.FluentResource.fromString(ftlCode);
 times.ftlEntriesParseEnd = dateNow();
 
 var bundle = new Fluent.FluentBundle('en-US');

--- a/tools/perf/benchmark.node.js
+++ b/tools/perf/benchmark.node.js
@@ -20,7 +20,7 @@ var resource = FluentSyntax.parse(ftlCode);
 cumulative.ftlParseEnd = process.hrtime(start);
 
 cumulative.ftlEntriesParseStart = process.hrtime(start);
-var [entries] = Fluent._parse(ftlCode);
+var resource = Fluent.FluentResource.fromString(ftlCode);
 cumulative.ftlEntriesParseEnd = process.hrtime(start);
 
 var bundle = new Fluent.FluentBundle('en-US');


### PR DESCRIPTION
We added `FluentResource` in #244 but we kept it hidden. Let's expose it as an export of the `fluent` module.