### PR TITLE
Default the child element of Localized to null

### DIFF
--- a/fluent-react/src/localized.js
+++ b/fluent-react/src/localized.js
@@ -79,7 +79,7 @@ export default class Localized extends Component {
 
   render() {
     const { l10n, parseMarkup } = this.context;
-    const { id, attrs, children: elem } = this.props;
+    const { id, attrs, children: elem = null } = this.props;
 
     // Validate that the child element isn't an array
     if (Array.isArray(elem)) {


### PR DESCRIPTION
If no child element is provided and `<Localized />` tries to return the children as a fallback, `undefined` is returned. This causes a React error that is difficult to track down. Instead, default the child element to `null`, which is a valid return value for a React component.

Fixes #377 