### PR TITLE
(@fluent/bundle) Forbid setting NUMBER's currency

### DIFF
--- a/fluent-bundle/src/builtins.ts
+++ b/fluent-bundle/src/builtins.ts
@@ -18,10 +18,15 @@ import {
   FluentDateTime
 } from "./types.js";
 
-function values(opts: Record<string, FluentValue>): Record<string, unknown> {
+function values(
+  opts: Record<string, FluentValue>,
+  exclude?: string
+): Record<string, unknown> {
   const unwrapped: Record<string, unknown> = {};
   for (const [name, opt] of Object.entries(opts)) {
-    unwrapped[name] = opt.valueOf();
+    if (exclude === undefined || name !== exclude) {
+      unwrapped[name] = opt.valueOf();
+    }
   }
   return unwrapped;
 }
@@ -37,7 +42,10 @@ export function NUMBER(
   }
 
   if (arg instanceof FluentNumber || arg instanceof FluentDateTime) {
-    return new FluentNumber(arg.valueOf(), { ...arg.opts, ...values(opts) });
+    return new FluentNumber(arg.valueOf(), {
+      ...arg.opts,
+      ...values(opts, "currency")
+    });
   }
 
   throw new TypeError("Invalid argument to NUMBER");

--- a/fluent-bundle/src/builtins.ts
+++ b/fluent-bundle/src/builtins.ts
@@ -18,13 +18,30 @@ import {
   FluentDateTime
 } from "./types.js";
 
-function values(opts: Record<string, FluentValue>): Record<string, unknown> {
-  const unwrapped: Record<string, unknown> = {};
+function values(
+  opts: Record<string, FluentValue>,
+  allowed: Array<string>
+): Record<string, unknown> {
+  const unwrapped: Record<string, unknown> = Object.create(null);
   for (const [name, opt] of Object.entries(opts)) {
-    unwrapped[name] = opt.valueOf();
+    if (allowed.includes(name)) {
+      unwrapped[name] = opt.valueOf();
+    }
   }
   return unwrapped;
 }
+
+const NUMBER_ALLOWED = [
+  "numberingSystem",
+  "unitDisplay",
+  "currencyDisplay",
+  "useGrouping",
+  "minimumIntegerDigits",
+  "minimumFractionDigits",
+  "maximumFractionDigits",
+  "minimumSignificantDigits",
+  "maximumSignificantDigits",
+];
 
 export function NUMBER(
   args: Array<FluentValue>,
@@ -37,18 +54,34 @@ export function NUMBER(
   }
 
   if (arg instanceof FluentNumber || arg instanceof FluentDateTime) {
-    if (Object.prototype.hasOwnProperty.call(opts, "currency")) {
-      throw new RangeError("Forbidden option to NUMBER: currency");
-    }
-
     return new FluentNumber(arg.valueOf(), {
       ...arg.opts,
-      ...values(opts)
+      ...values(opts, NUMBER_ALLOWED)
     });
   }
 
   throw new TypeError("Invalid argument to NUMBER");
 }
+
+const DATETIME_ALLOWED = [
+  "dateStyle",
+  "timeStyle",
+  "fractionalSecondDigits",
+  "calendar",
+  "dayPeriod",
+  "numberingSystem",
+  "hour12",
+  "hourCycle",
+  "weekday",
+  "era",
+  "year",
+  "month",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "timeZoneName",
+];
 
 export function DATETIME(
   args: Array<FluentValue>,
@@ -63,7 +96,7 @@ export function DATETIME(
   if (arg instanceof FluentNumber || arg instanceof FluentDateTime) {
     return new FluentDateTime(arg.valueOf(), {
       ...arg.opts,
-      ...values(opts)
+      ...values(opts, DATETIME_ALLOWED)
     });
   }
 

--- a/fluent-bundle/src/builtins.ts
+++ b/fluent-bundle/src/builtins.ts
@@ -18,15 +18,10 @@ import {
   FluentDateTime
 } from "./types.js";
 
-function values(
-  opts: Record<string, FluentValue>,
-  exclude?: string
-): Record<string, unknown> {
+function values(opts: Record<string, FluentValue>): Record<string, unknown> {
   const unwrapped: Record<string, unknown> = {};
   for (const [name, opt] of Object.entries(opts)) {
-    if (exclude === undefined || name !== exclude) {
-      unwrapped[name] = opt.valueOf();
-    }
+    unwrapped[name] = opt.valueOf();
   }
   return unwrapped;
 }
@@ -42,9 +37,13 @@ export function NUMBER(
   }
 
   if (arg instanceof FluentNumber || arg instanceof FluentDateTime) {
+    if (Object.prototype.hasOwnProperty.call(opts, "currency")) {
+      throw new RangeError("Forbidden option to NUMBER: currency");
+    }
+
     return new FluentNumber(arg.valueOf(), {
       ...arg.opts,
-      ...values(opts, "currency")
+      ...values(opts)
     });
   }
 
@@ -62,7 +61,10 @@ export function DATETIME(
   }
 
   if (arg instanceof FluentNumber || arg instanceof FluentDateTime) {
-    return new FluentDateTime(arg.valueOf(), { ...arg.opts, ...values(opts) });
+    return new FluentDateTime(arg.valueOf(), {
+      ...arg.opts,
+      ...values(opts)
+    });
   }
 
   throw new TypeError("Invalid argument to DATETIME");

--- a/fluent-bundle/src/builtins.ts
+++ b/fluent-bundle/src/builtins.ts
@@ -32,7 +32,6 @@ function values(
 }
 
 const NUMBER_ALLOWED = [
-  "numberingSystem",
   "unitDisplay",
   "currencyDisplay",
   "useGrouping",
@@ -67,11 +66,8 @@ const DATETIME_ALLOWED = [
   "dateStyle",
   "timeStyle",
   "fractionalSecondDigits",
-  "calendar",
   "dayPeriod",
-  "numberingSystem",
   "hour12",
-  "hourCycle",
   "weekday",
   "era",
   "year",

--- a/fluent-bundle/test/arguments_test.js
+++ b/fluent-bundle/test/arguments_test.js
@@ -5,7 +5,7 @@ import ftl from "@fluent/dedent";
 
 import {FluentBundle} from '../esm/bundle';
 import {FluentResource} from '../esm/resource';
-import {FluentType} from '../esm/types';
+import {FluentType, FluentNumber, FluentDateTime} from '../esm/types';
 
 suite('Variables', function() {
   let bundle, errs;
@@ -171,28 +171,31 @@ suite('Variables', function() {
   });
 
   suite('and numbers', function(){
-    let args;
-
     suiteSetup(function() {
       bundle = new FluentBundle('en-US', { useIsolating: false });
       bundle.addResource(new FluentResource(ftl`
         foo = { $arg }
         `));
-      args = {
-        arg: 1
-      };
     });
 
     test('can be a number', function(){
       const msg = bundle.getMessage('foo');
-      const val = bundle.formatPattern(msg.value, args, errs);
+      const val = bundle.formatPattern(msg.value, {arg: 1}, errs);
       assert.strictEqual(val, '1');
+      assert.strictEqual(errs.length, 0);
+    });
+
+    test('can be a FluentNumber', function(){
+      const arg = new FluentNumber(1, {minimumFractionDigits: 2});
+      const msg = bundle.getMessage('foo');
+      const val = bundle.formatPattern(msg.value, {arg}, errs);
+      assert.strictEqual(val, '1.00');
       assert.strictEqual(errs.length, 0);
     });
   });
 
   suite('and dates', function(){
-    let args, dtf;
+    let dtf;
 
     suiteSetup(function() {
       dtf = new Intl.DateTimeFormat('en-US');
@@ -200,16 +203,22 @@ suite('Variables', function() {
       bundle.addResource(new FluentResource(ftl`
         foo = { $arg }
         `));
-      args = {
-        arg: new Date('2016-09-29')
-      };
     });
 
     test('can be a date', function(){
+      const arg = new Date('2016-09-29');
       const msg = bundle.getMessage('foo');
-      const val = bundle.formatPattern(msg.value, args, errs);
+      const val = bundle.formatPattern(msg.value, {arg}, errs);
       // format the date argument to account for the testrunner's timezone
-      assert.strictEqual(val, dtf.format(args.arg));
+      assert.strictEqual(val, dtf.format(arg));
+      assert.strictEqual(errs.length, 0);
+    });
+
+    test('can be a FluentDateTime', function(){
+      const arg = new FluentDateTime(new Date('2016-09-29'), {weekday: "long"});
+      const msg = bundle.getMessage('foo');
+      const val = bundle.formatPattern(msg.value, {arg}, errs);
+      assert.strictEqual(val, 'Thursday');
       assert.strictEqual(errs.length, 0);
     });
   });

--- a/fluent-bundle/test/functions_builtin_test.js
+++ b/fluent-bundle/test/functions_builtin_test.js
@@ -23,7 +23,7 @@ suite('Built-in functions', function() {
         num-bad-opt = { NUMBER($arg, style: "bad") }
         num-currency-style = { NUMBER($arg, style: "currency") }
         num-currency-currency = { NUMBER($arg, currency: "EUR") }
-        num-currency-override = { NUMBER($arg, style: "currency", currency: "JPY") }
+        num-currency-style-currency = { NUMBER($arg, style: "currency", currency: "JPY") }
         `));
     });
 
@@ -66,7 +66,7 @@ suite('Built-in functions', function() {
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
-      msg = bundle.getMessage('num-currency-override');
+      msg = bundle.getMessage('num-currency-style-currency');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
@@ -99,14 +99,15 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('num-currency-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,234');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
 
       errors = [];
-      msg = bundle.getMessage('num-currency-override');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
+      msg = bundle.getMessage('num-currency-style-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
       assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError); // Currency code is required
+      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
     });
 
     test('FluentNumber argument, minimumFractionDigits=3', function() {
@@ -135,14 +136,15 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('num-currency-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,234.000');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
 
       errors = [];
-      msg = bundle.getMessage('num-currency-override');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
+      msg = bundle.getMessage('num-currency-style-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
       assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError); // Currency code is required
+      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
     });
 
     test('FluentNumber argument, style="currency", currency="USD"', function() {
@@ -170,13 +172,15 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('num-currency-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '$1,234.00');
-      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
 
       errors = [];
-      msg = bundle.getMessage('num-currency-override');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '$1,234.00');
-      assert.strictEqual(errors.length, 0);
+      msg = bundle.getMessage('num-currency-style-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
     });
 
     test('string argument', function() {

--- a/fluent-bundle/test/functions_builtin_test.js
+++ b/fluent-bundle/test/functions_builtin_test.js
@@ -21,6 +21,7 @@ suite('Built-in functions', function() {
         num-decimal = { NUMBER($arg) }
         num-percent = { NUMBER($arg, style: "percent") }
         num-bad-opt = { NUMBER($arg, style: "bad") }
+        num-unknown = { NUMBER($arg, unknown: "unknown") }
         num-currency-style = { NUMBER($arg, style: "currency") }
         num-currency-currency = { NUMBER($arg, currency: "EUR") }
         num-currency-style-currency = { NUMBER($arg, style: "currency", currency: "JPY") }
@@ -46,6 +47,13 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('num-bad-opt');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+
+      errors = [];
+      msg = bundle.getMessage('num-unknown');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
@@ -92,6 +100,11 @@ suite('Built-in functions', function() {
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
 
       errors = [];
+      msg = bundle.getMessage('num-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,234');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
       msg = bundle.getMessage('num-currency-style');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
       assert.strictEqual(errors.length, 1);
@@ -120,6 +133,10 @@ suite('Built-in functions', function() {
 
       msg = bundle.getMessage('num-percent');
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '123,400.000%');
+      assert.strictEqual(errors.length, 0);
+
+      msg = bundle.getMessage('num-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,234.000');
       assert.strictEqual(errors.length, 0);
 
       errors = [];
@@ -164,6 +181,11 @@ suite('Built-in functions', function() {
       assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
+
+      errors = [];
+      msg = bundle.getMessage('num-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '$1,234.00');
+      assert.strictEqual(errors.length, 0);
 
       errors = [];
       msg = bundle.getMessage('num-currency-style');

--- a/fluent-bundle/test/functions_builtin_test.js
+++ b/fluent-bundle/test/functions_builtin_test.js
@@ -5,48 +5,55 @@ import ftl from "@fluent/dedent";
 
 import {FluentBundle} from '../esm/bundle';
 import {FluentResource} from '../esm/resource';
-import {FluentNumber} from '../esm/types';
+import {FluentNumber, FluentDateTime} from '../esm/types';
 
 suite('Built-in functions', function() {
-  let bundle, errors;
-
-  setup(function () {
-    errors = [];
-  });
+  let bundle, errors, msg;
 
   suite('NUMBER', function(){
     suiteSetup(function() {
       bundle = new FluentBundle('en-US', { useIsolating: false });
       bundle.addResource(new FluentResource(ftl`
-        num-decimal = { NUMBER($arg) }
-        num-percent = { NUMBER($arg, style: "percent") }
-        num-bad-opt = { NUMBER($arg, style: "bad") }
+        num-bare = { NUMBER($arg) }
+        num-fraction-valid = { NUMBER($arg, minimumFractionDigits: 1) }
+        num-fraction-bad = { NUMBER($arg, minimumFractionDigits: "oops") }
+        num-style = { NUMBER($arg, style: "percent") }
+        num-currency = { NUMBER($arg, currency: "EUR") }
         num-unknown = { NUMBER($arg, unknown: "unknown") }
-        num-currency-style = { NUMBER($arg, style: "currency") }
-        num-currency-currency = { NUMBER($arg, currency: "EUR") }
-        num-currency-style-currency = { NUMBER($arg, style: "currency", currency: "JPY") }
         `));
     });
 
     test('missing argument', function() {
-      let msg;
-
       errors = [];
-      msg = bundle.getMessage('num-decimal');
+      msg = bundle.getMessage('num-bare');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
-      msg = bundle.getMessage('num-percent');
+      msg = bundle.getMessage('num-fraction-valid');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
-      msg = bundle.getMessage('num-bad-opt');
+      msg = bundle.getMessage('num-fraction-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+
+      errors = [];
+      msg = bundle.getMessage('num-style');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+
+      errors = [];
+      msg = bundle.getMessage('num-currency');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
@@ -54,27 +61,6 @@ suite('Built-in functions', function() {
 
       errors = [];
       msg = bundle.getMessage('num-unknown');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof ReferenceError);
-      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-
-      errors = [];
-      msg = bundle.getMessage('num-currency-style');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof ReferenceError);
-      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-
-      errors = [];
-      msg = bundle.getMessage('num-currency-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof ReferenceError);
-      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
-
-      errors = [];
-      msg = bundle.getMessage('num-currency-style-currency');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
@@ -82,198 +68,237 @@ suite('Built-in functions', function() {
     });
 
     test('number argument', function() {
-      const args = {arg: 1234};
-      let msg;
+      let arg = 1234;
 
-      msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,234');
-      assert.strictEqual(errors.length, 0);
-
-      msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '123,400%');
+      errors = [];
+      msg = bundle.getMessage('num-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234');
       assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
+      msg = bundle.getMessage('num-fraction-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234.0');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('num-fraction-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1234');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
 
       errors = [];
-      msg = bundle.getMessage('num-unknown');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,234');
+      msg = bundle.getMessage('num-style');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234');
       assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-currency-style');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError); // Currency code is required
+      msg = bundle.getMessage('num-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234');
+      assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-currency-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
-
-      errors = [];
-      msg = bundle.getMessage('num-currency-style-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
+      msg = bundle.getMessage('num-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234');
+      assert.strictEqual(errors.length, 0);
     });
 
     test('FluentNumber argument, minimumFractionDigits=3', function() {
-      const args = {arg: new FluentNumber(1234, {minimumFractionDigits: 3})};
-      let msg;
+      let arg =  new FluentNumber(1234, {
+        minimumFractionDigits: 3
+      });
 
-      msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,234.000');
-      assert.strictEqual(errors.length, 0);
-
-      msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '123,400.000%');
-      assert.strictEqual(errors.length, 0);
-
-      msg = bundle.getMessage('num-unknown');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,234.000');
+      errors = [];
+      msg = bundle.getMessage('num-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234.000');
       assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
+      msg = bundle.getMessage('num-fraction-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234.0');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('num-fraction-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1234');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
 
       errors = [];
-      msg = bundle.getMessage('num-currency-style');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof TypeError); // Currency code is required
+      msg = bundle.getMessage('num-style');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234.000');
+      assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-currency-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
+      msg = bundle.getMessage('num-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234.000');
+      assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-currency-style-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
+      msg = bundle.getMessage('num-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,234.000');
+      assert.strictEqual(errors.length, 0);
     });
 
     test('FluentNumber argument, style="currency", currency="USD"', function() {
-      const args = {arg: new FluentNumber(1234, {style: "currency", currency: "USD"})};
-      let msg;
+      let arg = new FluentNumber(1234, {
+        style: "currency",
+        currency: "USD"
+      });
 
-      msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '$1,234.00');
-      assert.strictEqual(errors.length, 0);
-
-      msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '123,400%');
+      errors = [];
+      msg = bundle.getMessage('num-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '$1,234.00');
       assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1234');
+      msg = bundle.getMessage('num-fraction-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '$1,234.0');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('num-fraction-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1234');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
 
       errors = [];
+      msg = bundle.getMessage('num-style');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '$1,234.00');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('num-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '$1,234.00');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
       msg = bundle.getMessage('num-unknown');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '$1,234.00');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '$1,234.00');
       assert.strictEqual(errors.length, 0);
-
-      errors = [];
-      msg = bundle.getMessage('num-currency-style');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '$1,234.00');
-      assert.strictEqual(errors.length, 0);
-
-      errors = [];
-      msg = bundle.getMessage('num-currency-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
-
-      errors = [];
-      msg = bundle.getMessage('num-currency-style-currency');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
-      assert.strictEqual(errors.length, 1);
-      assert.ok(errors[0] instanceof RangeError); // Forbidden "currency" option
     });
 
     test('string argument', function() {
-      const args = {arg: "Foo"};
-      let msg;
+      let arg = "Foo";
 
       errors = [];
-      msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      msg = bundle.getMessage('num-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
 
       errors = [];
-      msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      msg = bundle.getMessage('num-fraction-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
 
       errors = [];
-      msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER()}');
+      msg = bundle.getMessage('num-fraction-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
+
+      errors = [];
+      msg = bundle.getMessage('num-style');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
+
+      errors = [];
+      msg = bundle.getMessage('num-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
+
+      errors = [];
+      msg = bundle.getMessage('num-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Invalid argument to NUMBER");
     });
 
     test('date argument', function() {
-      const date = new Date('2016-09-29');
-      const args = {arg: date};
-      let msg;
+      let arg = new Date('2016-09-29');
 
       errors = [];
-      msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1,475,107,200,000');
+      msg = bundle.getMessage('num-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,475,107,200,000');
       assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '147,510,720,000,000%');
+      msg = bundle.getMessage('num-fraction-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,475,107,200,000.0');
       assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1475107200000');
+      msg = bundle.getMessage('num-fraction-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1475107200000');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
+
+      errors = [];
+      msg = bundle.getMessage('num-style');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,475,107,200,000');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('num-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,475,107,200,000');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('num-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,475,107,200,000');
+      assert.strictEqual(errors.length, 0);
     });
 
     test('invalid argument', function() {
-      const args = {arg: []};
-      let msg;
+      let arg = [];
 
       errors = [];
-      msg = bundle.getMessage('num-decimal');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER($arg)}');
+      msg = bundle.getMessage('num-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
 
       errors = [];
-      msg = bundle.getMessage('num-percent');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER($arg)}');
+      msg = bundle.getMessage('num-fraction-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
 
       errors = [];
-      msg = bundle.getMessage('num-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{NUMBER($arg)}');
+      msg = bundle.getMessage('num-fraction-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+
+      errors = [];
+      msg = bundle.getMessage('num-style');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+
+      errors = [];
+      msg = bundle.getMessage('num-currency');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+
+      errors = [];
+      msg = bundle.getMessage('num-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{NUMBER($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
@@ -284,31 +309,45 @@ suite('Built-in functions', function() {
     suiteSetup(function() {
       bundle = new FluentBundle('en-US', { useIsolating: false });
       bundle.addResource(new FluentResource(ftl`
-        dt-default = { DATETIME($arg) }
-        dt-month = { DATETIME($arg, month: "long") }
-        dt-bad-opt = { DATETIME($arg, month: "bad") }
+        dt-bare = { DATETIME($arg) }
+        dt-month-valid = { DATETIME($arg, month: "long") }
+        dt-month-bad = { DATETIME($arg, month: "oops") }
+        dt-timezone = { DATETIME($arg, timezone: "America/New_York") }
+        dt-unknown = { DATETIME($arg, unknown: "unknown") }
         `));
     });
 
     test('missing argument', function() {
-      let msg;
-
       errors = [];
-      msg = bundle.getMessage('dt-default');
+      msg = bundle.getMessage('dt-bare');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
-      msg = bundle.getMessage('dt-month');
+      msg = bundle.getMessage('dt-month-valid');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
       assert.strictEqual(errors[0].message, "Unknown variable: $arg");
 
       errors = [];
-      msg = bundle.getMessage('dt-bad-opt');
+      msg = bundle.getMessage('dt-month-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+
+      errors = [];
+      msg = bundle.getMessage('dt-timezone');
+      assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof ReferenceError);
+      assert.strictEqual(errors[0].message, "Unknown variable: $arg");
+
+      errors = [];
+      msg = bundle.getMessage('dt-unknown');
       assert.strictEqual(bundle.formatPattern(msg.value, {}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof ReferenceError);
@@ -316,103 +355,190 @@ suite('Built-in functions', function() {
     });
 
     test('Date argument', function () {
-      let args = {arg: new Date('2016-09-29')};
-      let msg;
+      let arg = new Date('2016-09-29');
 
       // Format the date argument to account for the testrunner's timezone.
       let expectedDate =
-        (new Intl.DateTimeFormat('en-US')).format(args.arg);
-      let expectedMonth =
-        (new Intl.DateTimeFormat('en-US', {month: 'long'})).format(args.arg);
+        (new Intl.DateTimeFormat('en-US')).format({arg}.arg);
+      let expectedMonthLong =
+        (new Intl.DateTimeFormat('en-US', {month: 'long'})).format({arg}.arg);
 
-      msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedDate);
+      errors = [];
+      msg = bundle.getMessage('dt-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedDate);
       assert.strictEqual(errors.length, 0);
 
-      msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedMonth);
+      errors = [];
+      msg = bundle.getMessage('dt-month-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedMonthLong);
       assert.strictEqual(errors.length, 0);
 
-      msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '2016-09-29T00:00:00.000Z');
+      errors = [];
+      msg = bundle.getMessage('dt-month-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '2016-09-29T00:00:00.000Z');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
+
+      errors = [];
+      msg = bundle.getMessage('dt-timezone');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedDate);
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('dt-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedDate);
+      assert.strictEqual(errors.length, 0);
+    });
+
+    test('FluentDateTime argument', function () {
+      let date = new Date('2016-09-29');
+      let arg = new FluentDateTime(date, {
+        month: "short",
+        day: "numeric",
+      });
+
+      // Format the date argument to account for the testrunner's timezone.
+      let expectedMonthShort =
+        (new Intl.DateTimeFormat('en-US', {month: 'short', day: "numeric"})).format(date);
+      let expectedMonthLong =
+        (new Intl.DateTimeFormat('en-US', {month: 'long', day: "numeric"})).format(date);
+
+      errors = [];
+      msg = bundle.getMessage('dt-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedMonthShort);
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('dt-month-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedMonthLong);
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('dt-month-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '2016-09-29T00:00:00.000Z');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof RangeError); // Invalid option value
+
+      errors = [];
+      msg = bundle.getMessage('dt-timezone');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedMonthShort);
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('dt-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedMonthShort);
+      assert.strictEqual(errors.length, 0);
     });
 
     test('number argument', function() {
-      let args = {arg: -1};
-      let msg;
+      let arg = -1;
 
       // Format the date argument to account for the testrunner's timezone.
       let expectedDate =
-        (new Intl.DateTimeFormat('en-US')).format(args.arg);
-      let expectedMonth =
-        (new Intl.DateTimeFormat('en-US', {month: 'long'})).format(args.arg);
+        (new Intl.DateTimeFormat('en-US')).format({arg}.arg);
+      let expectedMonthLong =
+        (new Intl.DateTimeFormat('en-US', {month: 'long'})).format({arg}.arg);
 
       errors = [];
-      msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedDate);
+      msg = bundle.getMessage('dt-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedDate);
       assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), expectedMonth);
+      msg = bundle.getMessage('dt-month-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedMonthLong);
       assert.strictEqual(errors.length, 0);
 
       errors = [];
-      msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '1969-12-31T23:59:59.999Z');
+      msg = bundle.getMessage('dt-month-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1969-12-31T23:59:59.999Z');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof RangeError); // Invalid option value
+
+      errors = [];
+      msg = bundle.getMessage('dt-timezone');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedDate);
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('dt-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedDate);
+      assert.strictEqual(errors.length, 0);
     });
 
     test('string argument', function() {
-      let args = {arg: 'Foo'};
-      let msg;
+      let arg = 'Foo';
 
       errors = [];
-      msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      msg = bundle.getMessage('dt-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Invalid argument to DATETIME");
 
       errors = [];
-      msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      msg = bundle.getMessage('dt-month-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Invalid argument to DATETIME");
 
       errors = [];
-      msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME()}');
+      msg = bundle.getMessage('dt-month-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument to DATETIME");
+
+      errors = [];
+      msg = bundle.getMessage('dt-timezone');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME()}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Invalid argument to DATETIME");
+
+      errors = [];
+      msg = bundle.getMessage('dt-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME()}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Invalid argument to DATETIME");
     });
 
     test('invalid argument', function() {
-      let args = {arg: []};
-      let msg;
+      let arg = [];
 
       errors = [];
-      msg = bundle.getMessage('dt-default');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME($arg)}');
+      msg = bundle.getMessage('dt-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
 
       errors = [];
-      msg = bundle.getMessage('dt-month');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME($arg)}');
+      msg = bundle.getMessage('dt-month-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
 
       errors = [];
-      msg = bundle.getMessage('dt-bad-opt');
-      assert.strictEqual(bundle.formatPattern(msg.value, args, errors), '{DATETIME($arg)}');
+      msg = bundle.getMessage('dt-month-bad');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+
+      errors = [];
+      msg = bundle.getMessage('dt-timezone');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME($arg)}');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0] instanceof TypeError);
+      assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");
+
+      errors = [];
+      msg = bundle.getMessage('dt-unknown');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '{DATETIME($arg)}');
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0] instanceof TypeError);
       assert.strictEqual(errors[0].message, "Variable type not supported: $arg, object");


### PR DESCRIPTION
If one of the named arguments passed into `NUMBER` is `currency`, we should remove it from the options bag. Right now this PR just ignores it silently, but perhaps it would be better to explicitly throw in `NUMBER` instead. @Pike, wdyt?

I also wonder if we should disallow `NUMBER`'s `style`, as well. Are there scenarios when we'd want the localization to choose a different style (e.g. `percent`) than the base (e.g. `currency`)? I guess one such example is when the base is not explicitly defined in the source, in which case `decimal` is used. This can happen in the declarative bindings where there's no way to pass an instance of `FluentNumber` (like in `DOMLocalization`).