### PR TITLE
Remove unecessary hasDefault assignment

### DIFF
--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -320,7 +320,6 @@ export default class FluentParser {
       }
       ps.next();
       defaultIndex = true;
-      hasDefault = true;
     }
 
     ps.expectChar("[");


### PR DESCRIPTION
Fix #324. I left the `hasDefault` check inside of `getVariant` to keep the error position at the unexpected `*`. The alternative would be to check it in `getVariants` after the `const variant = this.getVariant(ps)` line, but that would place the error at the end of the buggy variant.