### PR TITLE
Move memoizeIntlObject to Scope

### DIFF
--- a/fluent/src/bundle.js
+++ b/fluent/src/bundle.js
@@ -235,16 +235,4 @@ export default class FluentBundle {
       throw err;
     }
   }
-
-  _memoizeIntlObject(ctor, opts) {
-    const cache = this._intls.get(ctor) || {};
-    const id = JSON.stringify(opts);
-
-    if (!cache[id]) {
-      cache[id] = new ctor(this.locales, opts);
-      this._intls.set(ctor, cache);
-    }
-
-    return cache[id];
-  }
 }

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -48,7 +48,7 @@ const PDI = "\u2069";
 
 
 // Helper: match a variant key to the given selector.
-function match(bundle, selector, key) {
+function match(scope, selector, key) {
   if (key === selector) {
     // Both are strings.
     return true;
@@ -62,8 +62,8 @@ function match(bundle, selector, key) {
   }
 
   if (selector instanceof FluentNumber && typeof key === "string") {
-    let category = bundle
-      ._memoizeIntlObject(Intl.PluralRules, selector.opts)
+    let category = scope
+      .memoizeIntlObject(Intl.PluralRules, selector.opts)
       .select(selector.value);
     if (key === category) {
       return true;
@@ -240,7 +240,7 @@ function SelectExpression(scope, {selector, variants, star}) {
   // Match the selector against keys of each variant, in order.
   for (const variant of variants) {
     const key = resolveExpression(scope, variant.key);
-    if (match(scope.bundle, sel, key)) {
+    if (match(scope, sel, key)) {
       return resolvePattern(scope, variant.value);
     }
   }

--- a/fluent/src/scope.js
+++ b/fluent/src/scope.js
@@ -26,4 +26,17 @@ export default class Scope {
     }
     this.errors.push(error);
   }
+
+  memoizeIntlObject(ctor, opts) {
+    let cache = this.bundle._intls.get(ctor);
+    if (!cache) {
+      cache = {};
+      this.bundle._intls.set(ctor, cache);
+    }
+    let id = JSON.stringify(opts);
+    if (!cache[id]) {
+      cache[id] = new ctor(this.bundle.locales, opts);
+    }
+    return cache[id];
+  }
 }

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -61,9 +61,7 @@ export class FluentNumber extends FluentType {
 
   toString(scope) {
     try {
-      const nf = scope.bundle._memoizeIntlObject(
-        Intl.NumberFormat, this.opts
-      );
+      const nf = scope.memoizeIntlObject(Intl.NumberFormat, this.opts);
       return nf.format(this.value);
     } catch (e) {
       // XXX Report the error.
@@ -79,9 +77,7 @@ export class FluentDateTime extends FluentType {
 
   toString(scope) {
     try {
-      const dtf = scope.bundle._memoizeIntlObject(
-        Intl.DateTimeFormat, this.opts
-      );
+      const dtf = scope.memoizeIntlObject(Intl.DateTimeFormat, this.opts);
       return dtf.format(this.value);
     } catch (e) {
       // XXX Report the error.


### PR DESCRIPTION
Now that `Scope` is a proper class, we can move some private logic from `FluentBundle` to it.

I'm keeping `Scope.bundle` which still exposes `_messages`, `_terms` etc. We _could_ move assign them explicitly inside `Scope`, too, but they still need to be fields on `FluentBundle` anyways, since we need them for storage. I'd rather just wait for private fields than work around their lack with `WeakMap` or some other fashion.