### PR TITLE
Build system fixes for macos (#486)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -4,6 +4,7 @@
 ROOT := $(dir $(lastword $(MAKEFILE_LIST)))
 SOURCES := $(wildcard src/*)
 VERSION := $(shell node -pe "require('./package.json').version")
+DOC_DESTINATION := $(subst @fluent, ../html, $(PACKAGE))
 
 export SHELL := /bin/bash
 ESLINT ?= $(ROOT)node_modules/.bin/eslint
@@ -19,6 +20,15 @@ ROLLUP_CMD = $(ROLLUP) $(CURDIR)/esm/index.js \
 	--name $(GLOBAL) \
 	--output.format umd \
 	--output.file \
+	$(NULL)
+
+TYPEDOC_CMD = $(TYPEDOC) src \
+	--out $(DOC_DESTINATION) \
+	--mode file \
+	--excludeNotExported \
+	--excludePrivate \
+	--logger none \
+	--hideGenerator \
 	$(NULL)
 
 # Common maintenance tasks.

--- a/common.mk
+++ b/common.mk
@@ -31,6 +31,12 @@ TYPEDOC_CMD = $(TYPEDOC) src \
 	--hideGenerator \
 	$(NULL)
 
+MOCHA_CMD =@$(NYC) --reporter=text --reporter=html $(MOCHA) \
+	--recursive --ui tdd \
+	--require esm $(TEST_REQUIRES) \
+	test/**/*_test.js \
+	$(NULL)
+
 # Common maintenance tasks.
 .PHONY: clean lint test build html
 
@@ -47,14 +53,5 @@ deps:
 depsclean:
 	@rm -rf node_modules
 	@echo -e " $(OK) deps clean"
-
-# Shared recipes
-.PHONY: mocha-test
-
-mocha-test:
-	@$(NYC) --reporter=text --reporter=html $(MOCHA) \
-	    --recursive --ui tdd \
-	    --require esm $(TEST_REQUIRES) \
-	    test/**/*_test.js
 
 OK := \033[32;01m✓\033[0m

--- a/common.mk
+++ b/common.mk
@@ -33,7 +33,8 @@ TYPEDOC_CMD = $(TYPEDOC) src \
 
 MOCHA_CMD =@$(NYC) --reporter=text --reporter=html $(MOCHA) \
 	--recursive --ui tdd \
-	--require esm $(TEST_REQUIRES) \
+	--require esm \
+	$(MOCHA_EXTRA_ARGS) \
 	test/**/*_test.js \
 	$(NULL)
 

--- a/common.mk
+++ b/common.mk
@@ -13,6 +13,14 @@ MOCHA ?= $(ROOT)node_modules/.bin/mocha
 ROLLUP ?= $(ROOT)node_modules/.bin/rollup
 TYPEDOC ?= $(ROOT)node_modules/.bin/typedoc
 
+ROLLUP_CMD = $(ROLLUP) $(CURDIR)/esm/index.js \
+	--banner "/* $(PACKAGE)@$(VERSION) */" \
+	--amd.id $(PACKAGE) \
+	--name $(GLOBAL) \
+	--output.format umd \
+	--output.file \
+	$(NULL)
+
 # Common maintenance tasks.
 .PHONY: clean lint test build html
 

--- a/common.mk
+++ b/common.mk
@@ -1,12 +1,17 @@
 # This makefile is intended to be included by each package's makefile.  The
 # paths are relative to the package directory.
 
-ROOT := $(CURDIR)/..
+ROOT := $(dir $(lastword $(MAKEFILE_LIST)))
 SOURCES := $(wildcard src/*)
 VERSION := $(shell node -pe "require('./package.json').version")
 
 export SHELL := /bin/bash
-export PATH  := $(CURDIR)/node_modules/.bin:$(ROOT)/node_modules/.bin:$(PATH)
+ESLINT ?= $(ROOT)node_modules/.bin/eslint
+TSC ?= $(ROOT)node_modules/.bin/tsc
+NYC ?= $(ROOT)node_modules/.bin/nyc
+MOCHA ?= $(ROOT)node_modules/.bin/mocha
+ROLLUP ?= $(ROOT)node_modules/.bin/rollup
+TYPEDOC ?= $(ROOT)node_modules/.bin/typedoc
 
 # Common maintenance tasks.
 .PHONY: clean lint test build html
@@ -24,5 +29,14 @@ deps:
 depsclean:
 	@rm -rf node_modules
 	@echo -e " $(OK) deps clean"
+
+# Shared recipes
+.PHONY: mocha-test
+
+mocha-test:
+	@$(NYC) --reporter=text --reporter=html $(MOCHA) \
+	    --recursive --ui tdd \
+	    --require esm $(TEST_REQUIRES) \
+	    test/**/*_test.js
 
 OK := \033[32;01m✓\033[0m

--- a/fluent-bundle/makefile
+++ b/fluent-bundle/makefile
@@ -4,30 +4,27 @@ GLOBAL  := FluentBundle
 include ../common.mk
 
 lint:
-	@eslint --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
-	@eslint --config $(ROOT)/eslint_test.json --max-warnings 0 test/
+	@$(ESLINT) --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
+	@$(ESLINT) --config $(ROOT)/eslint_test.json --max-warnings 0 test/
 	@echo -e " $(OK) lint"
 
 .PHONY: compile
 compile: esm/.compiled
 
 esm/.compiled: $(SOURCES)
-	@tsc
+	@$(TSC)
 	@touch $@
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
 test: esm/.compiled
-	@nyc --reporter=text --reporter=html mocha \
-	    --recursive --ui tdd \
-	    --require esm \
-	    test/**/*_test.js
+	@$(MAKE) mocha-test
 
 .PHONY: build
 build: index.js
 
 index.js: esm/.compiled
-	@rollup $(CURDIR)/esm/index.js \
+	@$(ROLLUP) $(CURDIR)/esm/index.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -36,7 +33,7 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@typedoc src \
+	@$(TYPEDOC) src \
 	    --out ../html/bundle \
 	    --mode file \
 	    --excludeNotExported \
@@ -48,6 +45,7 @@ html:
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
+	@rm -rf ../html/bundle
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"
 

--- a/fluent-bundle/makefile
+++ b/fluent-bundle/makefile
@@ -18,7 +18,7 @@ esm/.compiled: $(SOURCES)
 
 .PHONY: test
 test: esm/.compiled
-	@$(MAKE) mocha-test
+	@$(MOCHA_CMD)
 
 .PHONY: build
 build: index.js

--- a/fluent-bundle/makefile
+++ b/fluent-bundle/makefile
@@ -24,12 +24,7 @@ test: esm/.compiled
 build: index.js
 
 index.js: esm/.compiled
-	@$(ROLLUP) $(CURDIR)/esm/index.js \
-	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --amd.id $(PACKAGE) \
-	    --name $(GLOBAL) \
-	    --output.format umd \
-	    --output.file $@
+	@$(ROLLUP_CMD) $@
 	@echo -e " $(OK) $@ built"
 
 html:

--- a/fluent-bundle/makefile
+++ b/fluent-bundle/makefile
@@ -28,19 +28,13 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@$(TYPEDOC) src \
-	    --out ../html/bundle \
-	    --mode file \
-	    --excludeNotExported \
-	    --excludePrivate \
-	    --logger none \
-	    --hideGenerator
+	@$(TYPEDOC_CMD)
 	@echo -e " $(OK) html built"
 
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
-	@rm -rf ../html/bundle
+	@rm -rf $(DOC_DESTINATION)
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"
 

--- a/fluent-dedent/makefile
+++ b/fluent-dedent/makefile
@@ -28,13 +28,7 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@$(TYPEDOC) src \
-	    --out ../html/dedent \
-	    --mode file \
-	    --excludeNotExported \
-	    --excludePrivate \
-	    --logger none \
-	    --hideGenerator
+	@$(TYPEDOC_CMD)
 	@echo -e " $(OK) html built"
 
 clean:

--- a/fluent-dedent/makefile
+++ b/fluent-dedent/makefile
@@ -4,30 +4,27 @@ GLOBAL  := FluentDedent
 include ../common.mk
 
 lint:
-	@eslint --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
-	@eslint --config $(ROOT)/eslint_test.json --max-warnings 0 test/
+	@$(ESLINT) --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
+	@$(ESLINT) --config $(ROOT)/eslint_test.json --max-warnings 0 test/
 	@echo -e " $(OK) lint"
 
 .PHONY: compile
 compile: esm/.compiled
 
 esm/.compiled: $(SOURCES)
-	@tsc
+	@$(TSC)
 	@touch $@
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
 test: esm/.compiled
-	@nyc --reporter=text --reporter=html mocha \
-	    --recursive --ui tdd \
-	    --require esm \
-	    test/**/*_test.js
+	@$(MAKE) mocha-test
 
 .PHONY: build
 build: index.js
 
 index.js: esm/.compiled
-	@rollup $(CURDIR)/esm/index.js \
+	@$(ROLLUP) $(CURDIR)/esm/index.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -36,7 +33,7 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@typedoc src \
+	@$(TYPEDOC) src \
 	    --out ../html/dedent \
 	    --mode file \
 	    --excludeNotExported \

--- a/fluent-dedent/makefile
+++ b/fluent-dedent/makefile
@@ -18,7 +18,7 @@ esm/.compiled: $(SOURCES)
 
 .PHONY: test
 test: esm/.compiled
-	@$(MAKE) mocha-test
+	@$(MOCHA_CMD)
 
 .PHONY: build
 build: index.js

--- a/fluent-dedent/makefile
+++ b/fluent-dedent/makefile
@@ -24,12 +24,7 @@ test: esm/.compiled
 build: index.js
 
 index.js: esm/.compiled
-	@$(ROLLUP) $(CURDIR)/esm/index.js \
-	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --amd.id $(PACKAGE) \
-	    --name $(GLOBAL) \
-	    --output.format umd \
-	    --output.file $@
+	@$(ROLLUP_CMD) $@
 	@echo -e " $(OK) $@ built"
 
 html:

--- a/fluent-dom/makefile
+++ b/fluent-dom/makefile
@@ -5,31 +5,27 @@ DEPS    := cached-iterable:CachedIterable
 include ../common.mk
 
 lint:
-	@eslint --config $(ROOT)/eslint_js.json --max-warnings 0 src/
-	@eslint --config $(ROOT)/eslint_test.json --max-warnings 0 test/
+	@$(ESLINT) --config $(ROOT)/eslint_js.json --max-warnings 0 src/
+	@$(ESLINT) --config $(ROOT)/eslint_test.json --max-warnings 0 test/
 	@echo -e " $(OK) lint"
 
 .PHONY: compile
 compile: esm/.compiled
 
 esm/.compiled: $(SOURCES)
-	@tsc
+	@$(TSC)
 	@touch $@
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
 test: esm/.compiled
-	@nyc --reporter=text --reporter=html mocha \
-	    --recursive --ui tdd \
-	    --require esm \
-	    --require ./test/index \
-	    test/**/*_test.js
+	@$(MAKE) mocha-test TEST_REQUIRES="--require ./test/index"
 
 .PHONY: build
 build: index.js
 
 index.js: esm/.compiled
-	@rollup $(CURDIR)/esm/index.js \
+	@$(ROLLUP) $(CURDIR)/esm/index.js \
 		--banner "/* $(PACKAGE)@$(VERSION) */" \
 		--amd.id $(PACKAGE) \
 		--name $(GLOBAL) \
@@ -39,7 +35,7 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@typedoc src \
+	@$(TYPEDOC) src \
 	    --out ../html/dom \
 	    --mode file \
 	    --excludeNotExported \
@@ -51,5 +47,6 @@ html:
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
+	@rm -rf ../html/dom
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"

--- a/fluent-dom/makefile
+++ b/fluent-dom/makefile
@@ -18,7 +18,7 @@ esm/.compiled: $(SOURCES)
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
-test: TEST_REQUIRES=--require ./test/index
+test: MOCHA_EXTRA_ARGS=--require ./test/index
 test: esm/.compiled
 	@$(MOCHA_CMD)
 

--- a/fluent-dom/makefile
+++ b/fluent-dom/makefile
@@ -18,8 +18,9 @@ esm/.compiled: $(SOURCES)
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
+test: TEST_REQUIRES=--require ./test/index
 test: esm/.compiled
-	@$(MAKE) mocha-test TEST_REQUIRES="--require ./test/index"
+	@$(MOCHA_CMD)
 
 .PHONY: build
 build: index.js

--- a/fluent-dom/makefile
+++ b/fluent-dom/makefile
@@ -35,18 +35,12 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@$(TYPEDOC) src \
-	    --out ../html/dom \
-	    --mode file \
-	    --excludeNotExported \
-	    --excludePrivate \
-	    --logger none \
-	    --hideGenerator
+	@$(TYPEDOC_CMD)
 	@echo -e " $(OK) html built"
 
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
-	@rm -rf ../html/dom
+	@rm -rf $(DOC_DESTINATION)
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"

--- a/fluent-gecko/makefile
+++ b/fluent-gecko/makefile
@@ -7,7 +7,7 @@ version = $(1)@$(shell node -e "\
 	console.log(require('../$(1)/package.json').version)")
 
 lint:
-	@eslint --config $(ROOT)/eslint_js.json --max-warnings 0 src/
+	@$(ESLINT) --config $(ROOT)/eslint_js.json --max-warnings 0 src/
 	@echo -e " $(OK) lint"
 
 test: ;
@@ -17,7 +17,7 @@ build: FluentSyntax.jsm fluent-react.js
 
 FluentSyntax.jsm: $(SOURCES)
 	$(MAKE) -sC ../fluent-syntax compile
-	@rollup $(CURDIR)/src/fluent-syntax.js \
+	@$(ROLLUP) $(CURDIR)/src/fluent-syntax.js \
 	    --config ./xpcom_config.js \
 	    --no-treeshake \
 	    --no-freeze \
@@ -27,7 +27,7 @@ FluentSyntax.jsm: $(SOURCES)
 
 fluent-react.js: $(SOURCES)
 	$(MAKE) -sC ../fluent-react compile
-	@rollup $(CURDIR)/src/fluent-react.js \
+	@$(ROLLUP) $(CURDIR)/src/fluent-react.js \
 	    --config ./vendor_config.js \
 	    --output.intro "/* $(call version,fluent-react) */" \
 	    --output.file ./dist/$@

--- a/fluent-langneg/makefile
+++ b/fluent-langneg/makefile
@@ -4,30 +4,27 @@ GLOBAL  := FluentLangNeg
 include ../common.mk
 
 lint:
-	@eslint --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
-	@eslint --config $(ROOT)/eslint_test.json --max-warnings 0 test/
+	@$(ESLINT) --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
+	@$(ESLINT) --config $(ROOT)/eslint_test.json --max-warnings 0 test/
 	@echo -e " $(OK) lint"
 
 .PHONY: compile
 compile: esm/.compiled
 
 esm/.compiled: $(SOURCES)
-	@tsc
+	@$(TSC)
 	@touch $@
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
 test: esm/.compiled
-	@nyc --reporter=text --reporter=html mocha \
-	    --recursive --ui tdd \
-	    --require esm \
-	    test/**/*_test.js
+	@$(MAKE) mocha-test
 
 .PHONY: build
 build: index.js
 
 index.js: $(SOURCES)
-	@rollup $(CURDIR)/esm/index.js \
+	@$(ROLLUP) $(CURDIR)/esm/index.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -36,7 +33,7 @@ index.js: $(SOURCES)
 	@echo -e " $(OK) $@ built"
 
 html:
-	@typedoc src \
+	@$(TYPEDOC) src \
 	    --out ../html/langneg \
 	    --mode file \
 	    --excludeNotExported \
@@ -48,5 +45,6 @@ html:
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
+	@rm -rf ../html/langneg
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"

--- a/fluent-langneg/makefile
+++ b/fluent-langneg/makefile
@@ -18,7 +18,7 @@ esm/.compiled: $(SOURCES)
 
 .PHONY: test
 test: esm/.compiled
-	@$(MAKE) mocha-test
+	@$(MOCHA_CMD)
 
 .PHONY: build
 build: index.js

--- a/fluent-langneg/makefile
+++ b/fluent-langneg/makefile
@@ -24,12 +24,7 @@ test: esm/.compiled
 build: index.js
 
 index.js: $(SOURCES)
-	@$(ROLLUP) $(CURDIR)/esm/index.js \
-	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --amd.id $(PACKAGE) \
-	    --name $(GLOBAL) \
-	    --output.format umd \
-	    --output.file $@
+	@$(ROLLUP_CMD) $@
 	@echo -e " $(OK) $@ built"
 
 html:

--- a/fluent-langneg/makefile
+++ b/fluent-langneg/makefile
@@ -28,18 +28,12 @@ index.js: $(SOURCES)
 	@echo -e " $(OK) $@ built"
 
 html:
-	@$(TYPEDOC) src \
-	    --out ../html/langneg \
-	    --mode file \
-	    --excludeNotExported \
-	    --excludePrivate \
-	    --logger none \
-	    --hideGenerator
+	@$(TYPEDOC_CMD)
 	@echo -e " $(OK) html built"
 
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
-	@rm -rf ../html/langneg
+	@rm -rf $(DOC_DESTINATION)
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"

--- a/fluent-react/makefile
+++ b/fluent-react/makefile
@@ -1,30 +1,31 @@
 PACKAGE := @fluent/react
 GLOBAL  := FluentReact
+JEST    ?= node_modules/.bin/jest
 
 include ../common.mk
 
 lint:
-	@eslint --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
-	@eslint --config $(ROOT)/eslint_test.json --max-warnings 0 test/
+	@$(ESLINT) --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
+	@$(ESLINT) --config $(ROOT)/eslint_test.json --max-warnings 0 test/
 	@echo -e " $(OK) lint"
 
 .PHONY: compile
 compile: esm/.compiled
 
 esm/.compiled: $(SOURCES)
-	@tsc
+	@$(TSC)
 	@touch $@
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
 test: esm/.compiled
-	@jest --collect-coverage
+	@$(JEST) --collect-coverage
 
 .PHONY: build
 build: index.js
 
 index.js: esm/.compiled
-	@rollup $(CURDIR)/esm/index.js \
+	@$(ROLLUP) $(CURDIR)/esm/index.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -34,7 +35,7 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@typedoc src \
+	@$(TYPEDOC) src \
 	    --out ../html/react \
 	    --mode file \
 	    --excludeNotExported \
@@ -46,5 +47,6 @@ html:
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
+	@rm -rf ../html/react
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"

--- a/fluent-react/makefile
+++ b/fluent-react/makefile
@@ -35,18 +35,12 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@$(TYPEDOC) src \
-	    --out ../html/react \
-	    --mode file \
-	    --excludeNotExported \
-	    --excludePrivate \
-	    --logger none \
-	    --hideGenerator
+	@$(TYPEDOC_CMD)
 	@echo -e " $(OK) html built"
 
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
-	@rm -rf ../html/react
+	@rm -rf $(DOC_DESTINATION)
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"

--- a/fluent-sequence/makefile
+++ b/fluent-sequence/makefile
@@ -28,18 +28,12 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@$(TYPEDOC) src \
-	    --out ../html/sequence \
-	    --mode file \
-	    --excludeNotExported \
-	    --excludePrivate \
-	    --logger none \
-	    --hideGenerator
+	@$(TYPEDOC_CMD)
 	@echo -e " $(OK) html built"
 
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
-	@rm -rf ../html/sequence
+	@rm -rf $(DOC_DESTINATION)
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"

--- a/fluent-sequence/makefile
+++ b/fluent-sequence/makefile
@@ -18,7 +18,7 @@ esm/.compiled: $(SOURCES)
 
 .PHONY: test
 test: esm/.compiled
-	@$(MAKE) mocha-test
+	@$(MOCHA_CMD)
 
 .PHONY: build
 build: index.js

--- a/fluent-sequence/makefile
+++ b/fluent-sequence/makefile
@@ -24,12 +24,7 @@ test: esm/.compiled
 build: index.js
 
 index.js: esm/.compiled
-	@$(ROLLUP) $(CURDIR)/esm/index.js \
-	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --amd.id $(PACKAGE) \
-	    --name $(GLOBAL) \
-	    --output.format umd \
-	    --output.file $@
+	@$(ROLLUP_CMD) $@
 	@echo -e " $(OK) $@ built"
 
 html:

--- a/fluent-sequence/makefile
+++ b/fluent-sequence/makefile
@@ -4,30 +4,27 @@ GLOBAL  := FluentSequence
 include ../common.mk
 
 lint:
-	@eslint --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
-	@eslint --config $(ROOT)/eslint_test.json --max-warnings 0 test/
+	@$(ESLINT) --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
+	@$(ESLINT) --config $(ROOT)/eslint_test.json --max-warnings 0 test/
 	@echo -e " $(OK) lint"
 
 .PHONY: compile
 compile: esm/.compiled
 
 esm/.compiled: $(SOURCES)
-	@tsc
+	@$(TSC)
 	@touch $@
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
 test: esm/.compiled
-	@nyc --reporter=text --reporter=html mocha \
-	    --recursive --ui tdd \
-	    --require esm \
-	    test/**/*_test.js
+	@$(MAKE) mocha-test
 
 .PHONY: build
 build: index.js
 
 index.js: esm/.compiled
-	@rollup $(CURDIR)/esm/index.js \
+	@$(ROLLUP) $(CURDIR)/esm/index.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -36,7 +33,7 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@typedoc src \
+	@$(TYPEDOC) src \
 	    --out ../html/sequence \
 	    --mode file \
 	    --excludeNotExported \
@@ -48,5 +45,6 @@ html:
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
+	@rm -rf ../html/sequence
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"

--- a/fluent-syntax/makefile
+++ b/fluent-syntax/makefile
@@ -18,7 +18,7 @@ esm/.compiled: $(SOURCES)
 
 .PHONY: test
 test: esm/.compiled
-	@$(MAKE) mocha-test
+	@$(MOCHA_CMD)
 
 .PHONY: build
 build: index.js

--- a/fluent-syntax/makefile
+++ b/fluent-syntax/makefile
@@ -28,19 +28,13 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@$(TYPEDOC) src \
-	    --out ../html/syntax \
-	    --mode file \
-	    --excludeNotExported \
-	    --excludePrivate \
-	    --logger none \
-	    --hideGenerator
+	@$(TYPEDOC_CMD)
 	@echo -e " $(OK) html built"
 
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
-	@rm -rf ../html/syntax
+	@rm -rf $(DOC_DESTINATION)
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"
 

--- a/fluent-syntax/makefile
+++ b/fluent-syntax/makefile
@@ -4,30 +4,27 @@ GLOBAL  := FluentSyntax
 include ../common.mk
 
 lint:
-	@eslint --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
-	@eslint --config $(ROOT)/eslint_test.json --max-warnings 0 test/
+	@$(ESLINT) --config $(ROOT)/eslint_ts.json --max-warnings 0 src/*.ts
+	@$(ESLINT) --config $(ROOT)/eslint_test.json --max-warnings 0 test/
 	@echo -e " $(OK) lint"
 
 .PHONY: compile
 compile: esm/.compiled
 
 esm/.compiled: $(SOURCES)
-	@tsc
+	@$(TSC)
 	@touch $@
 	@echo -e " $(OK) esm/ compiled"
 
 .PHONY: test
 test: esm/.compiled
-	@nyc --reporter=text --reporter=html mocha \
-	    --recursive --ui tdd \
-	    --require esm \
-	    test/**/*_test.js
+	@$(MAKE) mocha-test
 
 .PHONY: build
 build: index.js
 
 index.js: esm/.compiled
-	@rollup $(CURDIR)/esm/index.js \
+	@$(ROLLUP) $(CURDIR)/esm/index.js \
 	    --banner "/* $(PACKAGE)@$(VERSION) */" \
 	    --amd.id $(PACKAGE) \
 	    --name $(GLOBAL) \
@@ -36,7 +33,7 @@ index.js: esm/.compiled
 	@echo -e " $(OK) $@ built"
 
 html:
-	@typedoc src \
+	@$(TYPEDOC) src \
 	    --out ../html/syntax \
 	    --mode file \
 	    --excludeNotExported \
@@ -48,6 +45,7 @@ html:
 clean:
 	@rm -f esm/*.js esm/*.d.ts esm/.compiled
 	@rm -f index.js
+	@rm -rf ../html/syntax
 	@rm -rf .nyc_output coverage
 	@echo -e " $(OK) clean"
 

--- a/fluent-syntax/makefile
+++ b/fluent-syntax/makefile
@@ -24,12 +24,7 @@ test: esm/.compiled
 build: index.js
 
 index.js: esm/.compiled
-	@$(ROLLUP) $(CURDIR)/esm/index.js \
-	    --banner "/* $(PACKAGE)@$(VERSION) */" \
-	    --amd.id $(PACKAGE) \
-	    --name $(GLOBAL) \
-	    --output.format umd \
-	    --output.file $@
+	@$(ROLLUP_CMD) $@
 	@echo -e " $(OK) $@ built"
 
 html:

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 export SHELL := /bin/bash
-export PATH  := $(CURDIR)/node_modules/.bin:$(PATH)
+GH_PAGES ?= $(CURDIR)/node_modules/.bin/gh-pages
 
 TARGETS  := all dist lint test build html deps depsclean
 PACKAGES := $(wildcard fluent-*)
@@ -14,7 +14,7 @@ $(PACKAGES):
 .PHONY: $(TARGETS) $(PACKAGES)
 
 deploy-html:
-	gh-pages -d html
+	$(GH_PAGES) -d html
 
 clean: $(PACKAGES)
 	@echo


### PR DESCRIPTION
On macos, GNU make eagerly avoids calling into the shell,
so exposing node commands through $PATH doesn't work half of the
time.

I've put two alternatives up in the PR to give some context.

In #486, you mentioned you'd prefer absolute paths. I've done that in `fluent-dedent`. I've done it for commands that need it, so `tsc` and `eslint`. I've done it consistently for `eslint`, though only one needs it. I've not done it for `rollup` or `nyc`. Looking at my changes, I'm not fond.

I've also thrown out the start of doing `$(ESLINT)` in `fluent-dom`. Turns out that's actually much more *make*ier, now that I think about it.

@stasm, mind if I go for the latter consistently, and also drop the `$(ROOT)/node_modules/.bin` from `$PATH`?