### PR TITLE
Added option to FluentBundle to allow overriding messages and terms with a new value

### DIFF
--- a/fluent/src/bundle.js
+++ b/fluent/src/bundle.js
@@ -47,7 +47,7 @@ export default class FluentBundle {
    *   - `allowOverrides` - boolean specifying whether it's allowed to override
    *                      an existing message or term with a new value.
    *                      Default: false
-   * 
+   *
    *   - `transform` - a function used to transform string parts of patterns.
    *
    * @param   {string|Array<string>} locales - Locale or locales of the bundle
@@ -151,13 +151,13 @@ export default class FluentBundle {
       if (id.startsWith("-")) {
         // Identifiers starting with a dash (-) define terms. Terms are private
         // and cannot be retrieved from FluentBundle.
-        if (this._allowOverrides == false && this._terms.has(id)) {
+        if (this._allowOverrides === false && this._terms.has(id)) {
           errors.push(`Attempt to override an existing term: "${id}"`);
           continue;
         }
         this._terms.set(id, value);
       } else {
-        if (this._allowOverrides == false && this._messages.has(id)) {
+        if (this._allowOverrides === false && this._messages.has(id)) {
           errors.push(`Attempt to override an existing message: "${id}"`);
           continue;
         }

--- a/fluent/src/bundle.js
+++ b/fluent/src/bundle.js
@@ -109,8 +109,8 @@ export default class FluentBundle {
    *
    *     // Returns a raw representation of the 'foo' message.
    *
-   *     bundle.addMessages('bar = Bar', { allowOverrides: true });
-   *     bundle.addMessages('bar = Newbar');
+   *     bundle.addMessages('bar = Bar');
+   *     bundle.addMessages('bar = Newbar', { allowOverrides: true });
    *     bundle.getMessage('bar');
    *
    *     // Returns a raw representation of the 'bar' message: Newbar.
@@ -146,9 +146,9 @@ export default class FluentBundle {
    *     // Returns a raw representation of the 'foo' message.
    *
    *     let res = FluentResource.fromString("bar = Bar");
-   *     bundle.addResource(res, { allowOverrides: true });
-   *     res = FluentResource.fromString("bar = Newbar");
    *     bundle.addResource(res);
+   *     res = FluentResource.fromString("bar = Newbar");
+   *     bundle.addResource(res, { allowOverrides: true });
    *     bundle.getMessage('bar');
    *
    *     // Returns a raw representation of the 'bar' message: Newbar.

--- a/fluent/src/bundle.js
+++ b/fluent/src/bundle.js
@@ -42,7 +42,12 @@ export default class FluentBundle {
    *
    *   - `useIsolating` - boolean specifying whether to use Unicode isolation
    *                    marks (FSI, PDI) for bidi interpolations.
+   *                    Default: true
    *
+   *   - `allowOverrides` - boolean specifying whether it's allowed to override
+   *                      an existing message or term with a new value.
+   *                      Default: false
+   * 
    *   - `transform` - a function used to transform string parts of patterns.
    *
    * @param   {string|Array<string>} locales - Locale or locales of the bundle
@@ -52,6 +57,7 @@ export default class FluentBundle {
   constructor(locales, {
     functions = {},
     useIsolating = true,
+    allowOverrides = false,
     transform = v => v
   } = {}) {
     this.locales = Array.isArray(locales) ? locales : [locales];
@@ -60,6 +66,7 @@ export default class FluentBundle {
     this._messages = new Map();
     this._functions = functions;
     this._useIsolating = useIsolating;
+    this._allowOverrides = allowOverrides;
     this._transform = transform;
     this._intls = new WeakMap();
   }
@@ -144,13 +151,13 @@ export default class FluentBundle {
       if (id.startsWith("-")) {
         // Identifiers starting with a dash (-) define terms. Terms are private
         // and cannot be retrieved from FluentBundle.
-        if (this._terms.has(id)) {
+        if (this._allowOverrides == false && this._terms.has(id)) {
           errors.push(`Attempt to override an existing term: "${id}"`);
           continue;
         }
         this._terms.set(id, value);
       } else {
-        if (this._messages.has(id)) {
+        if (this._allowOverrides == false && this._messages.has(id)) {
           errors.push(`Attempt to override an existing message: "${id}"`);
           continue;
         }

--- a/fluent/src/bundle.js
+++ b/fluent/src/bundle.js
@@ -114,7 +114,7 @@ export default class FluentBundle {
    *     bundle.getMessage('bar');
    *
    *     // Returns a raw representation of the 'bar' message: Newbar.
-   * 
+   *
    * Parsed entities should be formatted with the `format` method in case they
    * contain logic (references, select expressions etc.).
    *
@@ -128,8 +128,7 @@ export default class FluentBundle {
    * @param   {Object} [options]
    * @returns {Array<Error>}
    */
-  addMessages(source, options = {}) {
-    const { allowOverrides = false } = options;
+  addMessages(source, options) {
     const res = FluentResource.fromString(source);
     return this.addResource(res, options);
   }

--- a/fluent/test/context_test.js
+++ b/fluent/test/context_test.js
@@ -109,11 +109,11 @@ suite('Bundle', function() {
     suiteSetup(function() {
       bundle = new FluentBundle('en-US', { useIsolating: false });
       let resource1 = FluentResource.fromString('key = Foo');
-      let resource2 = FluentResource.fromString('key = Bar');
       bundle.addResource(resource1);
     });
 
     test('addResource allowOverrides is false', function() {
+      let resource2 = FluentResource.fromString('key = Bar');
       let errors = bundle.addResource(resource2);
       assert.equal(errors.length, 1);
       let msg = bundle.getMessage('key');
@@ -121,6 +121,7 @@ suite('Bundle', function() {
     });
 
     test('addResource allowOverrides is true', function() {
+      let resource2 = FluentResource.fromString('key = Bar');
       let errors = bundle.addResource(resource2, { allowOverrides: true });
       assert.equal(errors.length, 0);
       let msg = bundle.getMessage('key');

--- a/fluent/test/context_test.js
+++ b/fluent/test/context_test.js
@@ -69,6 +69,22 @@ suite('Bundle', function() {
       assert.equal(val, 'Foo');
       assert.equal(errs.length, 0);
     });
+
+    test('overwrites existing messages if the ids are the same and allowOverrides is true', function() {
+      const errors = bundle.addMessages(ftl`
+        foo = New Foo
+      `, { allowOverrides: true });
+
+      // No overwrite errors reported
+      assert.equal(errors.length, 0);
+
+      assert.equal(bundle._messages.size, 2);
+
+      const msg = bundle.getMessage('foo');
+      const val = bundle.format(msg, args, errs);
+      assert.equal(val, 'New Foo');
+      assert.equal(errs.length, 0);
+    });
   });
 
   suite('addResource', function(){
@@ -86,6 +102,29 @@ suite('Bundle', function() {
       assert.equal(bundle._terms.has('foo'), false);
       assert.equal(bundle._messages.has('-bar'), false);
       assert.equal(bundle._terms.has('-bar'), true);
+    });
+  });
+
+  suite('allowOverrides', function(){
+    suiteSetup(function() {
+      bundle = new FluentBundle('en-US', { useIsolating: false });
+      let resource1 = FluentResource.fromString('key = Foo');
+      let resource2 = FluentResource.fromString('key = Bar');
+      bundle.addResource(resource1);
+    });
+
+    test('addResource allowOverrides is false', function() {
+      let errors = bundle.addResource(resource2);
+      assert.equal(errors.length, 1);
+      let msg = bundle.getMessage('key');
+      assert.equal(bundle.format(msg), 'Foo');
+    });
+
+    test('addResource allowOverrides is true', function() {
+      let errors = bundle.addResource(resource2, { allowOverrides: true });
+      assert.equal(errors.length, 0);
+      let msg = bundle.getMessage('key');
+      assert.equal(bundle.format(msg), 'Bar');
     });
   });
 


### PR DESCRIPTION
By allowing overrides I can dynamically load new messages when needed.