### PR TITLE
Travis: drop sudo:false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 script: make deps && make dist
 node_js: "8.9"


### PR DESCRIPTION
This PR removes the `sudo: false` directive, which is now unused.