### PR TITLE
Update README to point at Discourse instead of IRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ to contribute to, please do get in touch on the mailing list and the IRC
 channel.
 
  - mailing list: https://lists.mozilla.org/listinfo/tools-l10n
- - IRC channel: [irc://irc.mozilla.org/l20n](irc://irc.mozilla.org/l20n)
+ - Discourse: https://discourse.mozilla.org/c/fluent
 
 
 Get Involved


### PR DESCRIPTION
I recently posted a question to the Fluent team in the IRC channel and Pike helpfully redirected me to the Discourse, noting that the IRC was going to shut down. I figured it might be helpful to update the README to point at Discourse accordingly?