### PR TITLE
(@fluent/react) Use FluentContext.Consumer instead of useContext

### DIFF
--- a/fluent-react/src/localized.ts
+++ b/fluent-react/src/localized.ts
@@ -5,12 +5,12 @@ import {
   cloneElement,
   createElement,
   isValidElement,
-  useContext
 } from "react";
 import PropTypes from "prop-types";
 import voidElementTags from "../vendor/voidElementTags";
 import { FluentContext } from "./context";
 import { FluentArgument } from "@fluent/bundle";
+import { ReactLocalization } from "./localization";
 
 // Match the opening angle bracket (<) in HTML tags, and HTML entities like
 // &amp;, &#0038;, &#x0026;.
@@ -46,14 +46,27 @@ export interface LocalizedProps {
  *  source code.
  */
 export function Localized(props: LocalizedProps): ReactElement {
-  const { id, attrs, vars, elems, children: child = null } = props;
-  const l10n = useContext(FluentContext);
-
   // Validate that the child element isn't an array
-  if (Array.isArray(child)) {
+  if (Array.isArray(props.children)) {
     throw new Error("<Localized/> expected to receive a single " +
       "React node child");
   }
+
+  return createElement(
+    FluentContext.Consumer,
+    null,
+    (l10n: ReactLocalization) => createElement(ConnectedLocalized, {
+      l10n, ...props
+    })
+  );
+}
+
+interface ConnectedLocalizedProps extends LocalizedProps {
+  l10n: ReactLocalization;
+}
+
+function ConnectedLocalized(props: ConnectedLocalizedProps): ReactElement {
+  const { l10n, id, attrs, vars, elems, children: child = null } = props;
 
   if (!l10n) {
     // Use the wrapped component as fallback.

--- a/fluent-react/src/with_localization.ts
+++ b/fluent-react/src/with_localization.ts
@@ -1,6 +1,7 @@
-import { createElement, useContext, ComponentType, ReactElement } from "react";
+import { createElement, ComponentType, ReactElement } from "react";
 import { FluentContext } from "./context";
 import { FluentArgument } from "@fluent/bundle";
+import { ReactLocalization } from "./localization";
 
 export interface WithLocalizationProps {
   getString(
@@ -16,10 +17,15 @@ export function withLocalization<P extends WithLocalizationProps>(
   Inner: ComponentType<P>
 ): ComponentType<WithoutLocalizationProps<P>> {
   function WithLocalization(props: WithoutLocalizationProps<P>): ReactElement {
-    const l10n = useContext(FluentContext);
-    // Re-bind getString to trigger a re-render of Inner.
-    const getString = l10n.getString.bind(l10n);
-    return createElement(Inner, { getString, ...props } as P);
+    return createElement(
+      FluentContext.Consumer,
+      null,
+      (l10n: ReactLocalization) => {
+        // Re-bind getString to trigger a re-render of Inner.
+        const getString = l10n.getString.bind(l10n);
+        return createElement(Inner, { getString, ...props } as P);
+      }
+    );
   }
 
   WithLocalization.displayName = `WithLocalization(${displayName(Inner)})`;


### PR DESCRIPTION
The way hooks are implemented in React, they require that all components
use the same instance of React, likely due to a shared global state used
to store components' state. Unfortunately, this approach doesn't work
well when `@fluent/react` is installed into a project via `npm link`,
for instance for testig purposes.

We don't make a heavy use of hooks. In fact, we only currently use the
`useContext` hook which can be easily replaced by `Context.Consumer` and
a render prop, thus making testing a lot easier.

References:
    https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react
    https://github.com/facebook/react/issues/13991