### PR TITLE
Use a running count of resolved placeables to protect against denial of service attacks

### DIFF
--- a/fluent-bundle/src/resolver.js
+++ b/fluent-bundle/src/resolver.js
@@ -88,7 +88,7 @@ function getArguments(scope, args) {
     }
   }
 
-  return [positional, named];
+  return {positional, named};
 }
 
 // Resolve an expression to a Fluent type.
@@ -117,14 +117,22 @@ function resolveExpression(scope, expr) {
 
 // Resolve a reference to a variable.
 function VariableReference(scope, {name}) {
-  if (!scope.args || !scope.args.hasOwnProperty(name)) {
-    if (scope.insideTermReference === false) {
-      scope.reportError(new ReferenceError(`Unknown variable: $${name}`));
+  let arg;
+  if (scope.params) {
+    // We're inside a TermReference. It's OK to reference undefined parameters.
+    if (scope.params.hasOwnProperty(name)) {
+      arg = scope.params[name];
+    } else {
+      return new FluentNone(`$${name}`);
     }
+  } else if (scope.args && scope.args.hasOwnProperty(name)) {
+    // We're in the top-level Pattern or inside a MessageReference. Missing
+    // variables references produce ReferenceErrors.
+    arg = scope.args[name];
+  } else {
+    scope.reportError(new ReferenceError(`Unknown variable: $${name}`));
     return new FluentNone(`$${name}`);
   }
-
-  const arg = scope.args[name];
 
   // Return early if the argument already is an instance of FluentType.
   if (arg instanceof FluentType) {
@@ -183,20 +191,23 @@ function TermReference(scope, {name, attr, args}) {
     return new FluentNone(id);
   }
 
-  // Every TermReference has its own variables.
-  const [, params] = getArguments(scope, args);
-  const local = scope.cloneForTermReference(params);
-
   if (attr) {
     const attribute = term.attributes[attr];
     if (attribute) {
-      return resolvePattern(local, attribute);
+      // Every TermReference has its own variables.
+      scope.params = getArguments(scope, args).named;
+      const resolved = resolvePattern(scope, attribute);
+      scope.params = null;
+      return resolved;
     }
     scope.reportError(new ReferenceError(`Unknown attribute: ${attr}`));
     return new FluentNone(`${id}.${attr}`);
   }
 
-  return resolvePattern(local, term.value);
+  scope.params = getArguments(scope, args).named;
+  const resolved = resolvePattern(scope, term.value);
+  scope.params = null;
+  return resolved;
 }
 
 // Resolve a call to a Function with positional and key-value arguments.
@@ -215,7 +226,8 @@ function FunctionReference(scope, {name, args}) {
   }
 
   try {
-    return func(...getArguments(scope, args));
+    let resolved = getArguments(scope, args);
+    return func(resolved.positional, resolved.named);
   } catch (err) {
     scope.reportError(err);
     return new FluentNone(`${name}()`);

--- a/fluent-bundle/src/resource.js
+++ b/fluent-bundle/src/resource.js
@@ -48,10 +48,6 @@ const TOKEN_COLON = /\s*:\s*/y;
 const TOKEN_COMMA = /\s*,?\s*/y;
 const TOKEN_BLANK = /\s+/y;
 
-// Maximum number of placeables in a single Pattern to protect against Quadratic
-// Blowup attacks. See https://msdn.microsoft.com/en-us/magazine/ee335713.aspx.
-const MAX_PLACEABLES = 100;
-
 /**
  * Fluent Resource is a structure storing parsed localization entries.
  */
@@ -216,8 +212,6 @@ export default class FluentResource {
 
     // Parse a complex pattern as an array of elements.
     function parsePatternElements(elements = [], commonIndent) {
-      let placeableCount = 0;
-
       while (true) {
         if (test(RE_TEXT_RUN)) {
           elements.push(match1(RE_TEXT_RUN));
@@ -225,9 +219,6 @@ export default class FluentResource {
         }
 
         if (source[cursor] === "{") {
-          if (++placeableCount > MAX_PLACEABLES) {
-            throw new FluentError("Too many placeables");
-          }
           elements.push(parsePlaceable());
           continue;
         }

--- a/fluent-bundle/src/scope.js
+++ b/fluent-bundle/src/scope.js
@@ -3,7 +3,6 @@ export default class Scope {
     bundle,
     errors,
     args,
-    insideTermReference = false,
     dirty = new WeakSet()
   ) {
     /** The bundle for which the given resolution is happening. */
@@ -13,15 +12,21 @@ export default class Scope {
     /** A dict of developer-provided variables. */
     this.args = args;
 
-    /** Term references require different variable lookup logic. */
-    this.insideTermReference = insideTermReference;
     /** The Set of patterns already encountered during this resolution.
       * Used to detect and prevent cyclic resolutions. */
     this.dirty = dirty;
+    /** Term references require different variable lookup logic. */
+    this.insideTermReference = false;
+    /** The running count of placeables resolved so far. Used to detect the
+      * Billion Laughs and Quadratic Blowup attacks. */
+    this.placeables = 0;
   }
 
   cloneForTermReference(args) {
-    return new Scope(this.bundle, this.errors, args, true, this.dirty);
+    let scope = new Scope(this.bundle, this.errors, args, this.dirty);
+    scope.insideTermReference = true;
+    scope.placeables = this.placeables;
+    return scope;
   }
 
   reportError(error) {

--- a/fluent-bundle/src/scope.js
+++ b/fluent-bundle/src/scope.js
@@ -1,10 +1,5 @@
 export default class Scope {
-  constructor(
-    bundle,
-    errors,
-    args,
-    dirty = new WeakSet()
-  ) {
+  constructor(bundle, errors, args) {
     /** The bundle for which the given resolution is happening. */
     this.bundle = bundle;
     /** The list of errors collected while resolving. */
@@ -14,19 +9,12 @@ export default class Scope {
 
     /** The Set of patterns already encountered during this resolution.
       * Used to detect and prevent cyclic resolutions. */
-    this.dirty = dirty;
-    /** Term references require different variable lookup logic. */
-    this.insideTermReference = false;
+    this.dirty = new WeakSet();
+    /** A dict of parameters passed to a TermReference. */
+    this.params = null;
     /** The running count of placeables resolved so far. Used to detect the
       * Billion Laughs and Quadratic Blowup attacks. */
     this.placeables = 0;
-  }
-
-  cloneForTermReference(args) {
-    let scope = new Scope(this.bundle, this.errors, args, this.dirty);
-    scope.insideTermReference = true;
-    scope.placeables = this.placeables;
-    return scope;
   }
 
   reportError(error) {


### PR DESCRIPTION
Remove the arbitrary limit imposed on the length of resolved placeables. Instead, keep a running count of how many placeables there have been so far in the current call to `formatPattern`. This includes all nested placeables, preventing deeply nested hierarchies of references from eating up the memory and the CPU during resolution.