### PR TITLE
Omitting errors in formatPattern() makes it throw

### DIFF
--- a/fluent/src/bundle.js
+++ b/fluent/src/bundle.js
@@ -1,6 +1,7 @@
 import {resolveComplexPattern} from "./resolver.js";
 import FluentResource from "./resource.js";
 import { FluentNone } from "./types.js";
+import Scope from "./scope.js";
 
 /**
  * Message bundles are single-language stores of translations.  They are
@@ -222,7 +223,7 @@ export default class FluentBundle {
     }
 
     // Resolve a complex pattern.
-    let scope = this._createScope(args, errors);
+    let scope = new Scope(this, errors, args);
     try {
       let value = resolveComplexPattern(scope, pattern);
       return value.toString(scope);
@@ -233,17 +234,6 @@ export default class FluentBundle {
       }
       throw err;
     }
-  }
-
-  _createScope(args, errors) {
-    return {
-      args,
-      errors,
-      bundle: this,
-      dirty: new WeakSet(),
-      // TermReferences are resolved in a new scope.
-      insideTermReference: false,
-    };
   }
 
   _memoizeIntlObject(ctor, opts) {

--- a/fluent/src/bundle.js
+++ b/fluent/src/bundle.js
@@ -223,24 +223,22 @@ export default class FluentBundle {
 
     // Resolve a complex pattern.
     let scope = this._createScope(args, errors);
-    let value;
     try {
-      value = resolveComplexPattern(scope, pattern).toString(scope);
+      let value = resolveComplexPattern(scope, pattern);
+      return value.toString(scope);
     } catch (err) {
-      scope.errors.push(err);
-      value = new FluentNone().toString(scope);
+      if (scope.errors) {
+        scope.errors.push(err);
+        return new FluentNone().toString(scope);
+      }
+      throw err;
     }
-
-    if (!errors && scope.errors.length > 0) {
-      throw scope.errors[0];
-    }
-
-    return value;
   }
 
-  _createScope(args, errors = []) {
+  _createScope(args, errors) {
     return {
-      args, errors,
+      args,
+      errors,
       bundle: this,
       dirty: new WeakSet(),
       // TermReferences are resolved in a new scope.

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -191,9 +191,9 @@ function TermReference(scope, {name, attr, args}) {
     return new FluentNone(id);
   }
 
-  // Every TermReference has its own args.
-  const [, keyargs] = getArguments(scope, args);
-  const local = scope.clone(keyargs);
+  // Every TermReference has its own variables.
+  const [, params] = getArguments(scope, args);
+  const local = scope.cloneForTermReference(params);
 
   if (attr) {
     const attribute = term.attributes[attr];

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -47,16 +47,6 @@ const FSI = "\u2068";
 const PDI = "\u2069";
 
 
-// Helper: Report an error.
-function report(scope, error) {
-  if (scope.errors) {
-    scope.errors.push(error);
-  } else {
-    throw error;
-  }
-}
-
-
 // Helper: match a variant key to the given selector.
 function match(bundle, selector, key) {
   if (key === selector) {
@@ -89,7 +79,7 @@ function getDefault(scope, variants, star) {
     return resolvePattern(scope, variants[star].value);
   }
 
-  report(scope, new RangeError("No default"));
+  scope.reportError(new RangeError("No default"));
   return new FluentNone();
 }
 
@@ -137,7 +127,7 @@ function resolveExpression(scope, expr) {
 function VariableReference(scope, {name}) {
   if (!scope.args || !scope.args.hasOwnProperty(name)) {
     if (scope.insideTermReference === false) {
-      report(scope, new ReferenceError(`Unknown variable: ${name}`));
+      scope.reportError(new ReferenceError(`Unknown variable: ${name}`));
     }
     return new FluentNone(`$${name}`);
   }
@@ -160,7 +150,7 @@ function VariableReference(scope, {name}) {
         return new FluentDateTime(arg);
       }
     default:
-      report(scope,
+      scope.reportError(
         new TypeError(`Unsupported variable type: ${name}, ${typeof arg}`)
       );
       return new FluentNone(`$${name}`);
@@ -171,7 +161,7 @@ function VariableReference(scope, {name}) {
 function MessageReference(scope, {name, attr}) {
   const message = scope.bundle._messages.get(name);
   if (!message) {
-    report(scope, new ReferenceError(`Unknown message: ${name}`));
+    scope.reportError(new ReferenceError(`Unknown message: ${name}`));
     return new FluentNone(name);
   }
 
@@ -180,7 +170,7 @@ function MessageReference(scope, {name, attr}) {
     if (attribute) {
       return resolvePattern(scope, attribute);
     }
-    report(scope, new ReferenceError(`Unknown attribute: ${attr}`));
+    scope.reportError(new ReferenceError(`Unknown attribute: ${attr}`));
     return new FluentNone(`${name}.${attr}`);
   }
 
@@ -188,7 +178,7 @@ function MessageReference(scope, {name, attr}) {
     return resolvePattern(scope, message.value);
   }
 
-  report(scope, new ReferenceError(`No value: ${name}`));
+  scope.reportError(new ReferenceError(`No value: ${name}`));
   return new FluentNone(name);
 }
 
@@ -197,20 +187,20 @@ function TermReference(scope, {name, attr, args}) {
   const id = `-${name}`;
   const term = scope.bundle._terms.get(id);
   if (!term) {
-    report(scope, new ReferenceError(`Unknown term: ${id}`));
+    scope.reportError(new ReferenceError(`Unknown term: ${id}`));
     return new FluentNone(id);
   }
 
   // Every TermReference has its own args.
   const [, keyargs] = getArguments(scope, args);
-  const local = {...scope, args: keyargs, insideTermReference: true};
+  const local = scope.clone(keyargs);
 
   if (attr) {
     const attribute = term.attributes[attr];
     if (attribute) {
       return resolvePattern(local, attribute);
     }
-    report(scope, new ReferenceError(`Unknown attribute: ${attr}`));
+    scope.reportError(new ReferenceError(`Unknown attribute: ${attr}`));
     return new FluentNone(`${id}.${attr}`);
   }
 
@@ -223,12 +213,12 @@ function FunctionReference(scope, {name, args}) {
   // the `FluentBundle` constructor.
   const func = scope.bundle._functions[name] || builtins[name];
   if (!func) {
-    report(scope, new ReferenceError(`Unknown function: ${name}()`));
+    scope.reportError(new ReferenceError(`Unknown function: ${name}()`));
     return new FluentNone(`${name}()`);
   }
 
   if (typeof func !== "function") {
-    report(scope, new TypeError(`Function ${name}() is not callable`));
+    scope.reportError(new TypeError(`Function ${name}() is not callable`));
     return new FluentNone(`${name}()`);
   }
 
@@ -261,7 +251,7 @@ function SelectExpression(scope, {selector, variants, star}) {
 // Resolve a pattern (a complex string with placeables).
 export function resolveComplexPattern(scope, ptn) {
   if (scope.dirty.has(ptn)) {
-    report(scope, new RangeError("Cyclic reference"));
+    scope.reportError(new RangeError("Cyclic reference"));
     return new FluentNone();
   }
 

--- a/fluent/src/scope.js
+++ b/fluent/src/scope.js
@@ -1,16 +1,22 @@
 export default class Scope {
-  constructor(bundle, errors, args,
-    insideTermReference = false, dirty = new WeakSet()
+  constructor(
+    bundle,
+    errors,
+    args,
+    insideTermReference = false,
+    dirty = new WeakSet()
   ) {
     this.bundle = bundle;
     this.errors = errors;
     this.args = args;
-    this.dirty = dirty;
-    // TermReferences are resolved in a new scope.
+
+    // Term references require different variable lookup logic.
     this.insideTermReference = insideTermReference;
+    // Keeps track of visited Patterns. Used to detect cyclic references.
+    this.dirty = dirty;
   }
 
-  clone(args) {
+  cloneForTermReference(args) {
     return new Scope(this.bundle, this.errors, args, true, this.dirty);
   }
 

--- a/fluent/src/scope.js
+++ b/fluent/src/scope.js
@@ -1,0 +1,23 @@
+export default class Scope {
+  constructor(bundle, errors, args,
+    insideTermReference = false, dirty = new WeakSet()
+  ) {
+    this.bundle = bundle;
+    this.errors = errors;
+    this.args = args;
+    this.dirty = dirty;
+    // TermReferences are resolved in a new scope.
+    this.insideTermReference = insideTermReference;
+  }
+
+  clone(args) {
+    return new Scope(this.bundle, this.errors, args, true, this.dirty);
+  }
+
+  reportError(error) {
+    if (!this.errors) {
+      throw error;
+    }
+    this.errors.push(error);
+  }
+}

--- a/fluent/test/bomb_test.js
+++ b/fluent/test/bomb_test.js
@@ -35,6 +35,16 @@ suite('Reference bombs', function() {
       const val = bundle.formatPattern(msg.value, args, errs);
       assert.strictEqual(val, '{???}');
       assert.strictEqual(errs.length, 1);
+      assert.ok(errs[0] instanceof RangeError);
+    });
+
+    test('throws when errors are undefined', function() {
+      const msg = bundle.getMessage('lolz');
+      assert.throws(
+        () => bundle.formatPattern(msg.value),
+        RangeError,
+        "Too many characters in placeable"
+      );
     });
   });
 });

--- a/fluent/test/errors_test.js
+++ b/fluent/test/errors_test.js
@@ -1,0 +1,96 @@
+"use strict";
+
+import assert from "assert";
+import ftl from "@fluent/dedent";
+
+import FluentBundle from "../src/bundle";
+
+suite("Errors", function() {
+  let bundle, errs;
+  setup(function() {
+    errs = [];
+  });
+
+  suite("Reporting into an array", function(){
+    suiteSetup(function() {
+      bundle = new FluentBundle("en-US", { useIsolating: false });
+      bundle.addMessages(ftl`
+        foo = {$one} and {$two}
+        `);
+    });
+
+    test("Two errors are reported", function() {
+      let msg = bundle.getMessage("foo");
+      let val = bundle.formatPattern(msg.value, {}, errs);
+      assert.strictEqual(val, "{$one} and {$two}");
+      assert.strictEqual(errs.length, 2);
+      assert.ok(errs[0] instanceof ReferenceError);
+      assert.ok(errs[1] instanceof ReferenceError);
+    });
+
+    test("Two calls", function() {
+      let msg = bundle.getMessage("foo");
+      let val;
+
+      val = bundle.formatPattern(msg.value, {}, errs);
+      assert.strictEqual(val, "{$one} and {$two}");
+      assert.strictEqual(errs.length, 2);
+      assert.ok(errs[0] instanceof ReferenceError);
+      assert.ok(errs[1] instanceof ReferenceError);
+
+      val = bundle.formatPattern(msg.value, {}, errs);
+      assert.strictEqual(val, "{$one} and {$two}");
+      assert.strictEqual(errs.length, 4);
+      assert.ok(errs[0] instanceof ReferenceError);
+      assert.ok(errs[1] instanceof ReferenceError);
+      assert.ok(errs[2] instanceof ReferenceError);
+      assert.ok(errs[3] instanceof ReferenceError);
+    });
+
+    test("Non-empty errors array", function() {
+      errs = ["Something"];
+      let msg = bundle.getMessage("foo");
+      let val = bundle.formatPattern(msg.value, {}, errs);
+
+      assert.strictEqual(val, "{$one} and {$two}");
+      assert.strictEqual(errs.length, 3);
+      assert.strictEqual(errs[0], "Something");
+      assert.ok(errs[1] instanceof ReferenceError);
+      assert.ok(errs[2] instanceof ReferenceError);
+    });
+  });
+
+  suite("Throwing", function(){
+    suiteSetup(function() {
+      bundle = new FluentBundle("en-US", { useIsolating: false });
+      bundle.addMessages(ftl`
+        foo = {$one} and {$two}
+        `);
+    });
+
+    test("First error is thrown", function() {
+      let msg = bundle.getMessage("foo");
+      assert.throws(
+        () => bundle.formatPattern(msg.value, {}),
+        ReferenceError,
+        "Unknown variable: $one"
+      );
+    });
+
+    test("Two calls", function() {
+      let msg = bundle.getMessage("foo");
+
+      assert.throws(
+        () => bundle.formatPattern(msg.value, {}),
+        ReferenceError,
+        "Unknown variable: $one"
+      );
+
+      assert.throws(
+        () => bundle.formatPattern(msg.value, {}),
+        ReferenceError,
+        "Unknown variable: $one"
+      );
+    });
+  });
+});

--- a/fluent/test/errors_test.js
+++ b/fluent/test/errors_test.js
@@ -6,91 +6,40 @@ import ftl from "@fluent/dedent";
 import FluentBundle from "../src/bundle";
 
 suite("Errors", function() {
-  let bundle, errs;
-  setup(function() {
-    errs = [];
+  let bundle;
+
+  suiteSetup(function() {
+    bundle = new FluentBundle("en-US", { useIsolating: false });
+    bundle.addMessages(ftl`
+      foo = {$one} and {$two}
+      `);
   });
 
-  suite("Reporting into an array", function(){
-    suiteSetup(function() {
-      bundle = new FluentBundle("en-US", { useIsolating: false });
-      bundle.addMessages(ftl`
-        foo = {$one} and {$two}
-        `);
-    });
+  test("Reporting into an array", function() {
+    let errors = [];
+    let message = bundle.getMessage("foo");
 
-    test("Two errors are reported", function() {
-      let msg = bundle.getMessage("foo");
-      let val = bundle.formatPattern(msg.value, {}, errs);
-      assert.strictEqual(val, "{$one} and {$two}");
-      assert.strictEqual(errs.length, 2);
-      assert.ok(errs[0] instanceof ReferenceError);
-      assert.ok(errs[1] instanceof ReferenceError);
-    });
+    let val1 = bundle.formatPattern(message.value, {}, errors);
+    assert.strictEqual(val1, "{$one} and {$two}");
+    assert.strictEqual(errors.length, 2);
+    assert.ok(errors[0] instanceof ReferenceError);
+    assert.ok(errors[1] instanceof ReferenceError);
 
-    test("Two calls", function() {
-      let msg = bundle.getMessage("foo");
-      let val;
-
-      val = bundle.formatPattern(msg.value, {}, errs);
-      assert.strictEqual(val, "{$one} and {$two}");
-      assert.strictEqual(errs.length, 2);
-      assert.ok(errs[0] instanceof ReferenceError);
-      assert.ok(errs[1] instanceof ReferenceError);
-
-      val = bundle.formatPattern(msg.value, {}, errs);
-      assert.strictEqual(val, "{$one} and {$two}");
-      assert.strictEqual(errs.length, 4);
-      assert.ok(errs[0] instanceof ReferenceError);
-      assert.ok(errs[1] instanceof ReferenceError);
-      assert.ok(errs[2] instanceof ReferenceError);
-      assert.ok(errs[3] instanceof ReferenceError);
-    });
-
-    test("Non-empty errors array", function() {
-      errs = ["Something"];
-      let msg = bundle.getMessage("foo");
-      let val = bundle.formatPattern(msg.value, {}, errs);
-
-      assert.strictEqual(val, "{$one} and {$two}");
-      assert.strictEqual(errs.length, 3);
-      assert.strictEqual(errs[0], "Something");
-      assert.ok(errs[1] instanceof ReferenceError);
-      assert.ok(errs[2] instanceof ReferenceError);
-    });
+    let val2 = bundle.formatPattern(message.value, {}, errors);
+    assert.strictEqual(val2, "{$one} and {$two}");
+    assert.strictEqual(errors.length, 4);
+    assert.ok(errors[0] instanceof ReferenceError);
+    assert.ok(errors[1] instanceof ReferenceError);
+    assert.ok(errors[2] instanceof ReferenceError);
+    assert.ok(errors[3] instanceof ReferenceError);
   });
 
-  suite("Throwing", function(){
-    suiteSetup(function() {
-      bundle = new FluentBundle("en-US", { useIsolating: false });
-      bundle.addMessages(ftl`
-        foo = {$one} and {$two}
-        `);
-    });
-
-    test("First error is thrown", function() {
-      let msg = bundle.getMessage("foo");
-      assert.throws(
-        () => bundle.formatPattern(msg.value, {}),
-        ReferenceError,
-        "Unknown variable: $one"
-      );
-    });
-
-    test("Two calls", function() {
-      let msg = bundle.getMessage("foo");
-
-      assert.throws(
-        () => bundle.formatPattern(msg.value, {}),
-        ReferenceError,
-        "Unknown variable: $one"
-      );
-
-      assert.throws(
-        () => bundle.formatPattern(msg.value, {}),
-        ReferenceError,
-        "Unknown variable: $one"
-      );
-    });
+  test("First error is thrown", function() {
+    let message = bundle.getMessage("foo");
+    assert.throws(
+      () => bundle.formatPattern(message.value, {}),
+      ReferenceError,
+      "Unknown variable: $one"
+    );
   });
 });

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -59,6 +59,7 @@ suite('Built-in functions', function() {
     });
 
     // XXX Functions should report errors.
+    // https://github.com/projectfluent/fluent.js/issues/106
     test('string argument', function() {
       const args = {arg: "Foo"};
       let msg;
@@ -77,6 +78,7 @@ suite('Built-in functions', function() {
     });
 
     // XXX Functions should report errors.
+    // https://github.com/projectfluent/fluent.js/issues/106
     test('date argument', function() {
       const date = new Date('2016-09-29');
       const args = {arg: date};
@@ -174,6 +176,7 @@ suite('Built-in functions', function() {
     });
 
     // XXX Functions should report errors.
+    // https://github.com/projectfluent/fluent.js/issues/106
     test('number argument', function() {
       let args = {arg: 1};
       let msg;
@@ -192,6 +195,7 @@ suite('Built-in functions', function() {
     });
 
     // XXX Functions should report errors.
+    // https://github.com/projectfluent/fluent.js/issues/106
     test('string argument', function() {
       let args = {arg: 'Foo'};
       let msg;

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -6,7 +6,11 @@ import ftl from "@fluent/dedent";
 import FluentBundle from '../src/bundle';
 
 suite('Built-in functions', function() {
-  let bundle;
+  let bundle, errors;
+
+  setup(function () {
+    errors = [];
+  });
 
   suite('NUMBER', function(){
     suiteSetup(function() {
@@ -22,13 +26,19 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof ReferenceError);
 
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof ReferenceError);
 
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof ReferenceError);
     });
 
     test('number argument', function() {
@@ -36,42 +46,53 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '1');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '100%');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '100%');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '1');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1');
+      assert.strictEqual(errors.length, 0);
     });
 
+    // XXX Functions should report errors.
     test('string argument', function() {
       const args = {arg: "Foo"};
       let msg;
 
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 0);
     });
 
+    // XXX Functions should report errors.
     test('date argument', function() {
       const date = new Date('2016-09-29');
       const args = {arg: date};
       let msg;
 
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 0);
     });
 
     test('invalid argument', function() {
@@ -79,13 +100,19 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof TypeError);
 
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof TypeError);
 
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof TypeError);
     });
   });
 
@@ -103,13 +130,19 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof ReferenceError);
 
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof ReferenceError);
 
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof ReferenceError);
     });
 
     test('Date argument', function () {
@@ -124,45 +157,56 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), expectedDefault);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedDefault);
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), expectedMonth);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedMonth);
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-bad-opt');
       // The argument value will be coerced into a string by the join operation
       // in FluentBundle.format.  The result looks something like this; it
       // may vary depending on the TZ:
       //     Thu Sep 29 2016 02:00:00 GMT+0200 (CEST)
-      assert.strictEqual(bundle.formatPattern(msg.value, args), date.toString());
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), date.toString());
+      assert.strictEqual(errors.length, 0);
     });
 
+    // XXX Functions should report errors.
     test('number argument', function() {
       let args = {arg: 1};
       let msg;
 
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 0);
     });
 
+    // XXX Functions should report errors.
     test('string argument', function() {
       let args = {arg: 'Foo'};
       let msg;
 
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 0);
     });
 
     test('invalid argument', function() {
@@ -170,13 +214,19 @@ suite('Built-in functions', function() {
       let msg;
 
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof TypeError);
 
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof TypeError);
 
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args), '{$arg}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors.pop() instanceof TypeError);
     });
   });
 });

--- a/fluent/test/patterns_test.js
+++ b/fluent/test/patterns_test.js
@@ -84,12 +84,11 @@ suite('Patterns', function(){
         `);
     });
 
-    test('throws when trying to format a null value', function(){
+    test('returns {???} when trying to format a null value', function(){
       const msg = bundle.getMessage('foo');
-      assert.throws(
-        () => bundle.formatPattern(msg.value, args, errs),
-        /Invalid Pattern type/
-      );
+      const val = bundle.formatPattern(msg.value, args, errs);
+      assert.strictEqual(val, '{???}');
+      assert.strictEqual(errs.length, 1);
     });
 
     test('formats the attribute', function(){

--- a/fluent/test/values_format_test.js
+++ b/fluent/test/values_format_test.js
@@ -59,12 +59,11 @@ suite('Formatting values', function(){
     assert.strictEqual(errs.length, 1);
   });
 
-  test('throws when trying to format a null value', function(){
+  test('returns {???} when trying to format a null value', function(){
     const msg = bundle.getMessage('key5');
-    assert.throws(
-      () => bundle.formatPattern(msg.value, args, errs),
-      /Invalid Pattern type/
-    );
+    const val = bundle.formatPattern(msg.value, args, errs);
+    assert.strictEqual(val, '{???}');
+    assert.strictEqual(errs.length, 1);
   });
 
   test('allows to pass traits directly to bundle.formatPattern', function(){


### PR DESCRIPTION
This PR introduces a new opt-in error reporting strategy in `formatPattern`.

- If the `errors` argument is specified, the behavior is unchanged: `formatPattern` returns a string which is a best-effort attempt to resolve the given pattern. Any errors produced during the resolution are collected in the `errors` array.

- If the `errors` argument is omitted, the behavior changes to throwing the first encountered error, which also stops the resolving immediately. No fallback value is produced in this case. It's entirely up the user of the API to decide what the fallback should be, if any.

This fixes #390. Also see #364.