### PR TITLE
Nested children support in overlays 

### DIFF
--- a/fluent-react/test/localized_overlay.test.js
+++ b/fluent-react/test/localized_overlay.test.js
@@ -270,7 +270,10 @@ foo = Click <button><em>me</em></button>!
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo" elems={{button: <button onClick={alert}></button>}}>
+        <Localized id="foo" elems={{
+          button: <button onClick={alert}></button>,
+          em: <em></em>
+        }}>
           <div />
         </Localized>
       </LocalizationProvider>


### PR DESCRIPTION
This change makes it possible for translations to contain nested markup tags, like so:

```ftl
foo = This is some <em><strong>nested markup!</strong></em>
```

It also fixes the test which explicitly checks that this *doesn't* work, because that test was broken and incorrectly still passed after making this change. ¯\\\_(ツ)\_/¯ That's a separate commit though, so it can be picked out if desired.

Current state of tests: all tests pass, except the one which explicitly disallows this behaviour (obviously), as I'm not sure whether there's a specific reason why nested children have not been allowed up til now. I have not added new tests for this functionality, as I find it very frustrating to deal with TS and again, I have no idea whether this PR will be accepted or not :)

So yeah, this is a bit of a draft PR, I suppose. I need this in my own application (for basic Markdown support in translation strings), hence having created a fork, but I don't know whether you're also interested in it as the upstream.