### PR TITLE
Syntax 0.8, part 4: Add parameterized terms (macros)

### DIFF
--- a/fluent-syntax/src/errors.js
+++ b/fluent-syntax/src/errors.js
@@ -51,7 +51,7 @@ function getErrorMessage(code, args) {
     case "E0016":
       return "Message references cannot be used as selectors";
     case "E0017":
-      return "Variants cannot be used as selectors";
+      return "Terms cannot be used as selectors";
     case "E0018":
       return "Attributes of messages cannot be used as selectors";
     case "E0019":

--- a/fluent-syntax/src/serializer.js
+++ b/fluent-syntax/src/serializer.js
@@ -265,13 +265,13 @@ function serializeVariantExpression(expr) {
 
 
 function serializeCallExpression(expr) {
-  const fun = serializeExpression(expr.callee);
+  const callee = serializeExpression(expr.callee);
   const positional = expr.positional.map(serializeExpression).join(", ");
   const named = expr.named.map(serializeNamedArgument).join(", ");
   if (expr.positional.length > 0 && expr.named.length > 0) {
-    return `${fun}(${positional}, ${named})`;
+    return `${callee}(${positional}, ${named})`;
   }
-  return `${fun}(${positional || named})`;
+  return `${callee}(${positional || named})`;
 }
 
 

--- a/fluent-syntax/test/fixtures_behavior/term.ftl
+++ b/fluent-syntax/test/fixtures_behavior/term.ftl
@@ -11,22 +11,21 @@ key2 =
 
 key3 = Test { -brand-short-name[accusative] }
 
+key4 = { -brand() }
+
+# ~ERROR E0004, pos 306, args "0-9"
 err1 =
     { $foo ->
         [one] Foo
        *[-other] Foo 2
     }
-# ~ERROR E0004, pos 285, args "0-9"
 
+# ~ERROR E0004, pos 336, args "a-zA-Z"
 err2 = { $-foo }
-# ~ERROR E0004, pos 315, args "a-zA-Z"
 
-err4 = { -brand() }
-# ~ERROR E0008, pos 339
-
--err5 =
 # ~ERROR E0006, pos 351, args "err5"
+-err5 =
 
+# ~ERROR E0006, pos 360, args "err6"
 -err6 =
     .attr = Attribute
-# ~ERROR E0006, pos 360, args "err6"

--- a/fluent-syntax/test/fixtures_reference/call_expressions.ftl
+++ b/fluent-syntax/test/fixtures_reference/call_expressions.ftl
@@ -1,14 +1,13 @@
 ## Callees
 
 function-callee = {FUNCTION()}
+term-callee = {-term()}
 
 # ERROR Equivalent to a MessageReference callee.
 mixed-case-callee = {Function()}
 
 # ERROR MessageReference is not a valid callee.
 message-callee = {message()}
-# ERROR TermReference is not a valid callee.
-term-callee = {-term()}
 # ERROR VariableReference is not a valid callee.
 variable-callee = {$variable()}
 

--- a/fluent-syntax/test/fixtures_reference/call_expressions.json
+++ b/fluent-syntax/test/fixtures_reference/call_expressions.json
@@ -35,6 +35,35 @@
             "comment": null
         },
         {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "term-callee"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "TermReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "term"
+                                }
+                            },
+                            "positional": [],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
             "type": "Comment",
             "content": "ERROR Equivalent to a MessageReference callee."
         },
@@ -51,15 +80,6 @@
             "type": "Junk",
             "annotations": [],
             "content": "message-callee = {message()}\n"
-        },
-        {
-            "type": "Comment",
-            "content": "ERROR TermReference is not a valid callee."
-        },
-        {
-            "type": "Junk",
-            "annotations": [],
-            "content": "term-callee = {-term()}\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/fixtures_reference/select_expressions.ftl
+++ b/fluent-syntax/test/fixtures_reference/select_expressions.ftl
@@ -4,14 +4,26 @@ new-messages =
        *[other] {""}Other
     }
 
-valid-selector =
+valid-selector-term-attribute =
     { -term.case ->
        *[key] value
     }
 
 # ERROR
-invalid-selector =
+invalid-selector-term-value =
+    { -term ->
+       *[key] value
+    }
+
+# ERROR
+invalid-selector-term-variant =
     { -term[case] ->
+       *[key] value
+    }
+
+# ERROR
+invalid-selector-term-call =
+    { -term(case: "nominative") ->
        *[key] value
     }
 

--- a/fluent-syntax/test/fixtures_reference/select_expressions.json
+++ b/fluent-syntax/test/fixtures_reference/select_expressions.json
@@ -81,7 +81,7 @@
             "type": "Message",
             "id": {
                 "type": "Identifier",
-                "name": "valid-selector"
+                "name": "valid-selector-term-attribute"
             },
             "value": {
                 "type": "Pattern",
@@ -137,7 +137,25 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "invalid-selector =\n    { -term[case] ->\n       *[key] value\n    }\n"
+            "content": "invalid-selector-term-value =\n    { -term ->\n       *[key] value\n    }\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "invalid-selector-term-variant =\n    { -term[case] ->\n       *[key] value\n    }\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "invalid-selector-term-call =\n    { -term(case: \"nominative\") ->\n       *[key] value\n    }\n"
         },
         {
             "type": "Message",

--- a/fluent-syntax/test/fixtures_reference/term_parameters.ftl
+++ b/fluent-syntax/test/fixtures_reference/term_parameters.ftl
@@ -1,0 +1,8 @@
+-term = { $arg ->
+   *[key] Value
+}
+
+key01 = { -term }
+key02 = { -term() }
+key03 = { -term(arg: 1) }
+key04 = { -term("positional", narg1: 1, narg2: 2) }

--- a/fluent-syntax/test/fixtures_reference/term_parameters.json
+++ b/fluent-syntax/test/fixtures_reference/term_parameters.json
@@ -1,0 +1,203 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "term"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "VariableReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "arg"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key01"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "TermReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "term"
+                            }
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key02"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "TermReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "term"
+                                }
+                            },
+                            "positional": [],
+                            "named": []
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key03"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "TermReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "term"
+                                }
+                            },
+                            "positional": [],
+                            "named": [
+                                {
+                                    "type": "NamedArgument",
+                                    "name": {
+                                        "type": "Identifier",
+                                        "name": "arg"
+                                    },
+                                    "value": {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key04"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "CallExpression",
+                            "callee": {
+                                "type": "TermReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "term"
+                                }
+                            },
+                            "positional": [
+                                {
+                                    "type": "StringLiteral",
+                                    "raw": "positional",
+                                    "value": "positional"
+                                }
+                            ],
+                            "named": [
+                                {
+                                    "type": "NamedArgument",
+                                    "name": {
+                                        "type": "Identifier",
+                                        "name": "narg1"
+                                    },
+                                    "value": {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    }
+                                },
+                                {
+                                    "type": "NamedArgument",
+                                    "name": {
+                                        "type": "Identifier",
+                                        "name": "narg2"
+                                    },
+                                    "value": {
+                                        "type": "NumberLiteral",
+                                        "value": "2"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        }
+    ]
+}

--- a/fluent-syntax/test/serializer_test.js
+++ b/fluent-syntax/test/serializer_test.js
@@ -450,6 +450,13 @@ suite("Serialize resource", function() {
     assert.equal(pretty(input), input);
   });
 
+  test("macro call", function() {
+    const input = ftl`
+      foo = { -term() }
+    `;
+    assert.equal(pretty(input), input);
+  });
+
   test("nested placeables", function() {
     const input = ftl`
       foo = {{ FOO() }}

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -363,7 +363,7 @@ function VariableReference(env, {name}) {
 
   if (!args || !args.hasOwnProperty(name)) {
     errors.push(new ReferenceError(`Unknown variable: ${name}`));
-    return new FluentNone(name);
+    return new FluentNone(`$${name}`);
   }
 
   const arg = args[name];
@@ -387,7 +387,7 @@ function VariableReference(env, {name}) {
       errors.push(
         new TypeError(`Unsupported variable type: ${name}, ${typeof arg}`)
       );
-      return new FluentNone(name);
+      return new FluentNone(`$${name}`);
   }
 }
 

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -29,9 +29,10 @@
  * instantly resolve to the value of the `brand-name` message.  Instead, we
  * want to get the message object and look for its `nominative` variant.
  *
- * All other expressions (except for `FunctionReference` which is only used in
- * `CallExpression`) resolve to an instance of `FluentType`.  The caller should
- * use the `toString` method to convert the instance to a native value.
+ * All other expressions (except for `FunctionReference` which is only used as
+ * a callee in `FunctionExpression`) resolve to an instance of `FluentType`.
+ * The caller should use the `toString` method to convert the instance to a
+ * native value.
  *
  *
  * All functions in this file pass around a special object called `env`.
@@ -138,12 +139,12 @@ function DefaultMember(env, members, star) {
  */
 function MessageReference(env, {name}) {
   const { bundle, errors } = env;
-  const message = name.startsWith("-")
+  const message = name[0] === "-"
     ? bundle._terms.get(name)
     : bundle._messages.get(name);
 
   if (!message) {
-    const err = name.startsWith("-")
+    const err = name[0] === "-"
       ? new ReferenceError(`Unknown term: ${name}`)
       : new ReferenceError(`Unknown message: ${name}`);
     errors.push(err);
@@ -311,13 +312,15 @@ function Type(env, expr) {
       return new FluentNumber(expr.value);
     case "var":
       return VariableReference(env, expr);
-    case "func":
-      return FunctionReference(env, expr);
     case "call":
-      return CallExpression(env, expr);
+      return expr.ref.name[0] === "-"
+        ? MacroExpression(env, expr)
+        : FunctionExpression(env, expr);
     case "ref": {
       const message = MessageReference(env, expr);
-      return Type(env, message);
+      return expr.name[0] === "-"
+        ? Type({...env, args: {}}, message)
+        : Type(env, message);
     }
     case "getattr": {
       const attr = AttributeExpression(env, expr);
@@ -429,16 +432,15 @@ function FunctionReference(env, {name}) {
  *    Resolver environment object.
  * @param   {Object} expr
  *    An expression to be resolved.
- * @param   {Object} expr.callee
+ * @param   {Object} expr.ref
  *    FTL Function object.
  * @param   {Array} expr.args
  *    FTL Function argument list.
  * @returns {FluentType}
  * @private
  */
-function CallExpression(env, {callee, args}) {
-  const func = FunctionReference(env, callee);
-
+function FunctionExpression(env, {ref, args}) {
+  const func = FunctionReference(env, ref);
   if (func instanceof FluentNone) {
     return func;
   }
@@ -460,6 +462,36 @@ function CallExpression(env, {callee, args}) {
     // XXX Report errors.
     return new FluentNone();
   }
+}
+
+/**
+ * Resolve a call to a Term with key-value arguments.
+ *
+ * @param   {Object} env
+ *    Resolver environment object.
+ * @param   {Object} expr
+ *    An expression to be resolved.
+ * @param   {Object} expr.ref
+ *    FTL Function object.
+ * @param   {Array} expr.args
+ *    FTL Function argument list.
+ * @returns {FluentType}
+ * @private
+ */
+function MacroExpression(env, {ref, args}) {
+  const callee = MessageReference(env, ref);
+  if (callee instanceof FluentNone) {
+    return callee;
+  }
+
+  const keyargs = {};
+  for (const arg of args) {
+    if (arg.type === "narg") {
+      keyargs[arg.name] = Type(env, arg.value);
+    }
+  }
+
+  return Type({...env, args: keyargs}, callee);
 }
 
 /**

--- a/fluent/src/resource.js
+++ b/fluent/src/resource.js
@@ -311,8 +311,7 @@ export default class FluentResource extends Map {
         }
 
         if (consumeToken(TOKEN_PAREN_OPEN)) {
-          let callee = {...ref, type: "func"};
-          return {type: "call", callee, args: parseArguments()};
+          return {type: "call", ref, args: parseArguments()};
         }
 
         return ref;

--- a/fluent/test/arguments_test.js
+++ b/fluent/test/arguments_test.js
@@ -101,49 +101,49 @@ suite('Variables', function() {
     test('falls back to argument\'s name if it\'s missing', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, 'arg');
+      assert.equal(val, '$arg');
       assert(errs[0] instanceof ReferenceError); // unknown variable
     });
 
     test('cannot be arrays', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: [1, 2, 3] }, errs);
-      assert.equal(val, 'arg');
+      assert.equal(val, '$arg');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be a dict-like object', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: { prop: 1 } }, errs);
-      assert.equal(val, 'arg');
+      assert.equal(val, '$arg');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be a boolean', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: true }, errs);
-      assert.equal(val, 'arg');
+      assert.equal(val, '$arg');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be undefined', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: undefined }, errs);
-      assert.equal(val, 'arg');
+      assert.equal(val, '$arg');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be null', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: null }, errs);
-      assert.equal(val, 'arg');
+      assert.equal(val, '$arg');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be a function', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: () => null }, errs);
-      assert.equal(val, 'arg');
+      assert.equal(val, '$arg');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
   });

--- a/fluent/test/fixtures_behavior/term.json
+++ b/fluent/test/fixtures_behavior/term.json
@@ -13,5 +13,8 @@
   },
   "key3": {
     "value": true
+  },
+  "key4": {
+    "value": true
   }
 }

--- a/fluent/test/fixtures_reference/call_expressions.json
+++ b/fluent/test/fixtures_reference/call_expressions.json
@@ -2,9 +2,19 @@
     "function-callee": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUNCTION"
+            },
+            "args": []
+        }
+    ],
+    "term-callee": [
+        {
+            "type": "call",
+            "ref": {
+                "type": "ref",
+                "name": "-term"
             },
             "args": []
         }
@@ -12,8 +22,8 @@
     "mixed-case-callee": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "Function"
             },
             "args": []
@@ -22,19 +32,9 @@
     "message-callee": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "message"
-            },
-            "args": []
-        }
-    ],
-    "term-callee": [
-        {
-            "type": "call",
-            "callee": {
-                "type": "func",
-                "name": "-term"
             },
             "args": []
         }
@@ -42,8 +42,8 @@
     "positional-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -65,8 +65,8 @@
     "named-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -92,8 +92,8 @@
     "dense-named-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -119,8 +119,8 @@
     "mixed-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -158,8 +158,8 @@
     "shuffled-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -197,8 +197,8 @@
     "duplicate-named-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -224,8 +224,8 @@
     "sparse-inline-call": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -251,8 +251,8 @@
     "empty-inline-call": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": []
@@ -261,8 +261,8 @@
     "multiline-call": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -288,8 +288,8 @@
     "sparse-multiline-call": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -315,8 +315,8 @@
     "empty-multiline-call": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": []
@@ -325,8 +325,8 @@
     "unindented-arg-number": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -340,8 +340,8 @@
     "unindented-arg-string": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -355,8 +355,8 @@
     "unindented-arg-msg-ref": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -370,8 +370,8 @@
     "unindented-arg-term-ref": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -385,8 +385,8 @@
     "unindented-arg-var-ref": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -400,15 +400,15 @@
     "unindented-arg-call": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
                 {
                     "type": "call",
-                    "callee": {
-                        "type": "func",
+                    "ref": {
+                        "type": "ref",
                         "name": "OTHER"
                     },
                     "args": []
@@ -419,8 +419,8 @@
     "unindented-named-arg": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -438,8 +438,8 @@
     "unindented-closing-paren": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -453,8 +453,8 @@
     "one-argument": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -468,8 +468,8 @@
     "many-arguments": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -491,8 +491,8 @@
     "inline-sparse-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -514,8 +514,8 @@
     "mulitline-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -533,8 +533,8 @@
     "mulitline-sparse-args": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -552,8 +552,8 @@
     "sparse-named-arg": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -587,8 +587,8 @@
     "unindented-colon": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [
@@ -606,8 +606,8 @@
     "unindented-value": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FUN"
             },
             "args": [

--- a/fluent/test/fixtures_reference/select_expressions.json
+++ b/fluent/test/fixtures_reference/select_expressions.json
@@ -4,8 +4,8 @@
             "type": "select",
             "selector": {
                 "type": "call",
-                "callee": {
-                    "type": "func",
+                "ref": {
+                    "type": "ref",
                     "name": "BUILTIN"
                 },
                 "args": []
@@ -28,7 +28,7 @@
             "star": 1
         }
     ],
-    "valid-selector": [
+    "valid-selector-term-attribute": [
         {
             "type": "select",
             "selector": {
@@ -48,7 +48,23 @@
             "star": 0
         }
     ],
-    "invalid-selector": [
+    "invalid-selector-term-value": [
+        {
+            "type": "select",
+            "selector": {
+                "type": "ref",
+                "name": "-term"
+            },
+            "variants": [
+                {
+                    "key": "key",
+                    "value": "value"
+                }
+            ],
+            "star": 0
+        }
+    ],
+    "invalid-selector-term-variant": [
         {
             "type": "select",
             "selector": {
@@ -58,6 +74,35 @@
                     "name": "-term"
                 },
                 "selector": "case"
+            },
+            "variants": [
+                {
+                    "key": "key",
+                    "value": "value"
+                }
+            ],
+            "star": 0
+        }
+    ],
+    "invalid-selector-term-call": [
+        {
+            "type": "select",
+            "selector": {
+                "type": "call",
+                "ref": {
+                    "type": "ref",
+                    "name": "-term"
+                },
+                "args": [
+                    {
+                        "type": "narg",
+                        "name": "case",
+                        "value": {
+                            "type": "str",
+                            "value": "nominative"
+                        }
+                    }
+                ]
             },
             "variants": [
                 {

--- a/fluent/test/fixtures_reference/term_parameters.json
+++ b/fluent/test/fixtures_reference/term_parameters.json
@@ -1,0 +1,84 @@
+{
+    "-term": [
+        {
+            "type": "select",
+            "selector": {
+                "type": "var",
+                "name": "arg"
+            },
+            "variants": [
+                {
+                    "key": "key",
+                    "value": "Value"
+                }
+            ],
+            "star": 0
+        }
+    ],
+    "key01": [
+        {
+            "type": "ref",
+            "name": "-term"
+        }
+    ],
+    "key02": [
+        {
+            "type": "call",
+            "ref": {
+                "type": "ref",
+                "name": "-term"
+            },
+            "args": []
+        }
+    ],
+    "key03": [
+        {
+            "type": "call",
+            "ref": {
+                "type": "ref",
+                "name": "-term"
+            },
+            "args": [
+                {
+                    "type": "narg",
+                    "name": "arg",
+                    "value": {
+                        "type": "num",
+                        "value": "1"
+                    }
+                }
+            ]
+        }
+    ],
+    "key04": [
+        {
+            "type": "call",
+            "ref": {
+                "type": "ref",
+                "name": "-term"
+            },
+            "args": [
+                {
+                    "type": "str",
+                    "value": "positional"
+                },
+                {
+                    "type": "narg",
+                    "name": "narg1",
+                    "value": {
+                        "type": "num",
+                        "value": "1"
+                    }
+                },
+                {
+                    "type": "narg",
+                    "name": "narg2",
+                    "value": {
+                        "type": "num",
+                        "value": "2"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/fluent/test/fixtures_structure/expressions_call_args.json
+++ b/fluent/test/fixtures_structure/expressions_call_args.json
@@ -2,8 +2,8 @@
     "key": [
         {
             "type": "call",
-            "callee": {
-                "type": "func",
+            "ref": {
+                "type": "ref",
                 "name": "FOO"
             },
             "args": [

--- a/fluent/test/macros_test.js
+++ b/fluent/test/macros_test.js
@@ -1,0 +1,347 @@
+"use strict";
+
+import assert from "assert";
+
+import FluentBundle from "../src/bundle";
+import { ftl } from "../src/util";
+
+suite("Macros", function() {
+  let bundle, errs;
+
+  setup(function() {
+    errs = [];
+  });
+
+  suite("References and calls", function(){
+    suiteSetup(function() {
+      bundle = new FluentBundle("en-US", {
+        useIsolating: false,
+      });
+      bundle.addMessages(ftl`
+        foo = Foo
+        message-call = {foo()}
+
+        -bar = Bar
+        term-ref = {-bar}
+        term-call = {-bar()}
+      `);
+    });
+
+    test("messages cannot be parameterized", function() {
+      const msg = bundle.getMessage("message-call");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "foo()");
+      assert.equal(errs.length, 1);
+    });
+
+    test("terms can be referenced without parens", function() {
+      const msg = bundle.getMessage("term-ref");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Bar");
+      assert.equal(errs.length, 0);
+    });
+
+    test("terms can be parameterized", function() {
+      const msg = bundle.getMessage("term-call");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Bar");
+      assert.equal(errs.length, 0);
+    });
+  });
+
+  suite("Passing arguments", function(){
+    suiteSetup(function() {
+      bundle = new FluentBundle("en-US", {
+        useIsolating: false,
+      });
+      bundle.addMessages(ftl`
+        -foo = Foo {$arg}
+
+        ref-foo = {-foo}
+        call-foo-no-args = {-foo()}
+        call-foo-with-expected-arg = {-foo(arg: 1)}
+        call-foo-with-other-arg = {-foo(other: 3)}
+      `);
+    });
+
+    test("Not parameterized, no externals", function() {
+      const msg = bundle.getMessage("ref-foo");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("Not parameterized but with externals", function() {
+      const msg = bundle.getMessage("ref-foo");
+      const val = bundle.format(msg, {arg: 1}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No arguments, no externals", function() {
+      const msg = bundle.getMessage("call-foo-no-args");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No arguments, but with externals", function() {
+      const msg = bundle.getMessage("call-foo-no-args");
+      const val = bundle.format(msg, {arg: 1}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("With expected args, no externals", function() {
+      const msg = bundle.getMessage("call-foo-with-expected-arg");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("With expected args, and with externals", function() {
+      const msg = bundle.getMessage("call-foo-with-expected-arg");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("With other args, no externals", function() {
+      const msg = bundle.getMessage("call-foo-with-other-arg");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("With other args, and with externals", function() {
+      const msg = bundle.getMessage("call-foo-with-other-arg");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+  });
+
+  suite("Nesting message references", function(){
+    suiteSetup(function() {
+      bundle = new FluentBundle("en-US", {
+        useIsolating: false,
+      });
+      bundle.addMessages(ftl`
+        foo = Foo {$arg}
+        -bar = {foo}
+        ref-bar = {-bar}
+        call-bar = {-bar()}
+        call-bar-with-arg = {-bar(arg: 1)}
+      `);
+    });
+
+    test("No parameterization, no externals", function() {
+      const msg = bundle.getMessage("ref-bar");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No parameterization, but with externals", function() {
+      const msg = bundle.getMessage("ref-bar");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No arguments, no externals", function() {
+      const msg = bundle.getMessage("call-bar");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No arguments, but with externals", function() {
+      const msg = bundle.getMessage("call-bar");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("With arguments, no externals", function() {
+      const msg = bundle.getMessage("call-bar-with-arg");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+
+    });
+    test("With arguments and with externals", function() {
+      const msg = bundle.getMessage("call-bar-with-arg");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+  });
+
+  suite("Nesting term references", function(){
+    suiteSetup(function() {
+      bundle = new FluentBundle("en-US", {
+        useIsolating: false,
+      });
+      bundle.addMessages(ftl`
+        -foo = Foo {$arg}
+        -bar = {-foo}
+        -baz = {-foo()}
+        -qux = {-foo(arg: 1)}
+
+        ref-bar = {-bar}
+        ref-baz = {-baz}
+        ref-qux = {-qux}
+
+        call-bar-no-args = {-bar()}
+        call-baz-no-args = {-baz()}
+        call-qux-no-args = {-qux()}
+
+        call-bar-with-arg = {-bar(arg: 2)}
+        call-baz-with-arg = {-baz(arg: 2)}
+        call-qux-with-arg = {-qux(arg: 2)}
+        call-qux-with-other = {-qux(other: 3)}
+      `);
+    });
+
+    test("No parameterization, no parameterization, no externals", function() {
+      const msg = bundle.getMessage("ref-bar");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No parameterization, no parameterization, with externals", function() {
+      const msg = bundle.getMessage("ref-bar");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No parameterization, no arguments, no externals", function() {
+      const msg = bundle.getMessage("ref-baz");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No parameterization, no arguments, with externals", function() {
+      const msg = bundle.getMessage("ref-baz");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No parameterization, with arguments, no externals", function() {
+      const msg = bundle.getMessage("ref-qux");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("No parameterization, with arguments, with externals", function() {
+      const msg = bundle.getMessage("ref-qux");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("No arguments, no parameterization, no externals", function() {
+      const msg = bundle.getMessage("call-bar-no-args");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No arguments, no parameterization, with externals", function() {
+      const msg = bundle.getMessage("call-bar-no-args");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No arguments, no arguments, no externals", function() {
+      const msg = bundle.getMessage("call-baz-no-args");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No arguments, no arguments, with externals", function() {
+      const msg = bundle.getMessage("call-baz-no-args");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("No arguments, with arguments, no externals", function() {
+      const msg = bundle.getMessage("call-qux-no-args");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("No arguments, with arguments, with externals", function() {
+      const msg = bundle.getMessage("call-qux-no-args");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("With arguments, no parameterization, no externals", function() {
+      const msg = bundle.getMessage("call-bar-with-arg");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("With arguments, no parameterization, with externals", function() {
+      const msg = bundle.getMessage("call-bar-with-arg");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("With arguments, no arguments, no externals", function() {
+      const msg = bundle.getMessage("call-baz-with-arg");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("With arguments, no arguments, with externals", function() {
+      const msg = bundle.getMessage("call-baz-with-arg");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo $arg");
+      assert.equal(errs.length, 1);
+    });
+
+    test("With arguments, with arguments, no externals", function() {
+      const msg = bundle.getMessage("call-qux-with-arg");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("With arguments, with arguments, with externals", function() {
+      const msg = bundle.getMessage("call-qux-with-arg");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("With unexpected arguments, with arguments, no externals", function() {
+      const msg = bundle.getMessage("call-qux-with-other");
+      const val = bundle.format(msg, {}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+
+    test("With unexpected arguments, with arguments, with externals", function() {
+      const msg = bundle.getMessage("call-qux-with-other");
+      const val = bundle.format(msg, {arg: 5}, errs);
+      assert.equal(val, "Foo 1");
+      assert.equal(errs.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
Implement https://github.com/projectfluent/fluent/commit/dc20d52b622a41913c0f3875efa996e78952834a, without parameterized attributes, which I'll do in a different PR.

Depends on #310.