### PR TITLE
Syntax 0.8, part 7: \UHHHHHH and other changes

### DIFF
--- a/fluent-syntax/src/errors.js
+++ b/fluent-syntax/src/errors.js
@@ -69,8 +69,8 @@ function getErrorMessage(code, args) {
       return `Unknown escape sequence: \\${char}.`;
     }
     case "E0026": {
-      const [char] = args;
-      return `Invalid Unicode escape sequence: \\u${char}.`;
+      const [sequence] = args;
+      return `Invalid Unicode escape sequence: ${sequence}.`;
     }
     case "E0027":
       return "Unbalanced closing brace in TextElement.";

--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -6,10 +6,6 @@ import { ParseError } from "./errors";
 
 
 const trailingWSRe = /[ \t\n\r]+$/;
-// The Fluent Syntax spec uses /.*/ to parse comment lines. It matches all
-// characters except the following ones, which are considered line endings by
-// the regex engine.
-const COMMENT_EOL = ["\n", "\r", "\u2028", "\u2029"];
 
 
 function withSpan(fn) {
@@ -194,10 +190,10 @@ export default class FluentParser {
         level = i;
       }
 
-      if (!COMMENT_EOL.includes(ps.currentChar)) {
+      if (ps.currentChar !== EOL) {
         ps.expectChar(" ");
         let ch;
-        while ((ch = ps.takeChar(x => !COMMENT_EOL.includes(x)))) {
+        while ((ch = ps.takeChar(x => x !== EOL))) {
           content += ch;
         }
       }

--- a/fluent-syntax/test/fixtures_behavior/escape_sequences.ftl
+++ b/fluent-syntax/test/fixtures_behavior/escape_sequences.ftl
@@ -12,5 +12,5 @@ key08 = {"Escaped \u0041 A"}
 # ~ERROR E0025, pos 232, args "A"
 key09 = {"\A"}
 
-# ~ERROR E0026, pos 252, args "000z"
+# ~ERROR E0026, pos 252, args "\u000z"
 key10 = {"\u000z"}

--- a/fluent-syntax/test/fixtures_behavior/variant_lists.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_lists.ftl
@@ -17,6 +17,7 @@ message2 =
         *[one] One
     }
 
+# ~ERROR E0014, pos 211
 -term2 =
     {
         *[one] {

--- a/fluent-syntax/test/fixtures_reference/cr.json
+++ b/fluent-syntax/test/fixtures_reference/cr.json
@@ -2,9 +2,8 @@
     "type": "Resource",
     "body": [
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "### This entire file uses CR as EOL.\r\rerr01 = Value 01\rerr02 = Value 02\r\rerr03 =\r\r    Value 03\r    Continued\r\r    .title = Title\r\rerr04 = { \"str\r\rerr05 = { $sel -> }\r"
+            "type": "ResourceComment",
+            "content": "This entire file uses CR as EOL.\r\rerr01 = Value 01\rerr02 = Value 02\r\rerr03 =\r\r    Value 03\r    Continued\r\r    .title = Title\r\rerr04 = { \"str\r\rerr05 = { $sel -> }\r"
         }
     ]
 }

--- a/fluent-syntax/test/fixtures_reference/escaped_characters.ftl
+++ b/fluent-syntax/test/fixtures_reference/escaped_characters.ftl
@@ -14,8 +14,20 @@ mismatched-quote = {"\\""}
 unknown-escape = {"\x"}
 
 ## Unicode escapes
-string-unicode-sequence = {"\u0041"}
-string-escaped-unicode = {"\\u0041"}
+string-unicode-4digits = {"\u0041"}
+escape-unicode-4digits = {"\\u0041"}
+string-unicode-6digits = {"\U01F602"}
+escape-unicode-6digits = {"\\U01F602"}
+
+# OK The trailing "00" is part of the literal value.
+string-too-many-4digits = {"\u004100"}
+# OK The trailing "00" is part of the literal value.
+string-too-many-6digits = {"\U01F60200"}
+
+# ERROR Too few hex digits after \u.
+string-too-few-4digits = {"\u41"}
+# ERROR Too few hex digits after \U.
+string-too-few-6digits = {"\U1F602"}
 
 ## Literal braces
 brace-open = An opening {"{"} brace.

--- a/fluent-syntax/test/fixtures_reference/escaped_characters.json
+++ b/fluent-syntax/test/fixtures_reference/escaped_characters.json
@@ -179,7 +179,7 @@
             "type": "Message",
             "id": {
                 "type": "Identifier",
-                "name": "string-unicode-sequence"
+                "name": "string-unicode-4digits"
             },
             "value": {
                 "type": "Pattern",
@@ -201,7 +201,7 @@
             "type": "Message",
             "id": {
                 "type": "Identifier",
-                "name": "string-escaped-unicode"
+                "name": "escape-unicode-4digits"
             },
             "value": {
                 "type": "Pattern",
@@ -218,6 +218,118 @@
             },
             "attributes": [],
             "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "string-unicode-6digits"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "StringLiteral",
+                            "raw": "\\U01F602",
+                            "value": "😂"
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "escape-unicode-6digits"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "StringLiteral",
+                            "raw": "\\\\U01F602",
+                            "value": "\\U01F602"
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "string-too-many-4digits"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "StringLiteral",
+                            "raw": "\\u004100",
+                            "value": "A00"
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "OK The trailing \"00\" is part of the literal value."
+            }
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "string-too-many-6digits"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "StringLiteral",
+                            "raw": "\\U01F60200",
+                            "value": "😂00"
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "OK The trailing \"00\" is part of the literal value."
+            }
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR Too few hex digits after \\u."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "string-too-few-4digits = {\"\\u41\"}\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR Too few hex digits after \\U."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "string-too-few-6digits = {\"\\U1F602\"}\n\n"
         },
         {
             "type": "GroupComment",

--- a/fluent-syntax/test/fixtures_reference/select_expressions.ftl
+++ b/fluent-syntax/test/fixtures_reference/select_expressions.ftl
@@ -39,7 +39,7 @@ nested-select =
        }
     }
 
-# ERROR VariantLists cannot appear in SelectExpressions
+# ERROR VariantLists cannot be Variant values.
 nested-variant-list =
     { 1 ->
        *[one] {

--- a/fluent-syntax/test/fixtures_reference/select_expressions.json
+++ b/fluent-syntax/test/fixtures_reference/select_expressions.json
@@ -274,7 +274,7 @@
         },
         {
             "type": "Comment",
-            "content": "ERROR VariantLists cannot appear in SelectExpressions"
+            "content": "ERROR VariantLists cannot be Variant values."
         },
         {
             "type": "Junk",

--- a/fluent-syntax/test/fixtures_reference/variant_lists.ftl
+++ b/fluent-syntax/test/fixtures_reference/variant_lists.ftl
@@ -23,6 +23,7 @@ variant-list-in-message-attr = Value
            *[key] Value
         }
 
+# ERROR VariantLists cannot be Variant values.
 -nested-variant-list-in-term =
     {
        *[one] {
@@ -37,7 +38,7 @@ variant-list-in-message-attr = Value
        }
     }
 
-# ERROR VariantLists may not appear in SelectExpressions
+# ERROR VariantLists cannot be Variant values.
 nested-select-then-variant-list =
     {
        *[one] { 2 ->

--- a/fluent-syntax/test/fixtures_reference/variant_lists.json
+++ b/fluent-syntax/test/fixtures_reference/variant_lists.json
@@ -94,48 +94,13 @@
             "content": "    .attr =\n        {\n           *[key] Value\n        }\n\n"
         },
         {
-            "type": "Term",
-            "id": {
-                "type": "Identifier",
-                "name": "nested-variant-list-in-term"
-            },
-            "value": {
-                "type": "VariantList",
-                "variants": [
-                    {
-                        "type": "Variant",
-                        "key": {
-                            "type": "Identifier",
-                            "name": "one"
-                        },
-                        "value": {
-                            "type": "VariantList",
-                            "variants": [
-                                {
-                                    "type": "Variant",
-                                    "key": {
-                                        "type": "Identifier",
-                                        "name": "two"
-                                    },
-                                    "value": {
-                                        "type": "Pattern",
-                                        "elements": [
-                                            {
-                                                "type": "TextElement",
-                                                "value": "Value"
-                                            }
-                                        ]
-                                    },
-                                    "default": true
-                                }
-                            ]
-                        },
-                        "default": true
-                    }
-                ]
-            },
-            "attributes": [],
-            "comment": null
+            "type": "Comment",
+            "content": "ERROR VariantLists cannot be Variant values."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "-nested-variant-list-in-term =\n    {\n       *[one] {\n          *[two] Value\n       }\n    }\n\n"
         },
         {
             "type": "Term",
@@ -195,7 +160,7 @@
         },
         {
             "type": "Comment",
-            "content": "ERROR VariantLists may not appear in SelectExpressions"
+            "content": "ERROR VariantLists cannot be Variant values."
         },
         {
             "type": "Junk",

--- a/fluent/test/fixtures_reference/escaped_characters.json
+++ b/fluent/test/fixtures_reference/escaped_characters.json
@@ -18,11 +18,23 @@
     "backslash-in-string": [
         "\\"
     ],
-    "string-unicode-sequence": [
+    "string-unicode-4digits": [
         "A"
     ],
-    "string-escaped-unicode": [
+    "escape-unicode-4digits": [
         "\\u0041"
+    ],
+    "string-unicode-6digits": [
+        "😂"
+    ],
+    "escape-unicode-6digits": [
+        "\\U01F602"
+    ],
+    "string-too-many-4digits": [
+        "A00"
+    ],
+    "string-too-many-6digits": [
+        "😂00"
     ],
     "brace-open": [
         "An opening ",


### PR DESCRIPTION
Implement part 7 of #303.

- [x] 13.  Recognize \UHHHHHH as an escape sequence
    https://github.com/projectfluent/fluent/pull/201, tooling parser, runtime parser
- [x] 14. Change line endings in comments to line_end
    https://github.com/projectfluent/fluent/pull/219, tooling parser
- [x] 15. Forbid nested VariantLists
    https://github.com/projectfluent/fluent/pull/220, tooling parser