### PR TITLE
Refactor getInlineExpression

### DIFF
--- a/fluent-syntax/src/errors.js
+++ b/fluent-syntax/src/errors.js
@@ -74,6 +74,8 @@ function getErrorMessage(code, args) {
     }
     case "E0027":
       return "Unbalanced closing brace in TextElement.";
+    case "E0028":
+      return "Expected an inline expression";
     default:
       return code;
   }

--- a/fluent-syntax/test/fixtures_behavior/call_expression_with_bad_id.ftl
+++ b/fluent-syntax/test/fixtures_behavior/call_expression_with_bad_id.ftl
@@ -1,3 +1,3 @@
 key = { no-caps-name() }
 
-# ~ERROR E0008, pos 21
+# ~ERROR E0008, pos 20

--- a/fluent-syntax/test/fixtures_behavior/call_expression_with_wrong_value_type.ftl
+++ b/fluent-syntax/test/fixtures_behavior/call_expression_with_wrong_value_type.ftl
@@ -1,2 +1,2 @@
 key = { BUILTIN(key: foo) }
-# ~ERROR E0012, pos 21
+# ~ERROR E0014, pos 21

--- a/fluent-syntax/test/fixtures_behavior/unclosed_empty_placeable_error.ftl
+++ b/fluent-syntax/test/fixtures_behavior/unclosed_empty_placeable_error.ftl
@@ -1,5 +1,5 @@
 # ~ERROR E0003, pos 8, args "}"
 foo = {
 bar = Bar
-# ~ERROR E0014, pos 26
+# ~ERROR E0028, pos 26
 baz = {

--- a/fluent-syntax/test/fixtures_behavior/variant_expression_as_placeable.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_expression_as_placeable.ftl
@@ -1,3 +1,3 @@
-# ~ERROR E0024, pos 18
+# ~ERROR E0003, pos 17, args "}"
 key01 = { message[variant] }
 key02 = { -term[variant] }

--- a/fluent-syntax/test/fixtures_behavior/variant_expression_as_selector.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_expression_as_selector.ftl
@@ -3,7 +3,7 @@ err1 =
        *[1] One
         [2] Two
     }
-# ~ERROR E0024, pos 17
+# ~ERROR E0003, pos 16, args "}"
 
 err2 =
     { -foo[bar] ->

--- a/fluent-syntax/test/fixtures_behavior/variant_lists.ftl
+++ b/fluent-syntax/test/fixtures_behavior/variant_lists.ftl
@@ -1,10 +1,10 @@
-# ~ERROR E0014, pos 25
+# ~ERROR E0028, pos 25
 message1 =
     {
         *[one] One
     }
 
-# ~ERROR E0014, pos 97
+# ~ERROR E0028, pos 97
 message2 =
     { $sel ->
         *[one] {
@@ -17,7 +17,7 @@ message2 =
         *[one] One
     }
 
-# ~ERROR E0014, pos 211
+# ~ERROR E0028, pos 211
 -term2 =
     {
         *[one] {
@@ -25,7 +25,7 @@ message2 =
          }
     }
 
-# ~ERROR E0014, pos 292
+# ~ERROR E0028, pos 292
 -term3 =
     { $sel ->
         *[one] {

--- a/fluent-syntax/test/fixtures_structure/junk.json
+++ b/fluent-syntax/test/fixtures_structure/junk.json
@@ -212,9 +212,9 @@
       "annotations": [
         {
           "type": "Annotation",
-          "code": "E0014",
+          "code": "E0028",
           "args": [],
-          "message": "Expected literal",
+          "message": "Expected an inline expression",
           "span": {
             "type": "Span",
             "start": 153,


### PR DESCRIPTION
Fix #315 (to an extent). I didn't want to add spans manually, so I still kept `getSimpleExpression` as a separate method. (_Simple_ as opposed to _member_ expression; I'm open to other naming.) I think that once we implement https://github.com/projectfluent/fluent/pull/221, we'll be able to simplify this further.

I'll clean up the commit messages before landing.