### PR TITLE
Explicitly test reporting errors in fluent-react

### DIFF
--- a/fluent-react/package.json
+++ b/fluent-react/package.json
@@ -44,6 +44,12 @@
   "engines": {
     "node": ">=10.0.0"
   },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "./test/setup.js"
+    ],
+    "restoreMocks": true
+  },
   "dependencies": {
     "@fluent/sequence": "0.5.0",
     "cached-iterable": "^0.2.1",

--- a/fluent-react/test/localized_change.test.js
+++ b/fluent-react/test/localized_change.test.js
@@ -1,8 +1,11 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { ReactLocalization, LocalizationProvider, Localized }
-  from "../esm/index";
+import {
+  ReactLocalization,
+  LocalizationProvider,
+  Localized
+} from "../esm/index";
 
 test("relocalizes", () => {
   const Root = ({ l10n }) => (
@@ -14,10 +17,14 @@ test("relocalizes", () => {
   );
 
   const bundle1 = new FluentBundle();
-  bundle1.addResource(new FluentResource(`
+  bundle1.addResource(
+    new FluentResource(`
 foo = FOO
-`));
-  const renderer = TestRenderer.create(<Root l10n={new ReactLocalization([bundle1])} />);
+`)
+  );
+  const renderer = TestRenderer.create(
+    <Root l10n={new ReactLocalization([bundle1])} />
+  );
   expect(renderer.toJSON()).toMatchInlineSnapshot(`
     <div>
       FOO
@@ -25,9 +32,11 @@ foo = FOO
   `);
 
   const bundle2 = new FluentBundle();
-  bundle2.addResource(new FluentResource(`
+  bundle2.addResource(
+    new FluentResource(`
 foo = BAR
-`));
+`)
+  );
   renderer.update(<Root l10n={new ReactLocalization([bundle2])} />);
   expect(renderer.toJSON()).toMatchInlineSnapshot(`
     <div>

--- a/fluent-react/test/localized_fallback.test.js
+++ b/fluent-react/test/localized_fallback.test.js
@@ -1,14 +1,19 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { ReactLocalization, LocalizationProvider, Localized }
-  from "../esm/index";
+import {
+  ReactLocalization,
+  LocalizationProvider,
+  Localized
+} from "../esm/index";
 
 test("uses message from 1st bundle", () => {
   const bundle1 = new FluentBundle();
-  bundle1.addResource(new FluentResource(`
+  bundle1.addResource(
+    new FluentResource(`
 foo = FOO
-`));
+`)
+  );
 
   const renderer = TestRenderer.create(
     <LocalizationProvider l10n={new ReactLocalization([bundle1])}>
@@ -29,12 +34,16 @@ test("uses message from the 2nd bundle", function() {
   const bundle1 = new FluentBundle();
   const bundle2 = new FluentBundle();
 
-  bundle1.addResource(new FluentResource(`
+  bundle1.addResource(
+    new FluentResource(`
 not-foo = NOT FOO
-`));
-  bundle2.addResource(new FluentResource(`
+`)
+  );
+  bundle2.addResource(
+    new FluentResource(`
 foo = FOO
-`));
+`)
+  );
 
   const renderer = TestRenderer.create(
     <LocalizationProvider l10n={new ReactLocalization([bundle1, bundle2])}>
@@ -53,9 +62,11 @@ foo = FOO
 
 test("falls back back for missing message", function() {
   const bundle1 = new FluentBundle();
-  bundle1.addResource(new FluentResource(`
+  bundle1.addResource(
+    new FluentResource(`
 not-foo = NOT FOO
-`));
+`)
+  );
 
   const renderer = TestRenderer.create(
     <LocalizationProvider l10n={new ReactLocalization([bundle1])}>

--- a/fluent-react/test/localized_overlay.test.js
+++ b/fluent-react/test/localized_overlay.test.js
@@ -2,16 +2,21 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
 import { createParseMarkup } from "../esm/markup";
-import { ReactLocalization, LocalizationProvider, Localized }
-  from "../esm/index";
+import {
+  ReactLocalization,
+  LocalizationProvider,
+  Localized
+} from "../esm/index";
 
 describe("Localized - overlay", () => {
   test("< in text", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 true = 0 < 3 is true.
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -31,9 +36,11 @@ true = 0 < 3 is true.
   test("& in text", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 megaman = Jumping & Shooting
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -53,9 +60,11 @@ megaman = Jumping & Shooting
   test("HTML entity", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 two = First &middot; Second
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -75,67 +84,79 @@ two = First &middot; Second
   test("one element is matched", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = Click <button>me</button>!
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{button: <button onClick={alert}></button>}}>
+        <Localized
+          id="foo"
+          elems={{ button: <button onClick={alert}></button> }}
+        >
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    Click 
-                    <button
-                      onClick={[Function]}
-                    >
-                      me
-                    </button>
-                    !
-                  </div>
-            `);
+      <div>
+        Click 
+        <button
+          onClick={[Function]}
+        >
+          me
+        </button>
+        !
+      </div>
+    `);
   });
 
   test("an element of different case is lowercased and matched", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = Click <button>me</button>!
-`));
+`)
+    );
 
     // The Button prop is capitalized whereas the <button> element in the
     // translation is lowercase.
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{Button: <button onClick={alert}></button>}}>
+        <Localized
+          id="foo"
+          elems={{ Button: <button onClick={alert}></button> }}
+        >
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    Click 
-                    <button
-                      onClick={[Function]}
-                    >
-                      me
-                    </button>
-                    !
-                  </div>
-            `);
+      <div>
+        Click 
+        <button
+          onClick={[Function]}
+        >
+          me
+        </button>
+        !
+      </div>
+    `);
   });
 
   test("two elements are matched", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = <confirm>Sign in</confirm> or <cancel>cancel</cancel>.
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -152,60 +173,67 @@ foo = <confirm>Sign in</confirm> or <cancel>cancel</cancel>.
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    <button
-                      className="confirm"
-                    >
-                      Sign in
-                    </button>
-                     or 
-                    <button
-                      className="cancel"
-                    >
-                      cancel
-                    </button>
-                    .
-                  </div>
-            `);
+      <div>
+        <button
+          className="confirm"
+        >
+          Sign in
+        </button>
+         or 
+        <button
+          className="cancel"
+        >
+          cancel
+        </button>
+        .
+      </div>
+    `);
   });
 
   test("unexpected child is reduced to text", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = <confirm>Sign in</confirm> or <cancel>cancel</cancel>.
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{
+        <Localized
+          id="foo"
+          elems={{
             confirm: <button className="confirm"></button>
-        }}>
+          }}
+        >
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-            <div>
-              <button
-                className="confirm"
-              >
-                Sign in
-              </button>
-               or 
-              cancel
-              .
-            </div>
-        `);
+      <div>
+        <button
+          className="confirm"
+        >
+          Sign in
+        </button>
+         or 
+        cancel
+        .
+      </div>
+    `);
   });
 
   test("element not found in the translation is removed", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = <confirm>Sign in</confirm>.
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -236,69 +264,81 @@ foo = <confirm>Sign in</confirm>.
   test("attributes on translated children are ignored", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = Click <button className="foo">me</button>!
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{button: <button onClick={alert}></button>}}>
+        <Localized
+          id="foo"
+          elems={{ button: <button onClick={alert}></button> }}
+        >
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    Click 
-                    <button
-                      onClick={[Function]}
-                    >
-                      me
-                    </button>
-                    !
-                  </div>
-            `);
+      <div>
+        Click 
+        <button
+          onClick={[Function]}
+        >
+          me
+        </button>
+        !
+      </div>
+    `);
   });
 
   test("nested children are ignored", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = Click <button><em>me</em></button>!
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{button: <button onClick={alert}></button>}}>
+        <Localized
+          id="foo"
+          elems={{ button: <button onClick={alert}></button> }}
+        >
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    Click 
-                    <button
-                      onClick={[Function]}
-                    >
-                      me
-                    </button>
-                    !
-                  </div>
-            `);
+      <div>
+        Click 
+        <button
+          onClick={[Function]}
+        >
+          me
+        </button>
+        !
+      </div>
+    `);
   });
 
   test("non-React element prop is used in markup", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = <confirm>Sign in</confirm>.
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{confirm: "Not a React element"}}>
+        <Localized id="foo" elems={{ confirm: "Not a React element" }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -319,65 +359,71 @@ describe("Localized - overlay of void elements", () => {
   test("void prop name, void prop value, void translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <input/> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{input: <input type="text" />}}>
+        <Localized id="foo" elems={{ input: <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+         AFTER
+      </div>
+    `);
   });
 
   test("void prop name, void prop value, empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <input></input> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{input: <input type="text" />}}>
+        <Localized id="foo" elems={{ input: <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+         AFTER
+      </div>
+    `);
   });
 
   test("void prop name, void prop value, non-empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <input>Foo</input> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{input: <input type="text" />}}>
+        <Localized id="foo" elems={{ input: <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -386,78 +432,84 @@ foo = BEFORE <input>Foo</input> AFTER
     // The opening <input> tag is parsed as an HTMLInputElement and the closing
     // </input> is ignored. "Foo" is then parsed as a regular text node.
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                    Foo AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+        Foo AFTER
+      </div>
+    `);
   });
 
   test("void prop name, non-empty prop value, void translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <input/> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{input: <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ input: <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                      
-                    </span>
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+          
+        </span>
+         AFTER
+      </div>
+    `);
   });
 
   test("void prop name, non-empty prop value, empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <input></input> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{input: <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ input: <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                      
-                    </span>
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+          
+        </span>
+         AFTER
+      </div>
+    `);
   });
 
   test("void prop name, non-empty prop value, non-empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <input>Foo</input> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{input: <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ input: <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -466,26 +518,28 @@ foo = BEFORE <input>Foo</input> AFTER
     // The opening <input> tag is parsed as an HTMLInputElement and the closing
     // </input> is ignored. "Foo" is then parsed as a regular text node.
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                      
-                    </span>
-                    Foo AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+          
+        </span>
+        Foo AFTER
+      </div>
+    `);
   });
 
   test("non-void prop name, void prop value, void translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <span/> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{span: <input type="text" />}}>
+        <Localized id="foo" elems={{ span: <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -497,77 +551,83 @@ foo = BEFORE <span/> AFTER
     // it becomes its children and is ignored because the <input> passed as a
     // prop is known to be void.
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+      </div>
+    `);
   });
 
   test("non-void prop name, void prop value, empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <span></span> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{span: <input type="text" />}}>
+        <Localized id="foo" elems={{ span: <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+         AFTER
+      </div>
+    `);
   });
 
   test("non-void prop name, void prop value, non-empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <span>Foo</span> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{span: <input type="text" />}}>
+        <Localized id="foo" elems={{ span: <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+         AFTER
+      </div>
+    `);
   });
 
   test("non-void prop name, non-empty prop value, void translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <span/> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{span: <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ span: <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -578,77 +638,83 @@ foo = BEFORE <span/> AFTER
     // <span/> is parsed as an unclosed <span> element. Everything that follows
     // it becomes its children and is inserted into the <span> passed as a prop.
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                       AFTER
-                    </span>
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+           AFTER
+        </span>
+      </div>
+    `);
   });
 
   test("non-void prop name, non-empty prop value, empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <span></span> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{span: <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ span: <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                      
-                    </span>
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+          
+        </span>
+         AFTER
+      </div>
+    `);
   });
 
   test("non-void prop name, non-empty prop value, non-empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <span>Foo</span> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{span: <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ span: <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                      Foo
-                    </span>
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+          Foo
+        </span>
+         AFTER
+      </div>
+    `);
   });
 
   test("custom prop name, void prop value, void translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <text-input/> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{"text-input": <input type="text" />}}>
+        <Localized id="foo" elems={{ "text-input": <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -660,77 +726,83 @@ foo = BEFORE <text-input/> AFTER
     // Everything that follows it becomes its children which are ignored because
     // the <input> passed as a prop is known to be void.
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+      </div>
+    `);
   });
 
   test("custom prop name, void prop value, empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <text-input></text-input> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{"text-input": <input type="text" />}}>
+        <Localized id="foo" elems={{ "text-input": <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+         AFTER
+      </div>
+    `);
   });
 
   test("custom prop name, void prop value, non-empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <text-input>Foo</text-input> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{"text-input": <input type="text" />}}>
+        <Localized id="foo" elems={{ "text-input": <input type="text" /> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <input
-                      type="text"
-                    />
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <input
+          type="text"
+        />
+         AFTER
+      </div>
+    `);
   });
 
   test("custom prop name, non-empty prop value, void translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <text-elem/> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{"text-elem": <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ "text-elem": <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -742,74 +814,80 @@ foo = BEFORE <text-elem/> AFTER
     // Everything that follows it becomes its children which are inserted into
     // the <span> passed as a prop.
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                       AFTER
-                    </span>
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+           AFTER
+        </span>
+      </div>
+    `);
   });
 
   test("custom prop name, non-empty prop value, empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <text-elem></text-elem> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{"text-elem": <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ "text-elem": <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                      
-                    </span>
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+          
+        </span>
+         AFTER
+      </div>
+    `);
   });
 
   test("custom prop name, non-empty prop value, non-empty translation", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = BEFORE <text-elem>Foo</text-elem> AFTER
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{"text-elem": <span>Hardcoded</span>}}>
+        <Localized id="foo" elems={{ "text-elem": <span>Hardcoded</span> }}>
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    BEFORE 
-                    <span>
-                      Foo
-                    </span>
-                     AFTER
-                  </div>
-            `);
+      <div>
+        BEFORE 
+        <span>
+          Foo
+        </span>
+         AFTER
+      </div>
+    `);
   });
 });
 
 describe("Localized - custom parseMarkup", () => {
   test("disables the overlay logic if null", () => {
     const bundle = new FluentBundle();
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = test <em>null markup parser</em>
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle], null)}>
@@ -836,10 +914,12 @@ foo = test <em>null markup parser</em>
 
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 # We must use an HTML tag to trigger the overlay logic.
 foo = test <em>custom markup parser</em>
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle], parseMarkup)}>
@@ -864,10 +944,12 @@ foo = test <em>custom markup parser</em>
 
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 # We must use an HTML tag to trigger the overlay logic.
 foo = test <em>custom markup parser</em>
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle], parseMarkup)}>

--- a/fluent-react/test/localized_render.test.js
+++ b/fluent-react/test/localized_render.test.js
@@ -1,8 +1,11 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { ReactLocalization, LocalizationProvider, Localized }
-  from "../esm/index";
+import {
+  ReactLocalization,
+  LocalizationProvider,
+  Localized
+} from "../esm/index";
 
 describe("Localized - rendering", () => {
   test("render the value", () => {
@@ -176,10 +179,12 @@ foo =
   test("protect existing attributes if setting is forbidden", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo =
     .existing = ATTR
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -199,10 +204,12 @@ foo =
   test("protect existing attributes by default", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo =
     .existing = ATTR
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -222,10 +229,12 @@ foo =
   test("preserve children when translation value is null", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo =
     .title = TITLE
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -252,13 +261,15 @@ foo =
     const bundle = new FluentBundle("en", { useIsolating: false });
     const format = jest.spyOn(bundle, "formatPattern");
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = { $arg }
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" vars={{arg: "ARG"}}>
+        <Localized id="foo" vars={{ arg: "ARG" }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -270,7 +281,11 @@ foo = { $arg }
       </div>
     `);
 
-    expect(format).toHaveBeenCalledWith(expect.anything(), { arg: "ARG" }, expect.anything());
+    expect(format).toHaveBeenCalledWith(
+      expect.anything(),
+      { arg: "ARG" },
+      expect.anything()
+    );
   });
 
   test("$arg is passed to format the attributes", () => {
@@ -286,7 +301,7 @@ foo = { $arg }
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" attrs={{ title: true }} vars={{arg: "ARG"}}>
+        <Localized id="foo" attrs={{ title: true }} vars={{ arg: "ARG" }}>
           <div />
         </Localized>
       </LocalizationProvider>
@@ -301,13 +316,23 @@ foo = { $arg }
     `);
 
     // The value.
-    expect(format).toHaveBeenNthCalledWith(1, expect.anything(), {
-      arg: "ARG"
-    }, expect.anything());
+    expect(format).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      {
+        arg: "ARG"
+      },
+      expect.anything()
+    );
     // The attribute.
-    expect(format).toHaveBeenNthCalledWith(2, expect.anything(), {
-      arg: "ARG"
-    }, expect.anything());
+    expect(format).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      {
+        arg: "ARG"
+      },
+      expect.anything()
+    );
   });
 
   test("render with a fragment and no message preserves the fragment", () => {
@@ -359,10 +384,12 @@ foo = { $arg }
 
   test("render with a fragment and no message value preserves the fragment", () => {
     const bundle = new FluentBundle();
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo =
     .attr = Attribute
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -383,9 +410,11 @@ foo =
 
   test("render with a fragment renders the message into the fragment", () => {
     const bundle = new FluentBundle();
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = Test message
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -416,10 +445,12 @@ foo = Test message
 
   test("render with an empty fragment and no message value preserves the fragment", () => {
     const bundle = new FluentBundle();
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo =
     .attr = Attribute
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -434,9 +465,11 @@ foo =
 
   test("render with an empty fragment renders the message into the fragment", () => {
     const bundle = new FluentBundle();
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = Test message
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -463,9 +496,11 @@ foo = Test message
 
   test("render with a string fallback returns the message", () => {
     const bundle = new FluentBundle();
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = Test message
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -479,9 +514,11 @@ foo = Test message
   test("render without a fallback returns the message", () => {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = Message
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>

--- a/fluent-react/test/localized_render.test.js
+++ b/fluent-react/test/localized_render.test.js
@@ -356,6 +356,7 @@ foo = { $arg }
   });
 
   test("A missing $arg does not break rendering", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
     const bundle = new FluentBundle("en", { useIsolating: false });
 
     bundle.addResource(
@@ -380,6 +381,16 @@ foo = { $arg }
               {$arg}
             </div>
         `);
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] ReferenceError: Unknown variable: $arg",
+        ],
+        Array [
+          "[@fluent/react] ReferenceError: Unknown variable: $arg",
+        ],
+      ]
+    `);
   });
 
   test("render with a fragment and no message value preserves the fragment", () => {

--- a/fluent-react/test/localized_valid.test.js
+++ b/fluent-react/test/localized_valid.test.js
@@ -1,6 +1,10 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import { ReactLocalization, LocalizationProvider, Localized } from "../esm/index";
+import {
+  ReactLocalization,
+  LocalizationProvider,
+  Localized
+} from "../esm/index";
 
 describe("Localized - validation", () => {
   let consoleError = console.error;
@@ -54,8 +58,8 @@ describe("Localized - validation", () => {
             <div />
           </Localized>
         </LocalizationProvider>
-      )
-    }).toThrow(/single/)
+      );
+    }).toThrow(/single/);
   });
 
   test("without id", () => {

--- a/fluent-react/test/localized_valid.test.js
+++ b/fluent-react/test/localized_valid.test.js
@@ -7,16 +7,6 @@ import {
 } from "../esm/index";
 
 describe("Localized - validation", () => {
-  let consoleError = console.error;
-
-  beforeAll(() => {
-    console.error = () => {};
-  });
-
-  afterAll(() => {
-    console.error = consoleError;
-  });
-
   test("inside of a LocalizationProvider", () => {
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([])}>
@@ -50,6 +40,9 @@ describe("Localized - validation", () => {
   });
 
   test("with multiple children", () => {
+    // React also does a console.error, ignore that here.
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
     expect(() => {
       TestRenderer.create(
         <LocalizationProvider l10n={new ReactLocalization([])}>
@@ -60,6 +53,8 @@ describe("Localized - validation", () => {
         </LocalizationProvider>
       );
     }).toThrow(/single/);
+
+    expect(console.error).toHaveBeenCalled();
   });
 
   test("without id", () => {

--- a/fluent-react/test/localized_void.test.js
+++ b/fluent-react/test/localized_void.test.js
@@ -1,16 +1,21 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { ReactLocalization, LocalizationProvider, Localized }
-  from "../esm/index";
+import {
+  ReactLocalization,
+  LocalizationProvider,
+  Localized
+} from "../esm/index";
 
 describe("Localized - void elements", function() {
   test("do not render the value in void elements", function() {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = FOO
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -26,10 +31,12 @@ foo = FOO
   test("render attributes in void elements", function() {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo =
     .title = TITLE
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -49,10 +56,12 @@ foo =
   test("render attributes but not value in void elements", function() {
     const bundle = new FluentBundle();
 
-    bundle.addResource(new FluentResource(`
+    bundle.addResource(
+      new FluentResource(`
 foo = FOO
     .title = TITLE
-`));
+`)
+    );
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>

--- a/fluent-react/test/provider_valid.test.js
+++ b/fluent-react/test/provider_valid.test.js
@@ -1,12 +1,12 @@
 import React from "react";
-import TestRenderer, {act} from "react-test-renderer";
+import TestRenderer, { act } from "react-test-renderer";
 import { ReactLocalization, LocalizationProvider } from "../esm/index";
 
 describe("LocalizationProvider - validation", () => {
   let consoleError = console.error;
 
   beforeAll(() => {
-    console.error = (message) => {
+    console.error = message => {
       if (/(Failed prop type)/.test(message)) {
         throw new Error(message);
       }
@@ -28,7 +28,9 @@ describe("LocalizationProvider - validation", () => {
 
   test("without a child", () => {
     expect(() => {
-      TestRenderer.create(<LocalizationProvider l10n={new ReactLocalization([])} />);
+      TestRenderer.create(
+        <LocalizationProvider l10n={new ReactLocalization([])} />
+      );
     }).toThrow(/required/);
   });
 

--- a/fluent-react/test/setup.js
+++ b/fluent-react/test/setup.js
@@ -1,0 +1,11 @@
+beforeEach(() => {
+  jest.spyOn(console, "warn").mockImplementation((...messages) => {
+    throw new Error([
+      "Unexpected console.warn() in a test run. Add a jest.spyOn(console, \"warn\")",
+      "line to the test if this console.warn is actually expected.",
+      "",
+      "console.warn message:",
+      ...messages
+    ].join('\n'));
+  });
+});

--- a/fluent-react/test/use_localization.test.js
+++ b/fluent-react/test/use_localization.test.js
@@ -1,14 +1,16 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { ReactLocalization, LocalizationProvider, useLocalization } from "../esm/index";
+import {
+  ReactLocalization,
+  LocalizationProvider,
+  useLocalization
+} from "../esm/index";
 
 function DummyComponent() {
   const { l10n } = useLocalization();
 
-  return (
-    <p>{l10n.getString('foo')}</p>
-  );
+  return <p>{l10n.getString("foo")}</p>;
 }
 
 describe("useLocalization", () => {

--- a/fluent-react/test/with_localization.test.js
+++ b/fluent-react/test/with_localization.test.js
@@ -1,7 +1,11 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { FluentBundle, FluentResource } from "@fluent/bundle";
-import { ReactLocalization, LocalizationProvider, withLocalization } from "../esm/index";
+import {
+  ReactLocalization,
+  LocalizationProvider,
+  withLocalization
+} from "../esm/index";
 
 function DummyComponent() {
   return <div />;

--- a/fluent-react/test/with_localization.test.js
+++ b/fluent-react/test/with_localization.test.js
@@ -31,6 +31,7 @@ describe("withLocalization", () => {
   });
 
   test("getString with access to the l10n context", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
     const bundle = new FluentBundle("en", { useIsolating: false });
     const EnhancedComponent = withLocalization(DummyComponent);
 
@@ -48,14 +49,24 @@ bar = BAR {$arg}
     );
 
     const { getString } = renderer.root.findByType(DummyComponent).props;
+
     // Returns the translation.
     expect(getString("foo", {})).toBe("FOO");
     expect(getString("bar", { arg: "ARG" })).toBe("BAR ARG");
-    // Doesn't throw on formatting errors.
+
+    // It reports an error on formatting errors, but doesn't throw.
     expect(getString("bar", {})).toBe("BAR {$arg}");
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] ReferenceError: Unknown variable: $arg",
+        ],
+      ]
+    `);
   });
 
   test("getString with access to the l10n context, with fallback value", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
     const bundle = new FluentBundle("en", { useIsolating: false });
     const EnhancedComponent = withLocalization(DummyComponent);
 
@@ -80,6 +91,13 @@ bar = BAR {$arg}
     expect(getString("bar", { arg: "ARG" })).toBe("BAR ARG");
     // Doesn't throw on formatting errors.
     expect(getString("bar", {})).toBe("BAR {$arg}");
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] ReferenceError: Unknown variable: $arg",
+        ],
+      ]
+    `);
   });
 
   test("getString without access to the l10n context", () => {


### PR DESCRIPTION
In preparation for #519, this PR adds explicit testing to the use of errors in fluent-react. I split this out into a separate PR, as I had to do a few different steps to get the proper testing in place to where I would feel comfortable adding the new feature. Each commit should be reviewed separately, and has a full commit message describing the decisions and process I went through.

There is no behavior change for the project, these changes are test only.