### PR TITLE
(fluent-bundle) Rename FluentArgument to FluentVariable

### DIFF
--- a/fluent-bundle/src/bundle.ts
+++ b/fluent-bundle/src/bundle.ts
@@ -7,8 +7,8 @@ import { NUMBER, DATETIME } from "./builtins.js";
 
 export type TextTransform = (text: string) => string;
 
-type NativeArgument = string | number | Date;
-export type FluentArgument = FluentValue | NativeArgument;
+type NativeValue = string | number | Date;
+export type FluentVariable = FluentValue | NativeValue;
 
 /**
  * Message bundles are single-language stores of translation resources. They are
@@ -176,7 +176,7 @@ export class FluentBundle {
    */
   formatPattern(
     pattern: Pattern,
-    args: Record<string, FluentArgument> | null = null,
+    args: Record<string, FluentVariable> | null = null,
     errors: Array<Error> | null = null
   ): string {
     // Resolve a simple pattern without creating a scope. No error handling is

--- a/fluent-bundle/src/index.ts
+++ b/fluent-bundle/src/index.ts
@@ -7,11 +7,7 @@
  *
  */
 
-export {
-  FluentBundle,
-  FluentArgument,
-  TextTransform
-} from "./bundle.js";
+export { FluentBundle, FluentVariable, TextTransform } from "./bundle.js";
 export { FluentResource } from "./resource.js";
 export {
   FluentValue,

--- a/fluent-bundle/src/resolver.ts
+++ b/fluent-bundle/src/resolver.ts
@@ -44,7 +44,7 @@ import {
   ComplexPattern,
   Pattern
 } from "./ast.js";
-import { FluentArgument } from "./bundle.js";
+import { FluentVariable } from "./bundle.js";
 
 // The maximum number of placeables which can be expanded in a single call to
 // `formatPattern`. The limit protects against the Billion Laughs and Quadratic
@@ -153,7 +153,7 @@ function resolveVariableReference(
   scope: Scope,
   { name }: VariableReference
 ): FluentValue {
-  let arg: FluentArgument;
+  let arg: FluentVariable;
   if (scope.params) {
     // We're inside a TermReference. It's OK to reference undefined parameters.
     if (Object.prototype.hasOwnProperty.call(scope.params, name)) {

--- a/fluent-bundle/src/scope.ts
+++ b/fluent-bundle/src/scope.ts
@@ -1,4 +1,4 @@
-import { FluentBundle, FluentArgument } from "./bundle.js";
+import { FluentBundle, FluentVariable } from "./bundle.js";
 import { ComplexPattern } from "./ast.js";
 
 export class Scope {
@@ -7,12 +7,12 @@ export class Scope {
   /** The list of errors collected while resolving. */
   public errors: Array<Error> | null;
   /** A dict of developer-provided variables. */
-  public args: Record<string, FluentArgument> | null;
+  public args: Record<string, FluentVariable> | null;
   /** The Set of patterns already encountered during this resolution.
    * Used to detect and prevent cyclic resolutions. */
   public dirty: WeakSet<ComplexPattern> = new WeakSet();
   /** A dict of parameters passed to a TermReference. */
-  public params: Record<string, FluentArgument> | null = null;
+  public params: Record<string, FluentVariable> | null = null;
   /** The running count of placeables resolved so far. Used to detect the
     * Billion Laughs and Quadratic Blowup attacks. */
   public placeables: number = 0;
@@ -20,7 +20,7 @@ export class Scope {
   constructor(
     bundle: FluentBundle,
     errors: Array<Error> | null,
-    args: Record<string, FluentArgument> | null,
+    args: Record<string, FluentVariable> | null,
   ) {
     this.bundle = bundle;
     this.errors = errors;


### PR DESCRIPTION
We've been using this naming for a while but so far it hasn't been reflected in the code. Since I'm about to publish `@fluent/bundle` 0.16 with the changes to the build system and the compatibility strategy, I'd like to take the opportunity to make this rename.

I'll need to update `@fluent/react` afterwards, too.