### PR TITLE
Allow NUMBER and DATETIME to take strings, numbers, dates

### DIFF
--- a/fluent/src/builtins.js
+++ b/fluent/src/builtins.js
@@ -31,11 +31,12 @@ function NUMBER([arg], opts) {
     return new FluentNone(`NUMBER(${arg.valueOf()})`);
   }
 
-  if (arg instanceof FluentNumber) {
-    return new FluentNumber(arg.valueOf(), merge(arg.opts, opts));
+  let value = parseFloat(arg.valueOf());
+  if (Number.isNaN(value)) {
+    throw new TypeError("Invalid argument to NUMBER");
   }
 
-  throw new TypeError("Invalid argument type to NUMBER");
+  return new FluentNumber(value, merge(arg.opts, opts));
 }
 
 export
@@ -44,9 +45,10 @@ function DATETIME([arg], opts) {
     return new FluentNone(`DATETIME(${arg.valueOf()})`);
   }
 
-  if (arg instanceof FluentDateTime) {
-    return new FluentDateTime(arg.valueOf(), merge(arg.opts, opts));
+  let value = parseFloat(arg.valueOf());
+  if (Number.isNaN(value)) {
+    throw new TypeError("Invalid argument to DATETIME");
   }
 
-  throw new TypeError("Invalid argument type to DATETIME");
+  return new FluentDateTime(value, merge(arg.opts, opts));
 }

--- a/fluent/src/builtins.js
+++ b/fluent/src/builtins.js
@@ -31,7 +31,7 @@ function NUMBER([arg], opts) {
     return new FluentNone(`NUMBER(${arg.valueOf()})`);
   }
 
-  let value = parseFloat(arg.valueOf());
+  let value = Number(arg.valueOf());
   if (Number.isNaN(value)) {
     throw new TypeError("Invalid argument to NUMBER");
   }
@@ -45,7 +45,7 @@ function DATETIME([arg], opts) {
     return new FluentNone(`DATETIME(${arg.valueOf()})`);
   }
 
-  let value = parseFloat(arg.valueOf());
+  let value = Number(arg.valueOf());
   if (Number.isNaN(value)) {
     throw new TypeError("Invalid argument to DATETIME");
   }

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -134,10 +134,10 @@ function VariableReference(scope, {name}) {
     case "string":
       return arg;
     case "number":
-      return new FluentNumber(arg);
+      return new FluentNumber(parseFloat(arg));
     case "object":
       if (arg instanceof Date) {
-        return new FluentDateTime(arg);
+        return new FluentDateTime(arg.getTime());
       }
     default:
       scope.reportError(

--- a/fluent/src/resolver.js
+++ b/fluent/src/resolver.js
@@ -134,7 +134,7 @@ function VariableReference(scope, {name}) {
     case "string":
       return arg;
     case "number":
-      return new FluentNumber(parseFloat(arg));
+      return new FluentNumber(arg);
     case "object":
       if (arg instanceof Date) {
         return new FluentDateTime(arg.getTime());

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -94,7 +94,7 @@ export class FluentNumber extends FluentType {
       return nf.format(this.value);
     } catch (err) {
       scope.reportError(err);
-      return this.value;
+      return this.value.toString(10);
     }
   }
 }
@@ -127,7 +127,7 @@ export class FluentDateTime extends FluentType {
       return dtf.format(this.value);
     } catch (err) {
       scope.reportError(err);
-      return this.value;
+      return (new Date(this.value)).toISOString();
     }
   }
 }

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -11,15 +11,12 @@ export class FluentType {
   /**
    * Create a `FluentType` instance.
    *
-   * @param   {Any}    value - JavaScript value to wrap.
-   * @param   {Object} opts  - Configuration.
+   * @param   {Any} value - JavaScript value to wrap.
    * @returns {FluentType}
    */
-  constructor(value, opts) {
+  constructor(value) {
     /** The wrapped native value. */
     this.value = value;
-    /** Options passed to the corresponding Intl formatter. */
-    this.opts = opts;
   }
 
   /**
@@ -81,7 +78,9 @@ export class FluentNumber extends FluentType {
    * @returns {FluentType}
    */
   constructor(value, opts) {
-    super(value, opts);
+    super(value);
+    /** Options passed to Intl.NumberFormat. */
+    this.opts = opts;
   }
 
   /**
@@ -112,7 +111,9 @@ export class FluentDateTime extends FluentType {
    * @returns {FluentType}
    */
   constructor(value, opts) {
-    super(value, opts);
+    super(value);
+    /** Options passed to Intl.DateTimeFormat. */
+    this.opts = opts;
   }
 
   /**

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -76,12 +76,12 @@ export class FluentNumber extends FluentType {
   /**
    * Create an instance of `FluentNumber` with options to the
    * `Intl.NumberFormat` constructor.
-   * @param   {(number|string)} value
+   * @param   {number} value
    * @param   {Intl.NumberFormatOptions} opts
    * @returns {FluentType}
    */
   constructor(value, opts) {
-    super(parseFloat(value), opts);
+    super(value, opts);
   }
 
   /**
@@ -107,12 +107,12 @@ export class FluentDateTime extends FluentType {
   /**
    * Create an instance of `FluentDateTime` with options to the
    * `Intl.DateTimeFormat` constructor.
-   * @param   {(Date|number|string)} value
+   * @param   {number} value
    * @param   {Intl.DateTimeFormatOptions} opts
    * @returns {FluentType}
    */
   constructor(value, opts) {
-    super(new Date(value), opts);
+    super(value, opts);
   }
 
   /**

--- a/fluent/src/types.js
+++ b/fluent/src/types.js
@@ -106,7 +106,7 @@ export class FluentDateTime extends FluentType {
   /**
    * Create an instance of `FluentDateTime` with options to the
    * `Intl.DateTimeFormat` constructor.
-   * @param   {number} value
+   * @param   {number} value - timestamp in milliseconds
    * @param   {Intl.DateTimeFormatOptions} opts
    * @returns {FluentType}
    */

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -195,7 +195,7 @@ suite('Built-in functions', function() {
       assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1475107200000');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '2016-09-29T00:00:00.000Z');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
     });
@@ -222,7 +222,7 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '-1');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1969-12-31T23:59:59.999Z');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
     });

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -177,18 +177,17 @@ suite('Built-in functions', function() {
     });
 
     test('Date argument', function () {
-      const date = new Date('2016-09-29');
-      // format the date argument to account for the testrunner's timezone
-      const expectedDefault =
-        (new Intl.DateTimeFormat('en-US')).format(date);
-      const expectedMonth =
-        (new Intl.DateTimeFormat('en-US', {month: 'long'})).format(date);
-
-      const args = {arg: date};
+      let args = {arg: new Date('2016-09-29')};
       let msg;
 
+      // Format the date argument to account for the testrunner's timezone.
+      let expectedDate =
+        (new Intl.DateTimeFormat('en-US')).format(args.arg);
+      let expectedMonth =
+        (new Intl.DateTimeFormat('en-US', {month: 'long'})).format(args.arg);
+
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedDefault);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedDate);
       assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-month');
@@ -205,14 +204,20 @@ suite('Built-in functions', function() {
       let args = {arg: -1};
       let msg;
 
+      // Format the date argument to account for the testrunner's timezone.
+      let expectedDate =
+        (new Intl.DateTimeFormat('en-US')).format(args.arg);
+      let expectedMonth =
+        (new Intl.DateTimeFormat('en-US', {month: 'long'})).format(args.arg);
+
       errors = [];
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1/1/1970');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedDate);
       assert.strictEqual(errors.length, 0);
 
       errors = [];
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), 'January');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedMonth);
       assert.strictEqual(errors.length, 0);
 
       errors = [];

--- a/fluent/test/functions_builtin_test.js
+++ b/fluent/test/functions_builtin_test.js
@@ -75,21 +75,21 @@ suite('Built-in functions', function() {
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
+      assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
 
       errors = [];
       msg = bundle.getMessage('num-percent');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
+      assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
 
       errors = [];
       msg = bundle.getMessage('num-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
+      assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
     });
 
     test('date argument', function() {
@@ -99,24 +99,19 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,475,107,200,000');
+      assert.strictEqual(errors.length, 0);
 
       errors = [];
       msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '147,510,720,000,000%');
+      assert.strictEqual(errors.length, 0);
 
       errors = [];
       msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1475107200000');
       assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to NUMBER");
+      assert.ok(errors[0] instanceof RangeError); // Invalid option value
     });
 
     test('invalid argument', function() {
@@ -201,39 +196,30 @@ suite('Built-in functions', function() {
       assert.strictEqual(errors.length, 0);
 
       msg = bundle.getMessage('dt-bad-opt');
-      // The argument value will be coerced into a string by the join operation
-      // in FluentBundle.format.  The result looks something like this; it
-      // may vary depending on the TZ:
-      //     Thu Sep 29 2016 02:00:00 GMT+0200 (CEST)
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), date.toString());
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1475107200000');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
     });
 
     test('number argument', function() {
-      let args = {arg: 1};
+      let args = {arg: -1};
       let msg;
 
       errors = [];
       msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1/1/1970');
+      assert.strictEqual(errors.length, 0);
 
       errors = [];
       msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), 'January');
+      assert.strictEqual(errors.length, 0);
 
       errors = [];
       msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '-1');
       assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
+      assert.ok(errors[0] instanceof RangeError); // Invalid option value
     });
 
     test('string argument', function() {
@@ -245,21 +231,21 @@ suite('Built-in functions', function() {
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
+      assert.strictEqual(errors[0].message, "Invalid argument to DATETIME");
 
       errors = [];
       msg = bundle.getMessage('dt-month');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
+      assert.strictEqual(errors[0].message, "Invalid argument to DATETIME");
 
       errors = [];
       msg = bundle.getMessage('dt-bad-opt');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
-      assert.strictEqual(errors[0].message, "Invalid argument type to DATETIME");
+      assert.strictEqual(errors[0].message, "Invalid argument to DATETIME");
     });
 
     test('invalid argument', function() {


### PR DESCRIPTION
This PR relaxes the type guards inthe `NUMBER` and `DATETIME` builtins. They now accept strings, `FluentNumbers`, and `FluentDateTimes`. However, if the native value of the argument results in a `NaN` during `parseFloat`, an error is thrown.

Furthermore, `FluentDateTime` now stores the date as a number, which works well with the `isNaN` check mentioned above. `DateTimeFormat.format()` converts its `Date`-typed argument to a number anyways.