### PR TITLE
Allow whitespace before CallArguments (fixes #421)

### DIFF
--- a/fluent-syntax/src/parser.js
+++ b/fluent-syntax/src/parser.js
@@ -676,7 +676,9 @@ class FluentParser {
       }
 
       let args;
-      if (ps.currentChar === "(") {
+      ps.peekBlank();
+      if (ps.currentPeek === "(") {
+        ps.skipToPeek();
         args = this.getCallArguments(ps);
       }
 
@@ -685,13 +687,15 @@ class FluentParser {
 
     if (ps.isIdentifierStart()) {
       const id = this.getIdentifier(ps);
+      ps.peekBlank();
 
-      if (ps.currentChar === "(") {
+      if (ps.currentPeek === "(") {
         // It's a Function. Ensure it's all upper-case.
         if (!/^[A-Z][A-Z0-9_-]*$/.test(id.name)) {
           throw new ParseError("E0008");
         }
 
+        ps.skipToPeek();
         let args = this.getCallArguments(ps);
         return new AST.FunctionReference(id, args);
       }

--- a/fluent-syntax/test/fixtures_reference/call_expressions.ftl
+++ b/fluent-syntax/test/fixtures_reference/call_expressions.ftl
@@ -29,14 +29,15 @@ duplicate-named-args = {FUN(x: 1, x: "X")}
 
 ## Whitespace around arguments
 
-sparse-inline-call = {FUN(  "a"  , msg,   x: 1   )}
+sparse-inline-call = {FUN     (  "a"  , msg,   x: 1   )}
 empty-inline-call = {FUN(  )}
 multiline-call = {FUN(
         "a",
         msg,
         x: 1
     )}
-sparse-multiline-call = {FUN(
+sparse-multiline-call = {FUN
+    (
 
         "a"    ,
         msg

--- a/fluent-syntax/test/fixtures_reference/term_parameters.ftl
+++ b/fluent-syntax/test/fixtures_reference/term_parameters.ftl
@@ -3,6 +3,6 @@
 }
 
 key01 = { -term }
-key02 = { -term() }
+key02 = { -term () }
 key03 = { -term(arg: 1) }
 key04 = { -term("positional", narg1: 1, narg2: 2) }


### PR DESCRIPTION
This is picking up the tests for https://github.com/projectfluent/fluent/issues/281,
and adjusts the parser to pass those tests.

I'm not happy with the peek, but this is what makes the tests pass.