### PR TITLE
Syntax 0.8, part 5: Update reference fixtures

### DIFF
--- a/fluent-syntax/test/fixtures_reference/any_char.ftl
+++ b/fluent-syntax/test/fixtures_reference/any_char.ftl
@@ -1,0 +1,8 @@
+#             ↓ BEL, U+0007
+control0 = abcdef
+
+#           ↓ DEL, U+007F
+delete = abcdef
+
+#             ↓ BPM, U+0082
+control1 = abcdef

--- a/fluent-syntax/test/fixtures_reference/any_char.json
+++ b/fluent-syntax/test/fixtures_reference/any_char.json
@@ -1,0 +1,68 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "control0"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "abc\u0007def"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "            ↓ BEL, U+0007"
+            }
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "delete"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "abcdef"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "          ↓ DEL, U+007F"
+            }
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "control1"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "abcdef"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "            ↓ BPM, U+0082"
+            }
+        }
+    ]
+}

--- a/fluent-syntax/test/fixtures_reference/astral.json
+++ b/fluent-syntax/test/fixtures_reference/astral.json
@@ -154,7 +154,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "err-😂 = Value\n"
+            "content": "err-😂 = Value\n\n"
         },
         {
             "type": "Comment",
@@ -163,7 +163,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "err-invalid-expression = { 😂 }\n"
+            "content": "err-invalid-expression = { 😂 }\n\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/fixtures_reference/call_expressions.json
+++ b/fluent-syntax/test/fixtures_reference/call_expressions.json
@@ -70,7 +70,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "mixed-case-callee = {Function()}\n"
+            "content": "mixed-case-callee = {Function()}\n\n"
         },
         {
             "type": "Comment",
@@ -88,7 +88,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "variable-callee = {$variable()}\n"
+            "content": "variable-callee = {$variable()}\n\n"
         },
         {
             "type": "GroupComment",
@@ -323,7 +323,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "shuffled-args = {FUN(1, x: 1, \"a\", y: \"Y\", msg)}\n"
+            "content": "shuffled-args = {FUN(1, x: 1, \"a\", y: \"Y\", msg)}\n\n"
         },
         {
             "type": "Comment",
@@ -332,7 +332,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "duplicate-named-args = {FUN(x: 1, x: \"X\")}\n"
+            "content": "duplicate-named-args = {FUN(x: 1, x: \"X\")}\n\n\n"
         },
         {
             "type": "GroupComment",
@@ -1063,7 +1063,17 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "one-argument = {FUN(1,,)}\nmissing-arg = {FUN(,)}\nmissing-sparse-arg = {FUN(   ,   )}\n"
+            "content": "one-argument = {FUN(1,,)}\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "missing-arg = {FUN(,)}\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "missing-sparse-arg = {FUN(   ,   )}\n\n\n"
         },
         {
             "type": "GroupComment",

--- a/fluent-syntax/test/fixtures_reference/crlf.json
+++ b/fluent-syntax/test/fixtures_reference/crlf.json
@@ -61,7 +61,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "err03 = { \"str\r\n"
+            "content": "err03 = { \"str\r\n\r\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/fixtures_reference/escaped_characters.json
+++ b/fluent-syntax/test/fixtures_reference/escaped_characters.json
@@ -169,7 +169,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "unknown-escape = {\"\\x\"}\n"
+            "content": "unknown-escape = {\"\\x\"}\n\n"
         },
         {
             "type": "GroupComment",

--- a/fluent-syntax/test/fixtures_reference/junk.ftl
+++ b/fluent-syntax/test/fixtures_reference/junk.ftl
@@ -1,4 +1,21 @@
+## Two adjacent Junks.
+err01 = {1x}
+err02 = {2x}
+
+# A single Junk.
+err03 = {1x
+2
+
+# A single Junk.
 ą=Invalid identifier
 ć=Another one
 
-key01 = {
+# The COMMENT ends this junk.
+err04 = {
+# COMMENT
+
+# The COMMENT ends this junk.
+# The closing brace is a separate Junk.
+err04 = {
+# COMMENT
+}

--- a/fluent-syntax/test/fixtures_reference/junk.json
+++ b/fluent-syntax/test/fixtures_reference/junk.json
@@ -2,14 +2,67 @@
     "type": "Resource",
     "body": [
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "ą=Invalid identifier\nć=Another one\n"
+            "type": "GroupComment",
+            "content": "Two adjacent Junks."
         },
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key01 = {\n"
+            "content": "err01 = {1x}\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "err02 = {2x}\n\n"
+        },
+        {
+            "type": "Comment",
+            "content": "A single Junk."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "err03 = {1x\n2\n\n"
+        },
+        {
+            "type": "Comment",
+            "content": "A single Junk."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "ą=Invalid identifier\nć=Another one\n\n"
+        },
+        {
+            "type": "Comment",
+            "content": "The COMMENT ends this junk."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "err04 = {\n"
+        },
+        {
+            "type": "Comment",
+            "content": "COMMENT"
+        },
+        {
+            "type": "Comment",
+            "content": "The COMMENT ends this junk.\nThe closing brace is a separate Junk."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "err04 = {\n"
+        },
+        {
+            "type": "Comment",
+            "content": "COMMENT"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "}\n"
         }
     ]
 }

--- a/fluent-syntax/test/fixtures_reference/leading_dots.json
+++ b/fluent-syntax/test/fixtures_reference/leading_dots.json
@@ -173,7 +173,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "    .Continued\n"
+            "content": "    .Continued\n\n"
         },
         {
             "type": "Comment",
@@ -182,7 +182,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key08 =\n    .Value\n"
+            "content": "key08 =\n    .Value\n\n"
         },
         {
             "type": "Comment",
@@ -191,7 +191,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key09 =\n    .Value\n    Continued\n"
+            "content": "key09 =\n    .Value\n    Continued\n\n"
         },
         {
             "type": "Message",
@@ -410,7 +410,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key16 =\n    { 1 ->\n       *[one]\n           .Value\n    }\n"
+            "content": "key16 =\n    { 1 ->\n       *[one]\n           .Value\n    }\n\n"
         },
         {
             "type": "Comment",
@@ -419,7 +419,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key17 =\n    { 1 ->\n       *[one] Value\n           .Continued\n    }\n"
+            "content": "key17 =\n    { 1 ->\n       *[one] Value\n           .Continued\n    }\n\n"
         },
         {
             "type": "Comment",
@@ -428,7 +428,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key18 =\n.Value\n"
+            "content": "key18 =\n.Value\n\n"
         },
         {
             "type": "Message",

--- a/fluent-syntax/test/fixtures_reference/member_expressions.json
+++ b/fluent-syntax/test/fixtures_reference/member_expressions.json
@@ -70,7 +70,12 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "variant-expression = {msg[case]}\nattribute-expression = {-term.attr}\n"
+            "content": "variant-expression = {msg[case]}\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "attribute-expression = {-term.attr}\n"
         }
     ]
 }

--- a/fluent-syntax/test/fixtures_reference/messages.json
+++ b/fluent-syntax/test/fixtures_reference/messages.json
@@ -234,7 +234,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key07 =\n"
+            "content": "key07 =\n\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/fixtures_reference/mixed_entries.json
+++ b/fluent-syntax/test/fixtures_reference/mixed_entries.json
@@ -61,7 +61,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "ą=Invalid identifier\nć=Another one\n"
+            "content": "ą=Invalid identifier\nć=Another one\n\n"
         },
         {
             "type": "Message",
@@ -91,7 +91,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "    .attr = Dangling attribute\n"
+            "content": "    .attr = Dangling attribute\n\n"
         },
         {
             "type": "Message",

--- a/fluent-syntax/test/fixtures_reference/placeables.json
+++ b/fluent-syntax/test/fixtures_reference/placeables.json
@@ -80,7 +80,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "unmatched-open1 = { 1\n"
+            "content": "unmatched-open1 = { 1\n\n"
         },
         {
             "type": "Comment",
@@ -89,7 +89,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "unmatched-open2 = {{ 1 }\n"
+            "content": "unmatched-open2 = {{ 1 }\n\n"
         },
         {
             "type": "Comment",
@@ -98,7 +98,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "unmatched-close1 = 1 }\n"
+            "content": "unmatched-close1 = 1 }\n\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/fixtures_reference/select_expressions.json
+++ b/fluent-syntax/test/fixtures_reference/select_expressions.json
@@ -137,7 +137,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "invalid-selector-term-value =\n    { -term ->\n       *[key] value\n    }\n"
+            "content": "invalid-selector-term-value =\n    { -term ->\n       *[key] value\n    }\n\n"
         },
         {
             "type": "Comment",
@@ -146,7 +146,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "invalid-selector-term-variant =\n    { -term[case] ->\n       *[key] value\n    }\n"
+            "content": "invalid-selector-term-variant =\n    { -term[case] ->\n       *[key] value\n    }\n\n"
         },
         {
             "type": "Comment",
@@ -155,7 +155,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "invalid-selector-term-call =\n    { -term(case: \"nominative\") ->\n       *[key] value\n    }\n"
+            "content": "invalid-selector-term-call =\n    { -term(case: \"nominative\") ->\n       *[key] value\n    }\n\n"
         },
         {
             "type": "Message",
@@ -279,7 +279,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "nested-variant-list =\n    { 1 ->\n       *[one] {\n          *[two] Value\n       }\n    }\n"
+            "content": "nested-variant-list =\n    { 1 ->\n       *[one] {\n          *[two] Value\n       }\n    }\n\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/fixtures_reference/select_indent.json
+++ b/fluent-syntax/test/fixtures_reference/select_indent.json
@@ -548,7 +548,12 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "select-no-indent-multiline = { $selector ->\n   *[key] Value\nContinued without indent.\n}\n"
+            "content": "select-no-indent-multiline = { $selector ->\n   *[key] Value\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "Continued without indent.\n}\n\n"
         },
         {
             "type": "Message",

--- a/fluent-syntax/test/fixtures_reference/tab.json
+++ b/fluent-syntax/test/fixtures_reference/tab.json
@@ -29,7 +29,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key02\t= Value 02\n"
+            "content": "key02\t= Value 02\n\n"
         },
         {
             "type": "Comment",
@@ -38,7 +38,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key03 =\n\tThis line isn't properly indented.\n"
+            "content": "key03 =\n\tThis line isn't properly indented.\n\n"
         },
         {
             "type": "Message",

--- a/fluent-syntax/test/fixtures_reference/terms.json
+++ b/fluent-syntax/test/fixtures_reference/terms.json
@@ -65,7 +65,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "-term03 =\n    .attr = Attribute\n"
+            "content": "-term03 =\n    .attr = Attribute\n\n"
         },
         {
             "type": "Comment",
@@ -74,7 +74,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "-term04 =                \n    .attr1 = Attribute 1\n"
+            "content": "-term04 =                \n    .attr1 = Attribute 1\n\n"
         },
         {
             "type": "Comment",
@@ -83,7 +83,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "-term05 =\n"
+            "content": "-term05 =\n\n"
         },
         {
             "type": "Comment",
@@ -92,7 +92,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "-term06 =                \n"
+            "content": "-term06 =                \n\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/fixtures_reference/variant_keys.json
+++ b/fluent-syntax/test/fixtures_reference/variant_keys.json
@@ -132,7 +132,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "-invalid-identifier =\n    {\n       *[two words] value\n    }\n"
+            "content": "-invalid-identifier =\n    {\n       *[two words] value\n    }\n\n"
         },
         {
             "type": "Comment",
@@ -141,7 +141,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "-invalid-int =\n    {\n       *[1 apple] value\n    }\n"
+            "content": "-invalid-int =\n    {\n       *[1 apple] value\n    }\n\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/fixtures_reference/variant_lists.json
+++ b/fluent-syntax/test/fixtures_reference/variant_lists.json
@@ -56,7 +56,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "    .attr =\n        {\n           *[key] Value\n        }\n"
+            "content": "    .attr =\n        {\n           *[key] Value\n        }\n\n"
         },
         {
             "type": "Comment",
@@ -65,7 +65,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "variant-list-in-message =\n    {\n       *[key] Value\n    }\n"
+            "content": "variant-list-in-message =\n    {\n       *[key] Value\n    }\n\n"
         },
         {
             "type": "Message",
@@ -91,7 +91,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "    .attr =\n        {\n           *[key] Value\n        }\n"
+            "content": "    .attr =\n        {\n           *[key] Value\n        }\n\n"
         },
         {
             "type": "Term",
@@ -200,7 +200,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "nested-select-then-variant-list =\n    {\n       *[one] { 2 ->\n          *[two] {\n             *[three] Value\n          }\n       }\n    }\n"
+            "content": "nested-select-then-variant-list =\n    {\n       *[one] { 2 ->\n          *[two] {\n             *[three] Value\n          }\n       }\n    }\n\n"
         },
         {
             "type": "Comment",

--- a/fluent-syntax/test/reference_test.js
+++ b/fluent-syntax/test/reference_test.js
@@ -46,10 +46,11 @@ readdir(fixtures, function(err, filenames) {
         const ref = JSON.parse(expected)
         const ast = parser.parse(ftl);
 
-        // Ignore Junk which is parsed differently by the tooling parser, and
-        // which doesn't carry spans nor annotations in the reference parser.
-        ref.body = ref.body.filter(entry => entry.type !== "Junk");
-        ast.body = ast.body.filter(entry => entry.type !== "Junk");
+        // Only compare Junk content and ignore annotations, which carry error
+        // messages and positions. The reference parser doesn't produce
+        // annotations at the moment.
+        ast.body = ast.body.map(entry => entry.type === "Junk" ?
+          {...entry, annotations: []} : entry);
 
         assert.deepEqual(
           ast, ref,

--- a/fluent/test/fixtures_reference/any_char.json
+++ b/fluent/test/fixtures_reference/any_char.json
@@ -1,0 +1,5 @@
+{
+    "control0": "abc\u0007def",
+    "delete": "abcdef",
+    "control1": "abcdef"
+}


### PR DESCRIPTION
This is part 5 of #303:

- [x] 10. Stop parsing Junk on lines which look like Entries
    https://github.com/projectfluent/fluent/pull/211, tests only
- [x] 11. Allow all Unicode characters
    https://github.com/projectfluent/fluent/pull/207, tests only

With this PR the reference tests in `fluent-syntax` now compare the content of all `Junk` entries! (Comparing annotations and spans is far away.)

Depends on #311.