### PR TITLE
Consistently require the skip option in isNext* methods

### DIFF
--- a/fluent-syntax/src/ftlstream.js
+++ b/fluent-syntax/src/ftlstream.js
@@ -163,14 +163,16 @@ export class FTLParserStream extends ParserStream {
       return true;
     }
 
-    return this.isNextLineValue();
+    return this.isNextLineValue({skip});
   }
 
   // -1 - any
   //  0 - comment
   //  1 - group comment
   //  2 - resource comment
-  isPeekNextLineComment(level = -1) {
+  isNextLineComment(level = -1, {skip = false}) {
+    if (skip === true) throw new Error("Unimplemented");
+
     if (!this.currentPeekIs("\n")) {
       return false;
     }
@@ -199,7 +201,9 @@ export class FTLParserStream extends ParserStream {
     return false;
   }
 
-  isPeekNextLineVariantStart() {
+  isNextLineVariantStart({skip = false}) {
+    if (skip === true) throw new Error("Unimplemented");
+
     if (!this.currentPeekIs("\n")) {
       return false;
     }
@@ -218,7 +222,7 @@ export class FTLParserStream extends ParserStream {
     return false;
   }
 
-  isNextLineAttributeStart({skip = true} = {}) {
+  isNextLineAttributeStart({skip = true}) {
     if (skip === false) throw new Error("Unimplemented");
 
     this.peekBlank();
@@ -232,7 +236,7 @@ export class FTLParserStream extends ParserStream {
     return false;
   }
 
-  isNextLineValue({skip = true} = {}) {
+  isNextLineValue({skip = true}) {
     if (!this.currentPeekIs("\n")) {
       return false;
     }

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -193,7 +193,7 @@ export default class FluentParser {
         }
       }
 
-      if (ps.isPeekNextLineComment(level)) {
+      if (ps.isNextLineComment(level, {skip: false})) {
         content += ps.current();
         ps.next();
       } else {
@@ -226,7 +226,7 @@ export default class FluentParser {
       var pattern = this.getPattern(ps);
     }
 
-    if (ps.isNextLineAttributeStart()) {
+    if (ps.isNextLineAttributeStart({skip: true})) {
       var attrs = this.getAttributes(ps);
     }
 
@@ -250,7 +250,7 @@ export default class FluentParser {
       throw new ParseError("E0006", id.name);
     }
 
-    if (ps.isNextLineAttributeStart()) {
+    if (ps.isNextLineAttributeStart({skip: true})) {
       var attrs = this.getAttributes(ps);
     }
 
@@ -281,7 +281,7 @@ export default class FluentParser {
       const attr = this.getAttribute(ps);
       attrs.push(attr);
 
-      if (!ps.isNextLineAttributeStart()) {
+      if (!ps.isNextLineAttributeStart({skip: true})) {
         break;
       }
     }
@@ -366,7 +366,7 @@ export default class FluentParser {
 
       variants.push(variant);
 
-      if (!ps.isPeekNextLineVariantStart()) {
+      if (!ps.isNextLineVariantStart({skip: false})) {
         break;
       }
       ps.skipBlank();
@@ -417,7 +417,7 @@ export default class FluentParser {
     if (ps.currentIs("{")) {
       ps.peek();
       ps.peekBlankInline();
-      if (ps.isPeekNextLineVariantStart()) {
+      if (ps.isNextLineVariantStart({skip: false})) {
         return this.getVariantList(ps);
       }
 


### PR DESCRIPTION
While working on the Python port I noticed that there still was a slight inconsistency in method naming: sometimes it was `isNext.…` and sometimes `isPeekNext…`. In this PR I unify the naming and use the `skip` option in all invocations, as an explicit measure of documenting whether a method skips or just peeks.