### PR TITLE
Report errors from Functions and Intl objects

### DIFF
--- a/fluent/src/builtins.js
+++ b/fluent/src/builtins.js
@@ -28,7 +28,7 @@ function values(opts) {
 export
 function NUMBER([arg], opts) {
   if (arg instanceof FluentNone) {
-    return new FluentNone("NUMBER()");
+    return new FluentNone(`NUMBER(${arg.valueOf()})`);
   }
 
   if (arg instanceof FluentNumber) {
@@ -41,7 +41,7 @@ function NUMBER([arg], opts) {
 export
 function DATETIME([arg], opts) {
   if (arg instanceof FluentNone) {
-    return new FluentNone("DATETIME()");
+    return new FluentNone(`DATETIME(${arg.valueOf()})`);
   }
 
   if (arg instanceof FluentDateTime) {

--- a/fluent/src/builtins.js
+++ b/fluent/src/builtins.js
@@ -11,7 +11,7 @@
  * `FluentType`.  Functions must return `FluentType` objects as well.
  */
 
-import { FluentNumber, FluentDateTime } from "./types.js";
+import { FluentNone, FluentNumber, FluentDateTime } from "./types.js";
 
 function merge(argopts, opts) {
   return Object.assign({}, argopts, values(opts));
@@ -27,6 +27,10 @@ function values(opts) {
 
 export
 function NUMBER([arg], opts) {
+  if (arg instanceof FluentNone) {
+    return new FluentNone("NUMBER()");
+  }
+
   if (arg instanceof FluentNumber) {
     return new FluentNumber(arg.valueOf(), merge(arg.opts, opts));
   }
@@ -36,6 +40,10 @@ function NUMBER([arg], opts) {
 
 export
 function DATETIME([arg], opts) {
+  if (arg instanceof FluentNone) {
+    return new FluentNone("DATETIME()");
+  }
+
   if (arg instanceof FluentDateTime) {
     return new FluentDateTime(arg.valueOf(), merge(arg.opts, opts));
   }

--- a/fluent/src/builtins.js
+++ b/fluent/src/builtins.js
@@ -11,7 +11,7 @@
  * `FluentType`.  Functions must return `FluentType` objects as well.
  */
 
-import { FluentNone, FluentNumber, FluentDateTime } from "./types.js";
+import { FluentNumber, FluentDateTime } from "./types.js";
 
 function merge(argopts, opts) {
   return Object.assign({}, argopts, values(opts));
@@ -27,22 +27,18 @@ function values(opts) {
 
 export
 function NUMBER([arg], opts) {
-  if (arg instanceof FluentNone) {
-    return arg;
-  }
   if (arg instanceof FluentNumber) {
     return new FluentNumber(arg.valueOf(), merge(arg.opts, opts));
   }
-  return new FluentNone("NUMBER()");
+
+  throw new TypeError("Invalid argument type to NUMBER");
 }
 
 export
 function DATETIME([arg], opts) {
-  if (arg instanceof FluentNone) {
-    return arg;
-  }
   if (arg instanceof FluentDateTime) {
     return new FluentDateTime(arg.valueOf(), merge(arg.opts, opts));
   }
-  return new FluentNone("DATETIME()");
+
+  throw new TypeError("Invalid argument type to DATETIME");
 }

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -127,7 +127,7 @@ function resolveExpression(scope, expr) {
 function VariableReference(scope, {name}) {
   if (!scope.args || !scope.args.hasOwnProperty(name)) {
     if (scope.insideTermReference === false) {
-      scope.reportError(new ReferenceError(`Unknown variable: ${name}`));
+      scope.reportError(new ReferenceError(`Unknown variable: $${name}`));
     }
     return new FluentNone(`$${name}`);
   }
@@ -151,7 +151,7 @@ function VariableReference(scope, {name}) {
       }
     default:
       scope.reportError(
-        new TypeError(`Unsupported variable type: ${name}, ${typeof arg}`)
+        new TypeError(`Variable type not supported: $${name}, ${typeof arg}`)
       );
       return new FluentNone(`$${name}`);
   }
@@ -224,8 +224,8 @@ function FunctionReference(scope, {name, args}) {
 
   try {
     return func(...getArguments(scope, args));
-  } catch (e) {
-    // XXX Report errors.
+  } catch (err) {
+    scope.reportError(err);
     return new FluentNone(`${name}()`);
   }
 }

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -45,12 +45,12 @@ export class FluentType {
 }
 
 export class FluentNone extends FluentType {
-  valueOf() {
-    return null;
+  constructor(value = "???") {
+    super(value);
   }
 
   toString() {
-    return `{${this.value || "???"}}`;
+    return `{${this.value}}`;
   }
 }
 

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -65,8 +65,8 @@ export class FluentNumber extends FluentType {
         Intl.NumberFormat, this.opts
       );
       return nf.format(this.value);
-    } catch (e) {
-      // XXX Report the error.
+    } catch (err) {
+      scope.reportError(err);
       return this.value;
     }
   }
@@ -83,8 +83,8 @@ export class FluentDateTime extends FluentType {
         Intl.DateTimeFormat, this.opts
       );
       return dtf.format(this.value);
-    } catch (e) {
-      // XXX Report the error.
+    } catch (err) {
+      scope.reportError(err);
       return this.value;
     }
   }

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -28,29 +28,23 @@ suite('Built-in functions', function() {
       errors = [];
       msg = bundle.getMessage('num-decimal');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
 
       errors = [];
       msg = bundle.getMessage('num-percent');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
 
       errors = [];
       msg = bundle.getMessage('num-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
     });
 
     test('number argument', function() {
@@ -131,29 +125,23 @@ suite('Built-in functions', function() {
       errors = [];
       msg = bundle.getMessage('num-decimal');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
 
       errors = [];
       msg = bundle.getMessage('num-percent');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
 
       errors = [];
       msg = bundle.getMessage('num-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
     });
   });
 
@@ -173,29 +161,23 @@ suite('Built-in functions', function() {
       errors = [];
       msg = bundle.getMessage('dt-default');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
 
       errors = [];
       msg = bundle.getMessage('dt-month');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
 
       errors = [];
       msg = bundle.getMessage('dt-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
     });
 
     test('Date argument', function () {
@@ -286,29 +268,23 @@ suite('Built-in functions', function() {
       errors = [];
       msg = bundle.getMessage('dt-default');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
 
       errors = [];
       msg = bundle.getMessage('dt-month');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
 
       errors = [];
       msg = bundle.getMessage('dt-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 2);
+      assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
-      assert.ok(errors[1] instanceof TypeError);
-      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
     });
   });
 });

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -27,21 +27,21 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
@@ -124,21 +124,21 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
 
       errors = [];
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
 
       errors = [];
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
@@ -160,21 +160,21 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
@@ -267,21 +267,21 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
 
       errors = [];
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
 
       errors = [];
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -25,20 +25,32 @@ suite('Built-in functions', function() {
     test('missing argument', function() {
       let msg;
 
+      errors = [];
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof ReferenceError);
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
 
+      errors = [];
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof ReferenceError);
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
 
+      errors = [];
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof ReferenceError);
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
     });
 
     test('number argument', function() {
@@ -58,63 +70,89 @@ suite('Built-in functions', function() {
       assert.strictEqual(errors.length, 0);
     });
 
-    // XXX Functions should report errors.
-    // https://github.com/projectfluent/fluent.js/issues/106
     test('string argument', function() {
       const args = {arg: "Foo"};
       let msg;
 
+      errors = [];
       msg = bundle.getMessage('num-decimal');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
 
+      errors = [];
       msg = bundle.getMessage('num-percent');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
 
+      errors = [];
       msg = bundle.getMessage('num-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
     });
 
-    // XXX Functions should report errors.
-    // https://github.com/projectfluent/fluent.js/issues/106
     test('date argument', function() {
       const date = new Date('2016-09-29');
       const args = {arg: date};
       let msg;
 
+      errors = [];
       msg = bundle.getMessage('num-decimal');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
 
+      errors = [];
       msg = bundle.getMessage('num-percent');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
 
+      errors = [];
       msg = bundle.getMessage('num-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
     });
 
     test('invalid argument', function() {
       const args = {arg: []};
       let msg;
 
+      errors = [];
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof TypeError);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
 
+      errors = [];
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof TypeError);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
 
+      errors = [];
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof TypeError);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to NUMBER");
     });
   });
 
@@ -131,20 +169,32 @@ suite('Built-in functions', function() {
     test('missing argument', function() {
       let msg;
 
+      errors = [];
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof ReferenceError);
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
 
+      errors = [];
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof ReferenceError);
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
 
+      errors = [];
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof ReferenceError);
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
     });
 
     test('Date argument', function () {
@@ -175,62 +225,88 @@ suite('Built-in functions', function() {
       assert.strictEqual(errors.length, 0);
     });
 
-    // XXX Functions should report errors.
-    // https://github.com/projectfluent/fluent.js/issues/106
     test('number argument', function() {
       let args = {arg: 1};
       let msg;
 
+      errors = [];
       msg = bundle.getMessage('dt-default');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
 
+      errors = [];
       msg = bundle.getMessage('dt-month');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
 
+      errors = [];
       msg = bundle.getMessage('dt-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
     });
 
-    // XXX Functions should report errors.
-    // https://github.com/projectfluent/fluent.js/issues/106
     test('string argument', function() {
       let args = {arg: 'Foo'};
       let msg;
 
+      errors = [];
       msg = bundle.getMessage('dt-default');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
 
+      errors = [];
       msg = bundle.getMessage('dt-month');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
 
+      errors = [];
       msg = bundle.getMessage('dt-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
     });
 
     test('invalid argument', function() {
       let args = {arg: []};
       let msg;
 
+      errors = [];
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof TypeError);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
 
+      errors = [];
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof TypeError);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
 
+      errors = [];
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{$arg}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors.pop() instanceof TypeError);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 2);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+      assert.ok(errors[1] instanceof TypeError);
+      assert.strictEqual(errors[1].message, "Invalid argument type to DATETIME");
     });
   });
 });

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -67,7 +67,8 @@ suite('Built-in functions', function() {
 
       msg = bundle.getMessage('num-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof RangeError); // Invalid option value
     });
 
     test('string argument', function() {
@@ -222,7 +223,8 @@ suite('Built-in functions', function() {
       // may vary depending on the TZ:
       //     Thu Sep 29 2016 02:00:00 GMT+0200 (CEST)
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), date.toString());
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof RangeError); // Invalid option value
     });
 
     test('number argument', function() {


### PR DESCRIPTION
I had a look at our error reporting and I realized that there really isn't anything that would make it hard to report errors thrown by Functions and from `memoizeIntlObject`. Yay.

Fix #106. Fix #107.