### PR TITLE
@fluent/syntax: Don't drop to newline when serializing patterns starting with special chars

### DIFF
--- a/fluent-bundle/test/fixtures_reference/special_chars.json
+++ b/fluent-bundle/test/fixtures_reference/special_chars.json
@@ -1,0 +1,19 @@
+{
+    "body": [
+        {
+            "id": "bracket-inline",
+            "value": "[Value]",
+            "attributes": {}
+        },
+        {
+            "id": "dot-inline",
+            "value": ".Value",
+            "attributes": {}
+        },
+        {
+            "id": "star-inline",
+            "value": "*Value",
+            "attributes": {}
+        }
+    ]
+}

--- a/fluent-syntax/test/fixtures_reference/special_chars.ftl
+++ b/fluent-syntax/test/fixtures_reference/special_chars.ftl
@@ -1,0 +1,14 @@
+## OK
+
+bracket-inline = [Value]
+dot-inline = .Value
+star-inline = *Value
+
+## ERRORS
+
+bracket-newline =
+    [Value]
+dot-newline =
+    .Value
+star-newline =
+    *Value

--- a/fluent-syntax/test/fixtures_reference/special_chars.json
+++ b/fluent-syntax/test/fixtures_reference/special_chars.json
@@ -1,0 +1,82 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "GroupComment",
+            "content": "OK"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "bracket-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "[Value]"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "dot-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": ".Value"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "star-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "*Value"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "GroupComment",
+            "content": "ERRORS"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "bracket-newline =\n    [Value]\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "dot-newline =\n    .Value\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "star-newline =\n    *Value\n"
+        }
+    ]
+}

--- a/fluent-syntax/test/serializer_test.js
+++ b/fluent-syntax/test/serializer_test.js
@@ -188,6 +188,30 @@ suite("Serialize resource", function() {
     assert.strictEqual(pretty(input), input);
   });
 
+  test("multiline starting inline", function() {
+    const input = ftl`
+      foo = Foo
+          Bar
+
+      `;
+    const output = ftl`
+      foo =
+          Foo
+          Bar
+
+      `;
+    assert.strictEqual(pretty(input), output);
+  });
+
+  test("multiline starting inline with a special char", function() {
+    const input = ftl`
+      foo = *Foo
+          Bar
+
+      `;
+    assert.strictEqual(pretty(input), input);
+  });
+
   test("multiline with placeable", function() {
     const input = ftl`
       foo =
@@ -336,6 +360,17 @@ suite("Serialize resource", function() {
 
       `;
     assert.strictEqual(pretty(input), output);
+  });
+
+  test("select expression in inline value starting with a special char", function() {
+    const input = ftl`
+      foo = .Foo { $sel ->
+             *[a] A
+              [b] B
+          }
+
+      `;
+    assert.strictEqual(pretty(input), input);
   });
 
   test("select expression in multiline value", function() {


### PR DESCRIPTION
Fix #512.