### PR TITLE
fluent-react: Report errors from Localized and getString

### DIFF
--- a/fluent-react/src/localization.js
+++ b/fluent-react/src/localization.js
@@ -58,11 +58,24 @@ export default class ReactLocalization {
     if (bundle) {
       const msg = bundle.getMessage(id);
       if (msg && msg.value) {
-        return bundle.formatPattern(msg.value, args);
+        let errors = [];
+        let value = bundle.formatPattern(msg.value, args, errors);
+        for (let error of errors) {
+          this.reportError(error);
+        }
+        return value;
       }
     }
 
     return fallback || id;
+  }
+
+  // XXX Control this via a prop passed to the LocalizationProvider.
+  // See https://github.com/projectfluent/fluent.js/issues/411.
+  reportError(error) {
+    /* global console */
+    // eslint-disable-next-line no-console
+    console.warn(`[@fluent/react] ${error.name}: ${error.message}`);
   }
 }
 

--- a/fluent-react/test/localized_render_test.js
+++ b/fluent-react/test/localized_render_test.js
@@ -223,7 +223,7 @@ foo =
 
 
   test('$arg is passed to format the value', function() {
-    const bundle = new FluentBundle();
+    const bundle = new FluentBundle("en", {useIsolating: false});
     const formatPattern = sinon.spy(bundle, 'formatPattern');
     const l10n = new ReactLocalization([bundle]);
 
@@ -240,6 +240,10 @@ foo = { $arg }
 
     const { args } = formatPattern.getCall(0);
     assert.deepEqual(args[1], { arg: 'ARG' });
+
+    assert.ok(wrapper.contains(
+      <div>ARG</div>
+    ));
   });
 
   test('$arg is passed to format the attributes', function() {
@@ -249,18 +253,45 @@ foo = { $arg }
 
     bundle.addResource(new FluentResource(`
 foo = { $arg }
-    .attr = { $arg }
+    .title = { $arg }
 `));
 
     const wrapper = shallow(
-      <Localized id="foo" $arg="ARG">
+      <Localized id="foo" attrs={{title: true}} $arg="ARG">
         <div />
       </Localized>,
       { context: { l10n } }
     );
 
-    const { args } = formatPattern.getCall(0);
-    assert.deepEqual(args[1], { arg: 'ARG' });
+    // The value.
+    assert.deepEqual(formatPattern.getCall(0).args[1], { arg: 'ARG' });
+    // The attribute.
+    assert.deepEqual(formatPattern.getCall(1).args[1], { arg: 'ARG' });
+
+    assert.ok(wrapper.contains(
+      <div title="ARG">ARG</div>
+    ));
+  });
+
+  test('A missing $arg does not break rendering', function() {
+    const bundle = new FluentBundle("en", {useIsolating: false});
+    const l10n = new ReactLocalization([bundle]);
+
+    bundle.addResource(new FluentResource(`
+foo = { $arg }
+    .title = { $arg }
+`));
+
+    const wrapper = shallow(
+      <Localized id="foo" attrs={{title: true}}>
+        <div />
+      </Localized>,
+      { context: { l10n } }
+    );
+
+    assert.ok(wrapper.contains(
+      <div title="{$arg}">{"{$arg}"}</div>
+    ));
   });
 
   test('render with a fragment and no message preserves the fragment',

--- a/fluent-react/test/with_localization_test.js
+++ b/fluent-react/test/with_localization_test.js
@@ -31,12 +31,13 @@ suite('withLocalization', function() {
   });
 
   test('getString with access to the l10n context', function() {
-    const bundle = new FluentBundle();
+    const bundle = new FluentBundle("en", {useIsolating: false});
     const l10n = new ReactLocalization([bundle]);
     const EnhancedComponent = withLocalization(DummyComponent);
 
     bundle.addResource(new FluentResource(`
 foo = FOO
+bar = BAR {$arg}
 `));
 
     const wrapper = shallow(
@@ -47,15 +48,19 @@ foo = FOO
     const getString = wrapper.prop('getString');
     // Returns the translation.
     assert.strictEqual(getString('foo', {}), 'FOO');
+    assert.strictEqual(getString('bar', {arg: 'ARG'}), 'BAR ARG');
+    // Doesn't throw on formatting errors.
+    assert.strictEqual(getString('bar', {}), 'BAR {$arg}');
   });
 
   test('getString with access to the l10n context, with fallback value', function() {
-    const bundle = new FluentBundle();
+    const bundle = new FluentBundle("en", {useIsolating: false});
     const l10n = new ReactLocalization([bundle]);
     const EnhancedComponent = withLocalization(DummyComponent);
 
     bundle.addResource(new FluentResource(`
 foo = FOO
+bar = BAR {$arg}
 `));
 
     const wrapper = shallow(
@@ -65,7 +70,12 @@ foo = FOO
 
     const getString = wrapper.prop('getString');
     // Returns the translation, even if fallback value provided.
-    assert.strictEqual(getString('bar', {}, 'fallback'), 'fallback');
+    assert.strictEqual(getString('foo', {}, 'fallback'), 'FOO');
+    // Returns the fallback.
+    assert.strictEqual(getString('missing', {}, 'fallback'), 'fallback');
+    assert.strictEqual(getString('bar', {arg: 'ARG'}), 'BAR ARG');
+    // Doesn't throw on formatting errors.
+    assert.strictEqual(getString('bar', {}), 'BAR {$arg}');
   });
 
   test('getString without access to the l10n context', function() {


### PR DESCRIPTION
Another bug found in https://bugzilla.mozilla.org/show_bug.cgi?id=1568914. In #390 we made `formatPattern` throw when `errors` is not passed as the third argument. React doesn't like it when things throw in `render`. Let's `console.warn` the errors for now, and then let allow more control over error reporting in #411.