### PR TITLE
Add the fluent-dedent package

### DIFF
--- a/fluent-dedent/.esdoc.json
+++ b/fluent-dedent/.esdoc.json
@@ -1,0 +1,16 @@
+{
+    "source": "./src",
+    "destination": "../html/dedent",
+    "plugins": [
+        {
+            "name": "esdoc-standard-plugin"
+        },
+        {
+            "name": "esdoc-ecmascript-proposal-plugin",
+            "option": {
+                "objectRestSpread": true,
+                "asyncGenerators": true
+            }
+        }
+    ]
+}

--- a/fluent-dedent/.gitignore
+++ b/fluent-dedent/.gitignore
@@ -1,0 +1,2 @@
+/index.js
+/compat.js

--- a/fluent-dedent/.npmignore
+++ b/fluent-dedent/.npmignore
@@ -1,0 +1,5 @@
+.nyc_output
+coverage
+docs
+test
+makefile

--- a/fluent-dedent/CHANGELOG.md
+++ b/fluent-dedent/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+This is the first release of `@fluent/dedent` as an independent package. It's
+based on the `ftl` template tag from the `fluent` package, but the behavior
+has changed and the code has been refactored.
+
+The behavior in this version is largely based on the [multiline strings
+specification in Swift][1]. See the `README.md` for more details.
+
+[1]: https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html

--- a/fluent-dedent/README.md
+++ b/fluent-dedent/README.md
@@ -1,0 +1,98 @@
+# @fluent/dedent
+
+`@fluent/dedent` provides a template literal tag to dedent Fluent code.
+Fluent Syntax is indentation-sensitive, and `@fluent/dedent` offers a
+convenient way to include Fluent snippets in source code keeping the current
+level of indentation and without compromising the readability.
+
+
+## Installation
+
+`@fluent/dedent` can be used both on the client-side and the server-side.  You can
+install it from the npm registry or use it as a standalone script (as the
+`FluentDedent` global).
+
+    npm install @fluent/dedent
+
+
+## How to use
+
+`@fluent/dedent`'s default export is meant to be used as a template literal
+tag. By convention, the tag is often called `ftl`.
+
+```javascript
+import ftl from "@fluent/dedent";
+
+let messages = ftl`
+    hello = Hello, world!
+    welcome = Welcome, {$userName}!
+    `;
+```
+
+The position of the closing backtick defines how much indent will be removed
+from each line of the content. If the indentation is not sufficient in any of
+the non-blank lines of the content, a `RangeError` is thrown.
+
+```javascript
+import ftl from "@fluent/dedent";
+
+let messages = ftl`
+    hello = Hello, world!
+  welcome = Welcome, {$userName}!
+    `;
+
+// → RangeError("Insufficient indentation in line 1.")
+```
+
+Content must start on a new line and must end on a line of its own. The
+closing delimiter must appear on a new line. The first and the last line of
+the input will be removed from the output. If any of them contains
+non-whitespace characters, a `RangeError` is thrown.
+
+```javascript
+import ftl from "@fluent/dedent";
+
+let message1 = "hello = Hello, world!";
+let message2 = ftl`
+    hello = Hello, world!
+    `;
+
+assert(message1 === message2);
+```
+
+If you wish to include the leading or trailing line breaks in the output, put
+extra blank lines in the input.
+
+```javascript
+import ftl from "@fluent/dedent";
+
+let message = ftl`
+
+    hello = Hello, world!
+
+    `;
+
+assert(message === "\nhello = Hello, world!\n");
+```
+
+
+## Compatibility
+
+For legacy browsers, the `compat` build has been transpiled using Babel's [env
+preset][].
+
+```javascript
+import ftl from '@fluent/dedent/compat';
+```
+
+
+## Learn more
+
+Find out more about Project Fluent at [projectfluent.org][], including
+documentation of the Fluent file format ([FTL][]), links to other packages and
+implementations, and information about how to get involved.
+
+
+[env preset]: https://babeljs.io/docs/plugins/preset-env/
+[projectfluent.org]: http://projectfluent.org
+[FTL]: http://projectfluent.org/fluent/guide/

--- a/fluent-dedent/README.md
+++ b/fluent-dedent/README.md
@@ -41,7 +41,7 @@ let messages = ftl`
   welcome = Welcome, {$userName}!
     `;
 
-// → RangeError("Insufficient indentation in line 1.")
+// → RangeError("Insufficient indentation in line 2.")
 ```
 
 Content must start on a new line and must end on a line of its own. The

--- a/fluent-dedent/makefile
+++ b/fluent-dedent/makefile
@@ -1,0 +1,29 @@
+PACKAGE := @fluent/dedent
+GLOBAL  := FluentDedent
+
+include ../common.mk
+
+build: index.js compat.js
+
+index.js: $(SOURCES)
+	@rollup $(CURDIR)/src/index.js \
+	    --config $(ROOT)/bundle_config.js \
+	    --banner "/* $(PACKAGE)@$(VERSION) */" \
+	    --amd.id $(PACKAGE) \
+	    --name $(GLOBAL) \
+	    --output.file $@
+	@echo -e " $(OK) $@ built"
+
+compat.js: $(SOURCES)
+	@rollup $(CURDIR)/src/index.js \
+	    --config $(ROOT)/compat_config.js \
+	    --banner "/* $(PACKAGE)@$(VERSION) */" \
+	    --amd.id $(PACKAGE) \
+	    --name $(GLOBAL) \
+	    --output.file $@
+	@echo -e " $(OK) $@ built"
+
+clean:
+	@rm -f $(PACKAGE).js compat.js
+	@rm -rf .nyc_output coverage
+	@echo -e " $(OK) clean"

--- a/fluent-dedent/package.json
+++ b/fluent-dedent/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@fluent/dedent",
+  "description": "A template literal tag for dedenting Fluent code",
+  "version": "0.1.0",
+  "homepage": "https://projectfluent.org",
+  "author": "Mozilla <l10n-drivers@mozilla.org>",
+  "license": "Apache-2.0",
+  "contributors": [
+    {
+      "name": "Staś Małolepszy",
+      "email": "stas@mozilla.com"
+    }
+  ],
+  "directories": {
+    "lib": "./src"
+  },
+  "main": "./index.js",
+  "module": "./src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/projectfluent/fluent.js.git"
+  },
+  "keywords": [
+    "localization",
+    "l10n",
+    "internationalization",
+    "i18n",
+    "ftl",
+    "plural",
+    "gender",
+    "locale",
+    "language",
+    "formatting",
+    "translate",
+    "translation",
+    "format",
+    "parser"
+  ],
+  "engines": {
+    "node": ">=8.9.0"
+  }
+}

--- a/fluent-dedent/package.json
+++ b/fluent-dedent/package.json
@@ -21,20 +21,9 @@
     "url": "https://github.com/projectfluent/fluent.js.git"
   },
   "keywords": [
-    "localization",
-    "l10n",
-    "internationalization",
-    "i18n",
-    "ftl",
-    "plural",
-    "gender",
-    "locale",
-    "language",
-    "formatting",
-    "translate",
-    "translation",
-    "format",
-    "parser"
+    "dedent",
+    "fluent",
+    "ftl"
   ],
   "engines": {
     "node": ">=8.9.0"

--- a/fluent-dedent/src/index.js
+++ b/fluent-dedent/src/index.js
@@ -35,7 +35,7 @@ export default function ftl(strings, ...values) {
     }
     if (lineIndent !== commonIndent) {
       // The indentation of the line must match commonIndent exacty.
-      throw new RangeError(`Insufficient indentation in line ${idx}.`);
+      throw new RangeError(`Insufficient indentation in line ${idx + 1}.`);
     }
     // Strip commonIndent.
     return line.slice(commonIndent.length);

--- a/fluent-dedent/src/index.js
+++ b/fluent-dedent/src/index.js
@@ -1,0 +1,36 @@
+// A blank line may contain spaces and tabs.
+const RE_BLANK = /^[ \t]*$/;
+
+/**
+ * Template literal tag for dedenting Fluent code.
+ *
+ * Strip the indent of the last line from each line of the input. Remove the
+ * first and the last line from the output. The snippet must start on a new
+ * line and it must end on a line of its own, with the closing delimiter on a
+ * next line.
+ *
+ * @param {Array<string>} strings
+ * @returns string
+ */
+export default function ftl(strings) {
+  let lines = strings[0].split("\n");
+  let [first, last] = [lines.shift(), lines.pop()];
+
+  if (!RE_BLANK.test(first)) {
+    throw new RangeError("Content must start on a new line.");
+  }
+  if (!RE_BLANK.test(last)) {
+    throw new RangeError("Closing delimiter must appear on a new line.");
+  }
+
+  let commonIndent = last.length;
+  function dedent(line, idx) {
+    let indent = line.slice(0, commonIndent);
+    if (!RE_BLANK.test(indent)) {
+      throw new RangeError(`Insufficient indentation in line ${idx}.`);
+    }
+    return line.slice(commonIndent);
+  }
+
+  return lines.map(dedent).join("\n");
+}

--- a/fluent-dedent/src/index.js
+++ b/fluent-dedent/src/index.js
@@ -10,10 +10,12 @@ const RE_BLANK = /^[ \t]*$/;
  * next line.
  *
  * @param {Array<string>} strings
+ * @param {...any} values
  * @returns string
  */
-export default function ftl(strings) {
-  let lines = strings[0].split("\n");
+export default function ftl(strings, ...values) {
+  let code = strings.reduce((acc, cur) => acc + values.shift() + cur);
+  let lines = code.split("\n");
   let [first, last] = [lines.shift(), lines.pop()];
 
   if (!RE_BLANK.test(first)) {

--- a/fluent-dedent/test/blank_test.js
+++ b/fluent-dedent/test/blank_test.js
@@ -34,4 +34,31 @@ suite("blank lines", function() {
       "foo\n"
     );
   });
+
+  test("containing the same amount of spaces as the common indent", function() {
+    assert.equal(
+      ftl`
+      
+      `,
+      ""
+    );
+  });
+
+  test("containing too few spaces", function() {
+    assert.throws(
+      () => ftl`
+  
+      `,
+      /Insufficient indentation in line 0/
+    );
+  });
+
+  test("containing too many spaces", function() {
+    assert.equal(
+      ftl`
+        
+      `,
+      "  "
+    );
+  });
 });

--- a/fluent-dedent/test/blank_test.js
+++ b/fluent-dedent/test/blank_test.js
@@ -49,7 +49,7 @@ suite("blank lines", function() {
       () => ftl`
   
       `,
-      /Insufficient indentation in line 0/
+      /Insufficient indentation in line 1/
     );
   });
 

--- a/fluent-dedent/test/blank_test.js
+++ b/fluent-dedent/test/blank_test.js
@@ -1,0 +1,37 @@
+"use strict";
+
+import assert from "assert";
+import ftl from "../src/index";
+
+suite("blank lines", function() {
+  test("leading", function() {
+    assert.equal(
+      ftl`
+
+        foo
+        `,
+      "\nfoo"
+    );
+  });
+
+  test("middle", function() {
+    assert.equal(
+      ftl`
+        foo
+
+        bar
+        `,
+      "foo\n\nbar"
+    );
+  });
+
+  test("trailing", function() {
+    assert.equal(
+      ftl`
+        foo
+
+        `,
+      "foo\n"
+    );
+  });
+});

--- a/fluent-dedent/test/content_test.js
+++ b/fluent-dedent/test/content_test.js
@@ -1,0 +1,56 @@
+"use strict";
+
+import assert from "assert";
+import ftl from "../src/index";
+
+suite("content lines", function() {
+  test("no indent", function () {
+    assert.equal(
+      ftl`
+foo
+bar
+`,
+      "foo\nbar"
+    );
+  });
+
+  test("zero indent", function () {
+    assert.equal(
+      ftl`
+        foo
+    bar
+`,
+      "        foo\n    bar"
+    );
+  });
+
+  test("small indent", function () {
+    assert.equal(
+      ftl`
+        foo
+    bar
+    `,
+      "    foo\nbar"
+    );
+  });
+
+  test("same indent", function () {
+    assert.equal(
+      ftl`
+        foo
+        bar
+        `,
+      "foo\nbar"
+    );
+  });
+
+  test("larger indent", function () {
+    assert.throws(
+      () => ftl`
+          foo
+        bar
+          `,
+      /Insufficient indentation in line 1/
+    );
+  });
+});

--- a/fluent-dedent/test/content_test.js
+++ b/fluent-dedent/test/content_test.js
@@ -50,7 +50,7 @@ bar
           foo
         bar
           `,
-      /Insufficient indentation in line 1/
+      /Insufficient indentation in line 2/
     );
   });
 });

--- a/fluent-dedent/test/eol_test.js
+++ b/fluent-dedent/test/eol_test.js
@@ -1,0 +1,38 @@
+"use strict";
+
+import assert from "assert";
+import ftl from "../src/index";
+
+suite("EOL at extremes", function () {
+  test("no EOLs", function () {
+    assert.throws(
+      () => ftl`foo`,
+      /Content must start on a new line/
+    );
+  });
+
+  test("EOL at the beginning", function () {
+    assert.throws(
+      () => ftl`
+      foo`,
+      /Closing delimiter must appear on a new line/
+    );
+  });
+
+  test("EOL at the end", function () {
+    assert.throws(
+      () => ftl`foo
+`,
+      /Content must start on a new line/
+    );
+  });
+
+  test("two EOLs", function () {
+    assert.equal(
+      ftl`
+      foo
+      `,
+      "foo"
+    );
+  });
+});

--- a/fluent-dedent/test/interpolation_test.js
+++ b/fluent-dedent/test/interpolation_test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+import assert from "assert";
+import ftl from "../src/index";
+
+suite("interpolation", function() {
+  test("single", function() {
+    assert.equal(
+      ftl`
+        foo ${"bar"}
+        `,
+      "foo bar"
+    );
+  });
+
+  test("multiple", function() {
+    assert.equal(
+      ftl`
+        foo ${"bar"}${"baz"}
+        `,
+      "foo barbaz"
+    );
+  });
+
+  test("on separate lines", function() {
+    assert.equal(
+      ftl`
+        ${"foo"}
+          ${"bar"}
+        ${"baz"}
+        `,
+      "foo\n  bar\nbaz"
+    );
+  });
+});

--- a/fluent-dedent/test/mixed_test.js
+++ b/fluent-dedent/test/mixed_test.js
@@ -27,7 +27,7 @@ suite("mixed indent", function() {
       () => ftl`
 \tfoo
 \t    `,
-      /Insufficient indentation in line 0/
+      /Insufficient indentation in line 1/
     );
   });
 });

--- a/fluent-dedent/test/mixed_test.js
+++ b/fluent-dedent/test/mixed_test.js
@@ -1,0 +1,33 @@
+"use strict";
+
+import assert from "assert";
+import ftl from "../src/index";
+
+suite("mixed indent", function() {
+  test("same amount", function() {
+    assert.equal(
+      ftl`
+\t    foo
+\t    `,
+      "foo"
+    );
+  });
+
+  test("larger than common", function() {
+    assert.equal(
+      ftl`
+\t        foo
+\t    `,
+      "    foo"
+    );
+  });
+
+  test("smaller than common", function() {
+    assert.throws(
+      () => ftl`
+\tfoo
+\t    `,
+      /Insufficient indentation in line 0/
+    );
+  });
+});

--- a/fluent-dedent/test/tabs_test.js
+++ b/fluent-dedent/test/tabs_test.js
@@ -1,0 +1,69 @@
+"use strict";
+
+import assert from "assert";
+import ftl from "../src/index";
+
+suite("tab indent", function() {
+  test("same amount", function() {
+    assert.equal(
+      ftl`
+\t\tfoo
+\t\t`,
+      "foo"
+    );
+  });
+
+  test("larger than common", function() {
+    assert.equal(
+      ftl`
+\t\t\tfoo
+\t\t`,
+      "\tfoo"
+    );
+  });
+
+  test("smaller than common", function() {
+    assert.throws(
+      () => ftl`
+\tfoo
+\t\t`,
+      /Insufficient indentation in line 0/
+    );
+  });
+
+  test("2 tabs vs. 8 spaces", function() {
+    assert.throws(
+      () => ftl`
+\t\tfoo
+        `,
+      /Insufficient indentation in line 0/
+    );
+  });
+
+  test("8 spaces vs. 2 tabs", function() {
+    assert.throws(
+      () => ftl`
+        foo
+\t\t`,
+      /Insufficient indentation in line 0/
+    );
+  });
+
+  test("2 tabs vs. 2 spaces", function() {
+    assert.throws(
+      () => ftl`
+\t\tfoo
+  `,
+      /Insufficient indentation in line 0/
+    );
+  });
+
+  test("2 spaces vs. 2 tabs", function() {
+    assert.throws(
+      () => ftl`
+  foo
+\t\t`,
+      /Insufficient indentation in line 0/
+    );
+  });
+});

--- a/fluent-dedent/test/tabs_test.js
+++ b/fluent-dedent/test/tabs_test.js
@@ -27,7 +27,7 @@ suite("tab indent", function() {
       () => ftl`
 \tfoo
 \t\t`,
-      /Insufficient indentation in line 0/
+      /Insufficient indentation in line 1/
     );
   });
 
@@ -36,7 +36,7 @@ suite("tab indent", function() {
       () => ftl`
 \t\tfoo
         `,
-      /Insufficient indentation in line 0/
+      /Insufficient indentation in line 1/
     );
   });
 
@@ -45,7 +45,7 @@ suite("tab indent", function() {
       () => ftl`
         foo
 \t\t`,
-      /Insufficient indentation in line 0/
+      /Insufficient indentation in line 1/
     );
   });
 
@@ -54,7 +54,7 @@ suite("tab indent", function() {
       () => ftl`
 \t\tfoo
   `,
-      /Insufficient indentation in line 0/
+      /Insufficient indentation in line 1/
     );
   });
 
@@ -63,7 +63,7 @@ suite("tab indent", function() {
       () => ftl`
   foo
 \t\t`,
-      /Insufficient indentation in line 0/
+      /Insufficient indentation in line 1/
     );
   });
 });


### PR DESCRIPTION
Fix #362. Supersedes #369.

This PR adds the `@fluent/dedent` package which only provides the `ftl` template literal tag. Once it's merged and published, I'll remove the `ftl` helper from the `fluent` package. By moving the helper to its own package the refinements to it and changes to the behavior will not require version bumps of the main `fluent` package.

I rewrote the whole thing. The behavior is now based on the [multiline strings spec in Swift](https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html), where the indent of the closing delimiter defines the amount of indent removed from other lines. The first and the last lines are removed from the output, too. If they're not all-whitespace, or if the indentation is insufficient in any of the content lines, a `RangeError` is thrown.

```javascript
import ftl from "@fluent/dedent";
let messages = ftl`
    hello = Hello, world!
    welcome = Welcome, {$userName}!
    `;

assert(messages === "hello = Hello, world!\nwelcome = Welcome, {$userName}!");
```

I considered other options, but this one appealed to me the most with its simplicity and predictability. It's easy to explain in a single sentence, and visually too.