### PR TITLE
Fix stas feedback on perf tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prettyjson": "^1.2.1",
     "rollup": "^0.59.1",
     "rollup-plugin-babel": "^4.0.0-beta.4",
-    "rollup-plugin-node-resolve": "^3.0.3"
+    "rollup-plugin-node-resolve": "^3.0.3",
+    "intl-pluralrules": "^1.0.0"
   }
 }

--- a/tools/perf/benchmark.common.js
+++ b/tools/perf/benchmark.common.js
@@ -1,8 +1,8 @@
 function runTest(env) {
   const results = {};
   const testData = JSON.parse(env.readFile("./fixtures/benchmarks.json"));
-  const {args, functions} = testData[env.sampleName];
-  const ftlCode = env.readFile(`./fixtures/${env.sampleName}.ftl`);
+  const {args, functions} = testData[env.benchmarkName];
+  const ftlCode = env.readFile(`./fixtures/${env.benchmarkName}.ftl`);
 
   {
     const testName = "parse-syntax";
@@ -14,7 +14,7 @@ function runTest(env) {
       throw Error("Junk in syntax parser result!");
     }
 
-    results[`${testName}/"${env.sampleName}"`] = env.ms(end) - env.ms(start);
+    results[`${testName}/${env.benchmarkName}`] = env.ms(end) - env.ms(start);
   }
 
   let resource;
@@ -28,7 +28,7 @@ function runTest(env) {
     // we'll rely on the syntax parser to verify that
     // the sample test syntax is correct.
 
-    results[`${testName}/"${env.sampleName}"`] = env.ms(end) - env.ms(start);
+    results[`${testName}/${env.benchmarkName}`] = env.ms(end) - env.ms(start);
   }
 
   {
@@ -58,7 +58,7 @@ function runTest(env) {
       throw new Error(`Errors accumulated while resolving ${name}.`);
     }
 
-    results[`${testName}/"${env.sampleName}"`] = env.ms(end) - env.ms(start);
+    results[`${testName}/${env.benchmarkName}`] = env.ms(end) - env.ms(start);
   }
 
   return results;

--- a/tools/perf/benchmark.common.js
+++ b/tools/perf/benchmark.common.js
@@ -1,19 +1,8 @@
-
-function runTests(env) {
-  const testData = JSON.parse(env.readFile("./fixtures/benchmarks.json"));
-
+function runTest(env) {
   const results = {};
-
-  for (let testName in testData) {
-    let test = testData[testName];
-    runTest(env, testName, test.args, test.functions, results);
-  }
-
-  return results;
-}
-
-function runTest(env, name, args, fncs, results) {
-  const ftlCode = env.readFile(`./fixtures/${name}.ftl`);
+  const testData = JSON.parse(env.readFile("./fixtures/benchmarks.json"));
+  const {args, functions} = testData[env.sampleName];
+  const ftlCode = env.readFile(`./fixtures/${env.sampleName}.ftl`);
 
   {
     const testName = "parse-syntax";
@@ -25,7 +14,7 @@ function runTest(env, name, args, fncs, results) {
       throw Error("Junk in syntax parser result!");
     }
 
-    results[`${testName}/"${name}"`] = env.ms(end) - env.ms(start);
+    results[`${testName}/"${env.sampleName}"`] = env.ms(end) - env.ms(start);
   }
 
   let resource;
@@ -39,18 +28,18 @@ function runTest(env, name, args, fncs, results) {
     // we'll rely on the syntax parser to verify that
     // the sample test syntax is correct.
 
-    results[`${testName}/"${name}"`] = env.ms(end) - env.ms(start);
+    results[`${testName}/"${env.sampleName}"`] = env.ms(end) - env.ms(start);
   }
 
   {
     const testName = "resolve-runtime";
-    const functions = {};
-    for (let fnName in fncs) {
-      let body = fncs[fnName];
-      functions[fnName] = new Function(body);
+    const fncs = {};
+    for (let fnName in functions) {
+      let body = functions[fnName];
+      fncs[fnName] = new Function(body);
     }
     const bundle = new env.Fluent.FluentBundle('en-US', {
-      functions
+      functions: fncs
     });
     const errors = bundle.addResource(resource);
 
@@ -69,11 +58,12 @@ function runTest(env, name, args, fncs, results) {
       throw new Error(`Errors accumulated while resolving ${name}.`);
     }
 
-    results[`${testName}/"${name}"`] = env.ms(end) - env.ms(start);
+    results[`${testName}/"${env.sampleName}"`] = env.ms(end) - env.ms(start);
   }
+
+  return results;
 }
 
 if (typeof exports !== "undefined") {
   exports.runTest = runTest;
-  exports.runTests = runTests;
 }

--- a/tools/perf/benchmark.d8.js
+++ b/tools/perf/benchmark.d8.js
@@ -9,11 +9,12 @@ const env = {
   ms: (milliseconds) => {
     return milliseconds;
   },
+  sampleName: arguments[0],
   now: Date.now,
   FluentSyntax,
   Fluent,
 };
 
-const results = runTests(env);
+const results = runTest(env);
 
 print(JSON.stringify(results));

--- a/tools/perf/benchmark.d8.js
+++ b/tools/perf/benchmark.d8.js
@@ -9,7 +9,7 @@ const env = {
   ms: (milliseconds) => {
     return milliseconds;
   },
-  sampleName: arguments[0],
+  benchmarkName: arguments[0],
   now: Date.now,
   FluentSyntax,
   Fluent,

--- a/tools/perf/benchmark.jsshell.js
+++ b/tools/perf/benchmark.jsshell.js
@@ -9,7 +9,7 @@ const env = {
   ms: (milliseconds) => {
     return milliseconds;
   },
-  sampleName: scriptArgs[0],
+  benchmarkName: scriptArgs[0],
   now: performance.now,
   FluentSyntax,
   Fluent,

--- a/tools/perf/benchmark.jsshell.js
+++ b/tools/perf/benchmark.jsshell.js
@@ -9,11 +9,12 @@ const env = {
   ms: (milliseconds) => {
     return milliseconds;
   },
+  sampleName: scriptArgs[0],
   now: performance.now,
   FluentSyntax,
   Fluent,
 };
 
-const results = runTests(env);
+const results = runTest(env);
 
 print(JSON.stringify(results));

--- a/tools/perf/benchmark.node.js
+++ b/tools/perf/benchmark.node.js
@@ -12,7 +12,7 @@ const env = {
   ms: ([seconds, nanoseconds]) => {
     return seconds * 1e3 + nanoseconds / 1e6;
   },
-  sampleName: process.argv[2],
+  benchmarkName: process.argv[2],
   now: process.hrtime,
   FluentSyntax,
   Fluent,

--- a/tools/perf/benchmark.node.js
+++ b/tools/perf/benchmark.node.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 
 const Fluent = require('../../fluent');
 const FluentSyntax = require('../../fluent-syntax');
-const { runTest, runTests } = require('./benchmark.common');
+const { runTest } = require('./benchmark.common');
+require('intl-pluralrules');
 
 const env = {
   readFile: (path) => {
@@ -11,11 +12,12 @@ const env = {
   ms: ([seconds, nanoseconds]) => {
     return seconds * 1e3 + nanoseconds / 1e6;
   },
+  sampleName: process.argv[2],
   now: process.hrtime,
   FluentSyntax,
   Fluent,
 };
 
-const results = runTests(env);
+const results = runTest(env);
 
 console.log(JSON.stringify(results));

--- a/tools/perf/test.js
+++ b/tools/perf/test.js
@@ -14,7 +14,7 @@ program
   .usage('[options] [command]')
   .option('-e, --engine <string>', 'Engine to test: node, jsshell, d8 [node]',
           'node')
-  .option('-s, --sampleSize <int>', 'Sample size [30]', 30)
+  .option('-s, --sample <int>', 'Sample size [30]', 30)
   .option('-p, --progress', 'Show progress')
   .option('-n, --no-color', 'Print without color')
   .option('-r, --raw', 'Print raw JSON')
@@ -47,25 +47,25 @@ function color(str, col) {
   return str;
 }
 
-runAll(parseInt(program.sampleSize)).then(printResults);
+runAll(parseInt(program.sample)).then(printResults);
 
-async function runAll(sampleSize) {
+async function runAll(sample) {
   const results = {};
 
   const testData = JSON.parse(fs.readFileSync(`${__dirname}/fixtures/benchmarks.json`).toString());
-  for (let sampleName in testData) {
+  for (let benchmarkName in testData) {
     if (!program.raw && program.progress) {
-      process.stdout.write(color(`\n${sampleName}: `, INDICATOR));
+      process.stdout.write(color(`\n${benchmarkName}: `, INDICATOR));
     }
-    await runSample(sampleName, sampleSize, results);
+    await runBenchmark(benchmarkName, sample, results);
   }
   return results;
 }
 
-function runSample(sampleName, sampleSize, results) {
+function runBenchmark(benchmarkName, sample, results) {
   return new Promise((resolve, reject) => {
     const times = {};
-    const execCommand = `${command} ${sampleName}`;
+    const execCommand = `${command} ${benchmarkName}`;
     // run is recursive and thus sequential so that node doesn't spawn all the
     // processes at once
     run();
@@ -85,7 +85,7 @@ function runSample(sampleName, sampleSize, results) {
           }
           times[scenario].push(data[scenario]);
         }
-        if (times[scenario].length !== sampleSize) {
+        if (times[scenario].length !== sample) {
           run();
         } else {
           for (scenario in times) {
@@ -93,7 +93,7 @@ function runSample(sampleName, sampleSize, results) {
             results[scenario] = {
               mean: mean,
               stdev: util.stdev(times[scenario], mean),
-              sampleSize: sampleSize
+              sample: sample
             };
           }
           resolve(results);


### PR DESCRIPTION
Stas identified two problems with my last change:

1) lack of `intl-pluralrules` broke testing on node v8/v9
2) all samples were run in a single instance which caused JIT to kick in

I reorganized test.js a bit to separate out each test sample to be called separately, and verified that reordering samples (or tests) does not impact the result.