### PR TITLE
Print braces around missing references

### DIFF
--- a/fluent/src/builtins.js
+++ b/fluent/src/builtins.js
@@ -11,14 +11,7 @@
  * `FluentType`.  Functions must return `FluentType` objects as well.
  */
 
-import { FluentNumber, FluentDateTime } from "./types.js";
-
-export default {
-  "NUMBER": ([arg], opts) =>
-    new FluentNumber(arg.valueOf(), merge(arg.opts, opts)),
-  "DATETIME": ([arg], opts) =>
-    new FluentDateTime(arg.valueOf(), merge(arg.opts, opts)),
-};
+import { FluentNone, FluentNumber, FluentDateTime } from "./types.js";
 
 function merge(argopts, opts) {
   return Object.assign({}, argopts, values(opts));
@@ -30,4 +23,26 @@ function values(opts) {
     unwrapped[name] = opt.valueOf();
   }
   return unwrapped;
+}
+
+export
+function NUMBER([arg], opts) {
+  if (arg instanceof FluentNone) {
+    return arg;
+  }
+  if (arg instanceof FluentNumber) {
+    return new FluentNumber(arg.valueOf(), merge(arg.opts, opts));
+  }
+  return new FluentNone("NUMBER()");
+}
+
+export
+function DATETIME([arg], opts) {
+  if (arg instanceof FluentNone) {
+    return arg;
+  }
+  if (arg instanceof FluentDateTime) {
+    return new FluentDateTime(arg.valueOf(), merge(arg.opts, opts));
+  }
+  return new FluentNone("DATETIME()");
 }

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -37,7 +37,7 @@
 
 import { FluentType, FluentNone, FluentNumber, FluentDateTime }
   from "./types.js";
-import builtins from "./builtins.js";
+import * as builtins from "./builtins.js";
 
 // Prevent expansion of too long placeables.
 const MAX_PLACEABLE_LENGTH = 2500;

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -45,8 +45,12 @@ export class FluentType {
 }
 
 export class FluentNone extends FluentType {
+  valueOf() {
+    return null;
+  }
+
   toString() {
-    return this.value || "???";
+    return `{${this.value || "???"}}`;
   }
 }
 

--- a/fluent/test/arguments_test.js
+++ b/fluent/test/arguments_test.js
@@ -101,49 +101,49 @@ suite('Variables', function() {
     test('falls back to argument\'s name if it\'s missing', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, '$arg');
+      assert.equal(val, '{$arg}');
       assert(errs[0] instanceof ReferenceError); // unknown variable
     });
 
     test('cannot be arrays', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: [1, 2, 3] }, errs);
-      assert.equal(val, '$arg');
+      assert.equal(val, '{$arg}');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be a dict-like object', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: { prop: 1 } }, errs);
-      assert.equal(val, '$arg');
+      assert.equal(val, '{$arg}');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be a boolean', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: true }, errs);
-      assert.equal(val, '$arg');
+      assert.equal(val, '{$arg}');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be undefined', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: undefined }, errs);
-      assert.equal(val, '$arg');
+      assert.equal(val, '{$arg}');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be null', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: null }, errs);
-      assert.equal(val, '$arg');
+      assert.equal(val, '{$arg}');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
 
     test('cannot be a function', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, { arg: () => null }, errs);
-      assert.equal(val, '$arg');
+      assert.equal(val, '{$arg}');
       assert(errs[0] instanceof TypeError); // unsupported variable type
     });
   });

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -22,13 +22,13 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('num-decimal');
-      assert.equal(bundle.format(msg), 'NaN');
+      assert.equal(bundle.format(msg), '{$arg}');
 
       msg = bundle.getMessage('num-percent');
-      assert.equal(bundle.format(msg), 'NaN');
+      assert.equal(bundle.format(msg), '{$arg}');
 
       msg = bundle.getMessage('num-bad-opt');
-      assert.equal(bundle.format(msg), 'NaN');
+      assert.equal(bundle.format(msg), '{$arg}');
     });
 
     test('number argument', function() {
@@ -50,13 +50,42 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('num-decimal');
-      assert.equal(bundle.format(msg, args), 'NaN');
+      assert.equal(bundle.format(msg, args), '{NUMBER()}');
 
       msg = bundle.getMessage('num-percent');
-      assert.equal(bundle.format(msg, args), 'NaN');
+      assert.equal(bundle.format(msg, args), '{NUMBER()}');
 
       msg = bundle.getMessage('num-bad-opt');
-      assert.equal(bundle.format(msg, args), 'NaN');
+      assert.equal(bundle.format(msg, args), '{NUMBER()}');
+    });
+
+    test('date argument', function() {
+      const date = new Date('2016-09-29');
+      const args = {arg: date};
+      let msg;
+
+      msg = bundle.getMessage('num-decimal');
+      assert.equal(bundle.format(msg, args), '{NUMBER()}');
+
+      msg = bundle.getMessage('num-percent');
+      assert.equal(bundle.format(msg, args), '{NUMBER()}');
+
+      msg = bundle.getMessage('num-bad-opt');
+      assert.equal(bundle.format(msg, args), '{NUMBER()}');
+    });
+
+    test('invalid argument', function() {
+      const args = {arg: []};
+      let msg;
+
+      msg = bundle.getMessage('num-decimal');
+      assert.equal(bundle.format(msg, args), '{$arg}');
+
+      msg = bundle.getMessage('num-percent');
+      assert.equal(bundle.format(msg, args), '{$arg}');
+
+      msg = bundle.getMessage('num-bad-opt');
+      assert.equal(bundle.format(msg, args), '{$arg}');
     });
   });
 
@@ -74,13 +103,13 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('dt-default');
-      assert.equal(bundle.format(msg), 'Invalid Date');
+      assert.equal(bundle.format(msg), '{$arg}');
 
       msg = bundle.getMessage('dt-month');
-      assert.equal(bundle.format(msg), 'Invalid Date');
+      assert.equal(bundle.format(msg), '{$arg}');
 
       msg = bundle.getMessage('dt-bad-opt');
-      assert.equal(bundle.format(msg), 'Invalid Date');
+      assert.equal(bundle.format(msg), '{$arg}');
     });
 
     test('Date argument', function () {
@@ -106,6 +135,48 @@ suite('Built-in functions', function() {
       // may vary depending on the TZ:
       //     Thu Sep 29 2016 02:00:00 GMT+0200 (CEST)
       assert.equal(bundle.format(msg, args), date.toString());
+    });
+
+    test('number argument', function() {
+      let args = {arg: 1};
+      let msg;
+
+      msg = bundle.getMessage('dt-default');
+      assert.equal(bundle.format(msg, args), '{DATETIME()}');
+
+      msg = bundle.getMessage('dt-month');
+      assert.equal(bundle.format(msg, args), '{DATETIME()}');
+
+      msg = bundle.getMessage('dt-bad-opt');
+      assert.equal(bundle.format(msg, args), '{DATETIME()}');
+    });
+
+    test('string argument', function() {
+      let args = {arg: 'Foo'};
+      let msg;
+
+      msg = bundle.getMessage('dt-default');
+      assert.equal(bundle.format(msg, args), '{DATETIME()}');
+
+      msg = bundle.getMessage('dt-month');
+      assert.equal(bundle.format(msg, args), '{DATETIME()}');
+
+      msg = bundle.getMessage('dt-bad-opt');
+      assert.equal(bundle.format(msg, args), '{DATETIME()}');
+    });
+
+    test('invalid argument', function() {
+      let args = {arg: []};
+      let msg;
+
+      msg = bundle.getMessage('dt-default');
+      assert.equal(bundle.format(msg, args), '{$arg}');
+
+      msg = bundle.getMessage('dt-month');
+      assert.equal(bundle.format(msg, args), '{$arg}');
+
+      msg = bundle.getMessage('dt-bad-opt');
+      assert.equal(bundle.format(msg, args), '{$arg}');
     });
   });
 });

--- a/fluent/test/functions_test.js
+++ b/fluent/test/functions_test.js
@@ -23,7 +23,7 @@ suite('Functions', function() {
     test('falls back to the name of the function', function() {
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, args, errs);
-      assert.equal(val, 'MISSING()');
+      assert.equal(val, '{MISSING()}');
       assert.equal(errs.length, 1);
       assert(errs[0] instanceof ReferenceError); // unknown function
     });

--- a/fluent/test/macros_test.js
+++ b/fluent/test/macros_test.js
@@ -57,28 +57,28 @@ suite("Macros", function() {
     test("Not parameterized, no externals", function() {
       const msg = bundle.getMessage("ref-foo");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("Not parameterized but with externals", function() {
       const msg = bundle.getMessage("ref-foo");
       const val = bundle.format(msg, {arg: 1}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No arguments, no externals", function() {
       const msg = bundle.getMessage("call-foo-no-args");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No arguments, but with externals", function() {
       const msg = bundle.getMessage("call-foo-no-args");
       const val = bundle.format(msg, {arg: 1}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
@@ -99,14 +99,14 @@ suite("Macros", function() {
     test("With other args, no externals", function() {
       const msg = bundle.getMessage("call-foo-with-other-arg");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("With other args, and with externals", function() {
       const msg = bundle.getMessage("call-foo-with-other-arg");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
   });
@@ -128,28 +128,28 @@ suite("Macros", function() {
     test("No parameterization, no externals", function() {
       const msg = bundle.getMessage("ref-bar");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No parameterization, but with externals", function() {
       const msg = bundle.getMessage("ref-bar");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No arguments, no externals", function() {
       const msg = bundle.getMessage("call-bar");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No arguments, but with externals", function() {
       const msg = bundle.getMessage("call-bar");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
@@ -197,28 +197,28 @@ suite("Macros", function() {
     test("No parameterization, no parameterization, no externals", function() {
       const msg = bundle.getMessage("ref-bar");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No parameterization, no parameterization, with externals", function() {
       const msg = bundle.getMessage("ref-bar");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No parameterization, no arguments, no externals", function() {
       const msg = bundle.getMessage("ref-baz");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No parameterization, no arguments, with externals", function() {
       const msg = bundle.getMessage("ref-baz");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
@@ -239,28 +239,28 @@ suite("Macros", function() {
     test("No arguments, no parameterization, no externals", function() {
       const msg = bundle.getMessage("call-bar-no-args");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No arguments, no parameterization, with externals", function() {
       const msg = bundle.getMessage("call-bar-no-args");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No arguments, no arguments, no externals", function() {
       const msg = bundle.getMessage("call-baz-no-args");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("No arguments, no arguments, with externals", function() {
       const msg = bundle.getMessage("call-baz-no-args");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
@@ -281,28 +281,28 @@ suite("Macros", function() {
     test("With arguments, no parameterization, no externals", function() {
       const msg = bundle.getMessage("call-bar-with-arg");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("With arguments, no parameterization, with externals", function() {
       const msg = bundle.getMessage("call-bar-with-arg");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("With arguments, no arguments, no externals", function() {
       const msg = bundle.getMessage("call-baz-with-arg");
       const val = bundle.format(msg, {}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 
     test("With arguments, no arguments, with externals", function() {
       const msg = bundle.getMessage("call-baz-with-arg");
       const val = bundle.format(msg, {arg: 5}, errs);
-      assert.equal(val, "Foo $arg");
+      assert.equal(val, "Foo {$arg}");
       assert.equal(errs.length, 0);
     });
 

--- a/fluent/test/patterns_test.js
+++ b/fluent/test/patterns_test.js
@@ -62,14 +62,14 @@ suite('Patterns', function(){
     test('returns the id if a message reference is missing', function(){
       const msg = bundle.getMessage('ref-missing-message');
       const val = bundle.format(msg, args, errs);
-      assert.strictEqual(val, 'missing');
+      assert.strictEqual(val, '{missing}');
       assert.ok(errs[0] instanceof ReferenceError); // unknown message
     });
 
     test('returns the id if a term reference is missing', function(){
       const msg = bundle.getMessage('ref-missing-term');
       const val = bundle.format(msg, args, errs);
-      assert.strictEqual(val, '-missing');
+      assert.strictEqual(val, '{-missing}');
       assert.ok(errs[0] instanceof ReferenceError); // unknown message
     });
   });
@@ -102,7 +102,7 @@ suite('Patterns', function(){
        function(){
       const msg = bundle.getMessage('bar');
       const val = bundle.format(msg, args, errs);
-      assert.strictEqual(val, '??? Bar');
+      assert.strictEqual(val, '{???} Bar');
       assert.ok(errs[0] instanceof RangeError); // no default
     });
   });
@@ -119,7 +119,7 @@ suite('Patterns', function(){
     test('returns ???', function(){
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, args, errs);
-      assert.strictEqual(val, '???');
+      assert.strictEqual(val, '{???}');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
     });
   });
@@ -135,7 +135,7 @@ suite('Patterns', function(){
     test('returns the raw string', function(){
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, args, errs);
-      assert.strictEqual(val, '???');
+      assert.strictEqual(val, '{???}');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
     });
   });
@@ -156,7 +156,7 @@ suite('Patterns', function(){
     test('returns ???', function(){
       const msg = bundle.getMessage('foo');
       const val = bundle.format(msg, {sel: 'a'}, errs);
-      assert.strictEqual(val, '???');
+      assert.strictEqual(val, '{???}');
       assert.ok(errs[0] instanceof RangeError); // cyclic reference
     });
 

--- a/fluent/test/values_ref_test.js
+++ b/fluent/test/values_ref_test.js
@@ -77,7 +77,7 @@ suite('Referencing values', function(){
   test('uses ??? if there is no value', function(){
     const msg = bundle.getMessage('ref5');
     const val = bundle.format(msg, args, errs);
-    assert.strictEqual(val, '???');
+    assert.strictEqual(val, '{???}');
     assert.ok(errs[0] instanceof RangeError); // no default
   });
 


### PR DESCRIPTION
Fix #367.

This also fixes `NUMBER` and `DATETIME` to handle other types of arguments than numbers and dates, respectively. The fallback could be even better in those cases, but this PR is already an improvement, and I'd like to land it soon rather than wait for the spec to be ready.