### PR TITLE
(@fluent/react) Don't call createParseMarkup() in the default context

### DIFF
--- a/fluent-react/src/context.js
+++ b/fluent-react/src/context.js
@@ -1,4 +1,4 @@
 import { createContext } from "react";
 import ReactLocalization from "./localization";
 
-export default createContext(new ReactLocalization([]));
+export default createContext(new ReactLocalization([], null));

--- a/fluent-react/src/localized.js
+++ b/fluent-react/src/localized.js
@@ -135,7 +135,7 @@ function Localized(props) {
 
   // If the message value doesn't contain any markup nor any HTML entities,
   // insert it as the only child of the wrapped component.
-  if (!reMarkup.test(messageValue)) {
+  if (!reMarkup.test(messageValue) || l10n.parseMarkup === null) {
     return cloneElement(child, localizedProps, messageValue);
   }
 

--- a/fluent-react/test/localized_overlay.test.js
+++ b/fluent-react/test/localized_overlay.test.js
@@ -799,6 +799,27 @@ foo = BEFORE <text-elem>Foo</text-elem> AFTER
 });
 
 describe("Localized - custom parseMarkup", () => {
+  test("disables the overlay logic if null", () => {
+    const bundle = new FluentBundle();
+    bundle.addResource(new FluentResource(`
+foo = test <em>null markup parser</em>
+`));
+
+    const renderer = TestRenderer.create(
+      <LocalizationProvider bundles={[bundle]} parseMarkup={null}>
+        <Localized id="foo">
+          <div />
+        </Localized>
+      </LocalizationProvider>
+    );
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      <div>
+        test &lt;em&gt;null markup parser&lt;/em&gt;
+      </div>
+    `);
+  });
+
   test("is called if defined in the context", () => {
     let parseMarkupCalls = [];
 


### PR DESCRIPTION
Allow passing `null` as `parseMarkup` to disable the support for any markup in translations.

Fix #452.