### PR TITLE
fix SyntaxError on Edge

### DIFF
--- a/fluent-dom/src/dom_localization.js
+++ b/fluent-dom/src/dom_localization.js
@@ -34,7 +34,7 @@ export default class DOMLocalization extends Localization {
     this.mutationObserver = null;
 
     this.observerConfig = {
-      attribute: true,
+      attributes: true,
       characterData: false,
       childList: true,
       subtree: true,


### PR DESCRIPTION
when using a MutationObserver with attributesFilter on edge `attributes: true` needs to be defined (see https://stackoverflow.com/questions/50593385/mutationobserver-syntax-error-on-ie-11)

I guess `attribute: true` (without the `s`) was a typo