### PR TITLE
(@fluent/react) Pass instances of ReactLocalization to LocalizationProvider

### DIFF
--- a/fluent-react/src/index.ts
+++ b/fluent-react/src/index.ts
@@ -7,7 +7,7 @@
  * React's Components system and the virtual DOM.  Translations are exposed to
  * components via the provider pattern.
  *
- *     <LocalizationProvider bundles={…}>
+ *     <LocalizationProvider l10n={…}>
  *         <Localized id="hello-world">
  *             <p>{'Hello, world!'}</p>
  *         </Localized>
@@ -17,6 +17,7 @@
  * components for more information.
  */
 
+export { ReactLocalization} from "./localization";
 export { MemoLocalizationProvider as LocalizationProvider } from "./provider";
 export { withLocalization, WithLocalizationProps } from "./with_localization";
 export { Localized, LocalizedProps } from "./localized";

--- a/fluent-react/src/index.ts
+++ b/fluent-react/src/index.ts
@@ -18,7 +18,7 @@
  */
 
 export { ReactLocalization} from "./localization";
-export { MemoLocalizationProvider as LocalizationProvider } from "./provider";
+export { LocalizationProvider } from "./provider";
 export { withLocalization, WithLocalizationProps } from "./with_localization";
 export { Localized, LocalizedProps } from "./localized";
 export { MarkupParser } from "./markup";

--- a/fluent-react/src/provider.ts
+++ b/fluent-react/src/provider.ts
@@ -25,14 +25,6 @@ interface LocalizationProviderProps {
  * under the provider.
  */
 function LocalizationProvider(props: LocalizationProviderProps): ReactElement {
-  if (props.l10n === undefined) {
-    throw new Error("LocalizationProvider must receive the l10n prop.");
-  }
-
-  if (!(props.l10n instanceof ReactLocalization)) {
-    throw new Error("The bundles prop must be an iterable.");
-  }
-
   return createElement(
     FluentContext.Provider,
     {
@@ -44,30 +36,7 @@ function LocalizationProvider(props: LocalizationProviderProps): ReactElement {
 
 LocalizationProvider.propTypes = {
   children: PropTypes.element.isRequired,
-  l10n: isReactLocalization,
+  l10n: PropTypes.instanceOf(ReactLocalization).isRequired,
 };
-
-function isReactLocalization(
-  props: Record<string, unknown>,
-  propName: string,
-  componentName: string
-): null | Error {
-  const prop = props[propName];
-
-  if (!prop) {
-    return new Error(
-      `The ${propName} prop supplied to ${componentName} is required.`
-    );
-  }
-
-  if (prop instanceof ReactLocalization) {
-    return null;
-  }
-
-  return new Error(
-    `The ${propName} prop supplied to ${componentName} must be an instance \
-of ReactLocalization.`
-  );
-}
 
 export const MemoLocalizationProvider = memo(LocalizationProvider);

--- a/fluent-react/src/provider.ts
+++ b/fluent-react/src/provider.ts
@@ -1,4 +1,4 @@
-import { createElement, ReactNode, ReactElement, memo } from "react";
+import { createElement, ReactNode, ReactElement } from "react";
 import PropTypes from "prop-types";
 import { FluentContext } from "./context";
 import { ReactLocalization } from "./localization";
@@ -24,7 +24,9 @@ interface LocalizationProviderProps {
  * `l10n` prop. This instance will be made available to `Localized` components
  * under the provider.
  */
-function LocalizationProvider(props: LocalizationProviderProps): ReactElement {
+export function LocalizationProvider(
+  props: LocalizationProviderProps
+): ReactElement {
   return createElement(
     FluentContext.Provider,
     {
@@ -38,5 +40,3 @@ LocalizationProvider.propTypes = {
   children: PropTypes.element.isRequired,
   l10n: PropTypes.instanceOf(ReactLocalization).isRequired,
 };
-
-export const MemoLocalizationProvider = memo(LocalizationProvider);

--- a/fluent-react/test/localized_change.test.js
+++ b/fluent-react/test/localized_change.test.js
@@ -1,11 +1,12 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { LocalizationProvider, Localized } from "../esm/index";
+import { ReactLocalization, LocalizationProvider, Localized }
+  from "../esm/index";
 
 test("relocalizes", () => {
-  const Root = ({ bundle }) => (
-    <LocalizationProvider bundles={[bundle]}>
+  const Root = ({ l10n }) => (
+    <LocalizationProvider l10n={l10n}>
       <Localized id="foo">
         <div />
       </Localized>
@@ -16,7 +17,7 @@ test("relocalizes", () => {
   bundle1.addResource(new FluentResource(`
 foo = FOO
 `));
-  const renderer = TestRenderer.create(<Root bundle={bundle1} />);
+  const renderer = TestRenderer.create(<Root l10n={new ReactLocalization([bundle1])} />);
   expect(renderer.toJSON()).toMatchInlineSnapshot(`
     <div>
       FOO
@@ -27,7 +28,7 @@ foo = FOO
   bundle2.addResource(new FluentResource(`
 foo = BAR
 `));
-  renderer.update(<Root bundle={bundle2} />);
+  renderer.update(<Root l10n={new ReactLocalization([bundle2])} />);
   expect(renderer.toJSON()).toMatchInlineSnapshot(`
     <div>
       BAR

--- a/fluent-react/test/localized_fallback.test.js
+++ b/fluent-react/test/localized_fallback.test.js
@@ -1,17 +1,17 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { LocalizationProvider, Localized } from "../esm/index";
+import { ReactLocalization, LocalizationProvider, Localized }
+  from "../esm/index";
 
 test("uses message from 1st bundle", () => {
   const bundle1 = new FluentBundle();
-
   bundle1.addResource(new FluentResource(`
 foo = FOO
 `));
 
   const renderer = TestRenderer.create(
-    <LocalizationProvider bundles={[bundle1]}>
+    <LocalizationProvider l10n={new ReactLocalization([bundle1])}>
       <Localized id="foo">
         <div>Bar</div>
       </Localized>
@@ -37,7 +37,7 @@ foo = FOO
 `));
 
   const renderer = TestRenderer.create(
-    <LocalizationProvider bundles={[bundle1, bundle2]}>
+    <LocalizationProvider l10n={new ReactLocalization([bundle1, bundle2])}>
       <Localized id="foo">
         <div>Bar</div>
       </Localized>
@@ -53,13 +53,12 @@ foo = FOO
 
 test("falls back back for missing message", function() {
   const bundle1 = new FluentBundle();
-
   bundle1.addResource(new FluentResource(`
 not-foo = NOT FOO
 `));
 
   const renderer = TestRenderer.create(
-    <LocalizationProvider bundles={[bundle1]}>
+    <LocalizationProvider l10n={new ReactLocalization([bundle1])}>
       <Localized id="foo">
         <div>Bar</div>
       </Localized>

--- a/fluent-react/test/localized_overlay.test.js
+++ b/fluent-react/test/localized_overlay.test.js
@@ -2,7 +2,8 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
 import { createParseMarkup } from "../esm/markup";
-import { LocalizationProvider, Localized } from "../esm/index";
+import { ReactLocalization, LocalizationProvider, Localized }
+  from "../esm/index";
 
 describe("Localized - overlay", () => {
   test("< in text", () => {
@@ -13,7 +14,7 @@ true = 0 < 3 is true.
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="true">
           <div />
         </Localized>
@@ -35,7 +36,7 @@ megaman = Jumping & Shooting
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="megaman">
           <div />
         </Localized>
@@ -57,7 +58,7 @@ two = First &middot; Second
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="two">
           <div />
         </Localized>
@@ -79,7 +80,7 @@ foo = Click <button>me</button>!
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{button: <button onClick={alert}></button>}}>
           <div />
         </Localized>
@@ -109,7 +110,7 @@ foo = Click <button>me</button>!
     // The Button prop is capitalized whereas the <button> element in the
     // translation is lowercase.
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{Button: <button onClick={alert}></button>}}>
           <div />
         </Localized>
@@ -137,7 +138,7 @@ foo = <confirm>Sign in</confirm> or <cancel>cancel</cancel>.
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized
           id="foo"
           elems={{
@@ -176,7 +177,7 @@ foo = <confirm>Sign in</confirm> or <cancel>cancel</cancel>.
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{
             confirm: <button className="confirm"></button>
         }}>
@@ -207,7 +208,7 @@ foo = <confirm>Sign in</confirm>.
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized
           id="foo"
           elems={{
@@ -240,7 +241,7 @@ foo = Click <button className="foo">me</button>!
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{button: <button onClick={alert}></button>}}>
           <div />
         </Localized>
@@ -268,7 +269,7 @@ foo = Click <button><em>me</em></button>!
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{button: <button onClick={alert}></button>}}>
           <div />
         </Localized>
@@ -296,7 +297,7 @@ foo = <confirm>Sign in</confirm>.
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{confirm: "Not a React element"}}>
           <div />
         </Localized>
@@ -323,7 +324,7 @@ foo = BEFORE <input/> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{input: <input type="text" />}}>
           <div />
         </Localized>
@@ -349,7 +350,7 @@ foo = BEFORE <input></input> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{input: <input type="text" />}}>
           <div />
         </Localized>
@@ -375,7 +376,7 @@ foo = BEFORE <input>Foo</input> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{input: <input type="text" />}}>
           <div />
         </Localized>
@@ -403,7 +404,7 @@ foo = BEFORE <input/> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{input: <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -429,7 +430,7 @@ foo = BEFORE <input></input> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{input: <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -455,7 +456,7 @@ foo = BEFORE <input>Foo</input> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{input: <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -483,7 +484,7 @@ foo = BEFORE <span/> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{span: <input type="text" />}}>
           <div />
         </Localized>
@@ -513,7 +514,7 @@ foo = BEFORE <span></span> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{span: <input type="text" />}}>
           <div />
         </Localized>
@@ -539,7 +540,7 @@ foo = BEFORE <span>Foo</span> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{span: <input type="text" />}}>
           <div />
         </Localized>
@@ -565,7 +566,7 @@ foo = BEFORE <span/> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{span: <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -594,7 +595,7 @@ foo = BEFORE <span></span> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{span: <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -620,7 +621,7 @@ foo = BEFORE <span>Foo</span> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{span: <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -646,7 +647,7 @@ foo = BEFORE <text-input/> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{"text-input": <input type="text" />}}>
           <div />
         </Localized>
@@ -676,7 +677,7 @@ foo = BEFORE <text-input></text-input> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{"text-input": <input type="text" />}}>
           <div />
         </Localized>
@@ -702,7 +703,7 @@ foo = BEFORE <text-input>Foo</text-input> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{"text-input": <input type="text" />}}>
           <div />
         </Localized>
@@ -728,7 +729,7 @@ foo = BEFORE <text-elem/> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{"text-elem": <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -758,7 +759,7 @@ foo = BEFORE <text-elem></text-elem> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{"text-elem": <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -784,7 +785,7 @@ foo = BEFORE <text-elem>Foo</text-elem> AFTER
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" elems={{"text-elem": <span>Hardcoded</span>}}>
           <div />
         </Localized>
@@ -811,7 +812,7 @@ foo = test <em>null markup parser</em>
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]} parseMarkup={null}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle], null)}>
         <Localized id="foo">
           <div />
         </Localized>
@@ -841,7 +842,7 @@ foo = test <em>custom markup parser</em>
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]} parseMarkup={parseMarkup}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle], parseMarkup)}>
         <Localized id="foo">
           <div />
         </Localized>
@@ -869,7 +870,7 @@ foo = test <em>custom markup parser</em>
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]} parseMarkup={parseMarkup}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle], parseMarkup)}>
         <Localized id="foo">
           <div />
         </Localized>

--- a/fluent-react/test/localized_render.test.js
+++ b/fluent-react/test/localized_render.test.js
@@ -1,7 +1,8 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { LocalizationProvider, Localized } from "../esm/index";
+import { ReactLocalization, LocalizationProvider, Localized }
+  from "../esm/index";
 
 describe("Localized - rendering", () => {
   test("render the value", () => {
@@ -14,7 +15,7 @@ foo = FOO
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <div />
         </Localized>
@@ -39,7 +40,7 @@ foo =
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ attr: true }}>
           <div />
         </Localized>
@@ -65,7 +66,7 @@ foo =
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ attr2: true }}>
           <div />
         </Localized>
@@ -90,7 +91,7 @@ foo =
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ attr: false }}>
           <div />
         </Localized>
@@ -111,7 +112,7 @@ foo =
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <div />
         </Localized>
@@ -132,7 +133,7 @@ foo =
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ attr: true }}>
           <div existing={true} />
         </Localized>
@@ -158,7 +159,7 @@ foo =
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ existing: true }}>
           <div existing={true} />
         </Localized>
@@ -181,7 +182,7 @@ foo =
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ existing: false }}>
           <div existing={true} />
         </Localized>
@@ -204,7 +205,7 @@ foo =
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <div existing={true} />
         </Localized>
@@ -227,7 +228,7 @@ foo =
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ title: true }}>
           <select>
             <option>Option</option>
@@ -256,7 +257,7 @@ foo = { $arg }
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" vars={{arg: "ARG"}}>
           <div />
         </Localized>
@@ -284,7 +285,7 @@ foo = { $arg }
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ title: true }} vars={{arg: "ARG"}}>
           <div />
         </Localized>
@@ -313,7 +314,7 @@ foo = { $arg }
     const bundle = new FluentBundle();
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <React.Fragment>
             <div>Fragment content</div>
@@ -340,7 +341,7 @@ foo = { $arg }
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ title: true }}>
           <div />
         </Localized>
@@ -364,7 +365,7 @@ foo =
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <React.Fragment>
             <div>Fragment content</div>
@@ -387,7 +388,7 @@ foo = Test message
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <React.Fragment>
             <div>Fragment content</div>
@@ -403,7 +404,7 @@ foo = Test message
     const bundle = new FluentBundle();
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <React.Fragment />
         </Localized>
@@ -421,7 +422,7 @@ foo =
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <React.Fragment />
         </Localized>
@@ -438,7 +439,7 @@ foo = Test message
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <React.Fragment />
         </Localized>
@@ -452,7 +453,7 @@ foo = Test message
     const bundle = new FluentBundle();
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">String fallback</Localized>
       </LocalizationProvider>
     );
@@ -467,7 +468,7 @@ foo = Test message
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">String fallback</Localized>
       </LocalizationProvider>
     );
@@ -483,7 +484,7 @@ foo = Message
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" />
       </LocalizationProvider>
     );
@@ -495,7 +496,7 @@ foo = Message
     const bundle = new FluentBundle();
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" />
       </LocalizationProvider>
     );

--- a/fluent-react/test/localized_valid.test.js
+++ b/fluent-react/test/localized_valid.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import { LocalizationProvider, Localized } from "../esm/index";
+import { ReactLocalization, LocalizationProvider, Localized } from "../esm/index";
 
 describe("Localized - validation", () => {
   let consoleError = console.error;
@@ -15,7 +15,7 @@ describe("Localized - validation", () => {
 
   test("inside of a LocalizationProvider", () => {
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[]}>
+      <LocalizationProvider l10n={new ReactLocalization([])}>
         <Localized>
           <div />
         </Localized>
@@ -27,23 +27,9 @@ describe("Localized - validation", () => {
 
   test("outside of a LocalizationProvider", () => {
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[]}>
-        <Localized>
-          <div />
-        </Localized>
-      </LocalizationProvider>
-    );
-
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
-  });
-
-  test("with a manually set context", () => {
-    const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[]}>
-        <Localized>
-          <div />
-        </Localized>
-      </LocalizationProvider>
+      <Localized>
+        <div />
+      </Localized>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
@@ -51,7 +37,7 @@ describe("Localized - validation", () => {
 
   test("without a child", () => {
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[]}>
+      <LocalizationProvider l10n={new ReactLocalization([])}>
         <Localized />
       </LocalizationProvider>
     );
@@ -62,7 +48,7 @@ describe("Localized - validation", () => {
   test("with multiple children", () => {
     expect(() => {
       TestRenderer.create(
-        <LocalizationProvider bundles={[]}>
+        <LocalizationProvider l10n={new ReactLocalization([])}>
           <Localized>
             <div />
             <div />
@@ -74,7 +60,7 @@ describe("Localized - validation", () => {
 
   test("without id", () => {
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[]}>
+      <LocalizationProvider l10n={new ReactLocalization([])}>
         <Localized>
           <div />
         </Localized>

--- a/fluent-react/test/localized_void.test.js
+++ b/fluent-react/test/localized_void.test.js
@@ -1,7 +1,8 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { LocalizationProvider, Localized } from "../esm/index";
+import { ReactLocalization, LocalizationProvider, Localized }
+  from "../esm/index";
 
 describe("Localized - void elements", function() {
   test("do not render the value in void elements", function() {
@@ -12,7 +13,7 @@ foo = FOO
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo">
           <input />
         </Localized>
@@ -31,7 +32,7 @@ foo =
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ title: true }}>
           <input />
         </Localized>
@@ -54,7 +55,7 @@ foo = FOO
 `));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <Localized id="foo" attrs={{ title: true }}>
           <input />
         </Localized>

--- a/fluent-react/test/provider_valid.test.js
+++ b/fluent-react/test/provider_valid.test.js
@@ -37,28 +37,4 @@ describe("LocalizationProvider - validation", () => {
       TestRenderer.create(<LocalizationProvider />);
     }).toThrow(/marked as required/);
   });
-
-  test("is memoized (no re-render) when props are the same", () => {
-    const l10n = new ReactLocalization([]);
-    const mockFn = jest.fn();
-
-    function MockComponent() {
-      mockFn();
-      return "A mock component";
-    }
-
-    let renderer = TestRenderer.create(
-      <LocalizationProvider l10n={l10n}>
-        <MockComponent />
-      </LocalizationProvider>
-    );
-    act(() => {
-      renderer = renderer.update(
-        <LocalizationProvider l10n={l10n}>
-          <MockComponent />
-        </LocalizationProvider>
-      );
-    });
-    expect(mockFn).toHaveBeenCalledTimes(1);
-  });
 });

--- a/fluent-react/test/provider_valid.test.js
+++ b/fluent-react/test/provider_valid.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer, {act} from "react-test-renderer";
-import { LocalizationProvider } from "../esm/index";
+import { ReactLocalization, LocalizationProvider } from "../esm/index";
 
 describe("LocalizationProvider - validation", () => {
   let consoleError = console.error;
@@ -19,7 +19,7 @@ describe("LocalizationProvider - validation", () => {
 
   test("valid use", () => {
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[]}>
+      <LocalizationProvider l10n={new ReactLocalization([])}>
         <div />
       </LocalizationProvider>
     );
@@ -28,29 +28,37 @@ describe("LocalizationProvider - validation", () => {
 
   test("without a child", () => {
     expect(() => {
-      TestRenderer.create(<LocalizationProvider bundles={[]} />);
+      TestRenderer.create(<LocalizationProvider l10n={new ReactLocalization([])} />);
     }).toThrow(/required/);
   });
 
-  test("without bundles", () => {
+  test("without the l10n prop", () => {
     expect(() => {
       TestRenderer.create(<LocalizationProvider />);
     }).toThrow(/is required/);
   });
 
-  test("without iterable bundles", () => {
-    expect(() => {
-      TestRenderer.create(<LocalizationProvider bundles={0} />);
-    }).toThrow(/must be an iterable/);
-  });
-
   test("is memoized (no re-render) when props are the same", () => {
-    const bundles = [];
-    const spy = jest.spyOn(bundles, Symbol.iterator);
-    let renderer = TestRenderer.create(<LocalizationProvider bundles={bundles} />);
+    const l10n = new ReactLocalization([]);
+    const mockFn = jest.fn();
+
+    function MockComponent() {
+      mockFn();
+      return "A mock component";
+    }
+
+    let renderer = TestRenderer.create(
+      <LocalizationProvider l10n={l10n}>
+        <MockComponent />
+      </LocalizationProvider>
+    );
     act(() => {
-      renderer = renderer.update(<LocalizationProvider bundles={bundles} />);
+      renderer = renderer.update(
+        <LocalizationProvider l10n={l10n}>
+          <MockComponent />
+        </LocalizationProvider>
+      );
     });
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/fluent-react/test/provider_valid.test.js
+++ b/fluent-react/test/provider_valid.test.js
@@ -35,7 +35,7 @@ describe("LocalizationProvider - validation", () => {
   test("without the l10n prop", () => {
     expect(() => {
       TestRenderer.create(<LocalizationProvider />);
-    }).toThrow(/is required/);
+    }).toThrow(/marked as required/);
   });
 
   test("is memoized (no re-render) when props are the same", () => {

--- a/fluent-react/test/with_localization.test.js
+++ b/fluent-react/test/with_localization.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { LocalizationProvider, withLocalization } from "../esm/index";
+import { ReactLocalization, LocalizationProvider, withLocalization } from "../esm/index";
 
 function DummyComponent() {
   return <div />;
@@ -12,7 +12,7 @@ describe("withLocalization", () => {
     const EnhancedComponent = withLocalization(DummyComponent);
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[]}>
+      <LocalizationProvider l10n={new ReactLocalization([])}>
         <EnhancedComponent />
       </LocalizationProvider>
     );
@@ -38,7 +38,7 @@ bar = BAR {$arg}
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <EnhancedComponent />
       </LocalizationProvider>
     );
@@ -63,7 +63,7 @@ bar = BAR {$arg}
     );
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[bundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
         <EnhancedComponent />
       </LocalizationProvider>
     );
@@ -107,7 +107,7 @@ bar = BAR {$arg}
     initialBundle.addResource(new FluentResource("foo = FOO"));
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider bundles={[initialBundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([initialBundle])}>
         <EnhancedComponent />
       </LocalizationProvider>
     );
@@ -118,7 +118,7 @@ bar = BAR {$arg}
     newBundle.addResource(new FluentResource("foo = BAR"));
 
     renderer.update(
-      <LocalizationProvider bundles={[newBundle]}>
+      <LocalizationProvider l10n={new ReactLocalization([newBundle])}>
         <EnhancedComponent />
       </LocalizationProvider>
     );


### PR DESCRIPTION
This PR changes the API from ↓

```ts
<LocalizationProvider bundles={bundlesIterable} />
```

to ↓

```ts
let l10n = new ReactLocalization(bundlesIterable);
<LocalizationProvider l10n={l10n} />
```

In the old API, the `LocalizationProvider ` would automatically create a `ReactLocalization` instance. In the new API, the instance must be explicitly created by the developer. The reasoning behind this change are as follows:

- It's reasonable to expect that consumers will store `bundlesIterable` in their app's state.
- The app might re-render multiple times given the same state, and we should then produce the same result for each render.
- When `bundlesIterable` is an array, this works as expect.
- When `bundlesIterable` is a generator, it keeps its own state, and re-renders might change it, or even deplete it. 
  - The current implementation of `LocalizationProvider` internally creates a new `ReactLocalization` using `bundlesIterator` and uses it as the value for the `FluentContext`.
  - The new value of the context triggers re-renders of `Localized` descendants. 
  - The bundles yielded by the generator are cached in the internal `ReactLocalization` instance, but that instance is then thrown away when `LocalizationProvider` re-renders.
  - This results in `Localized` translating the app into a fallback language, or into the fallbacks stored in the source.
- React's `PureComponent` and `memo` might offer a away to remedy this situation, but I haven't been able to get them to work reliably. More importantly, the React docs are very clear about the fact that `memo` should not be used to fix these kind of bugs:

    > This method only exists as a performance optimization. Do not rely on it to “prevent” a render, as this can lead to bugs.

    And a similar note about the `useMemo` hook:

    > You may rely on useMemo as a performance optimization, not as a semantic guarantee. In the future, React may choose to “forget” some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. Write your code so that it still works without useMemo — and then add it to optimize performance.

- In contrast to generators, instances of `ReactLocalization` are safe to store in the app's state. Internally, the cached bundles yielded from `bundlesIterator` persist as long as the same `ReactLocalization` instance is used for all re-renders.

Interestingly, with this PR, we might not even need `LocalizationProvider` at all. All it's doing is render the `FluentContext.Provider`, which we could expose in the public API of `@fluent/react`:

```ts
let l10n = new ReactLocalization(bundlesIterable);
<FluentContext.Provider value={l10n}>
    <App />
</FluentContext.Provider>
```