### PR TITLE
Separate FluentNumber/Datetime opts when used in DATETIME/NUMBER, fix #526

### DIFF
--- a/fluent-bundle/src/builtins.ts
+++ b/fluent-bundle/src/builtins.ts
@@ -80,9 +80,15 @@ export function NUMBER(
     return new FluentNone(`NUMBER(${arg.valueOf()})`);
   }
 
-  if (arg instanceof FluentNumber || arg instanceof FluentDateTime) {
+  if (arg instanceof FluentNumber) {
     return new FluentNumber(arg.valueOf(), {
       ...arg.opts,
+      ...values(opts, NUMBER_ALLOWED)
+    });
+  }
+
+  if (arg instanceof FluentDateTime) {
+    return new FluentNumber(arg.valueOf(), {
       ...values(opts, NUMBER_ALLOWED)
     });
   }
@@ -151,9 +157,15 @@ export function DATETIME(
     return new FluentNone(`DATETIME(${arg.valueOf()})`);
   }
 
-  if (arg instanceof FluentNumber || arg instanceof FluentDateTime) {
+  if (arg instanceof FluentDateTime) {
     return new FluentDateTime(arg.valueOf(), {
       ...arg.opts,
+      ...values(opts, DATETIME_ALLOWED)
+    });
+  }
+
+  if (arg instanceof FluentNumber) {
+    return new FluentDateTime(arg.valueOf(), {
       ...values(opts, DATETIME_ALLOWED)
     });
   }

--- a/fluent-bundle/test/functions_builtin_test.js
+++ b/fluent-bundle/test/functions_builtin_test.js
@@ -177,6 +177,25 @@ suite('Built-in functions', function() {
       assert.strictEqual(errors.length, 0);
     });
 
+    test('FluentDateTime argument', function () {
+      // NUMBER must ignore datetime options
+      let date = new Date('2016-09-29');
+      let arg = new FluentDateTime(date, {
+        month: "short",
+        day: "numeric",
+      });
+
+      errors = [];
+      msg = bundle.getMessage('num-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,475,107,200,000');
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('num-fraction-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), '1,475,107,200,000.0');
+      assert.strictEqual(errors.length, 0);
+    });
+
     test('string argument', function() {
       let arg = "Foo";
 
@@ -427,6 +446,30 @@ suite('Built-in functions', function() {
       errors = [];
       msg = bundle.getMessage('dt-unknown');
       assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedMonthShort);
+      assert.strictEqual(errors.length, 0);
+    });
+
+    test('FluentNumber argument, minimumFractionDigits=3', function() {
+      // DATETIME must ignore number options
+      let date = new Date('2016-09-29');
+      let arg =  new FluentNumber(Number(date), {
+        minimumFractionDigits: 3
+      });
+
+      // Format the date argument to account for the testrunner's timezone.
+      let expectedDate =
+        (new Intl.DateTimeFormat('en-US')).format(date);
+      let expectedMonthLong =
+        (new Intl.DateTimeFormat('en-US', {month: 'long'})).format(date);
+
+      errors = [];
+      msg = bundle.getMessage('dt-bare');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedDate);
+      assert.strictEqual(errors.length, 0);
+
+      errors = [];
+      msg = bundle.getMessage('dt-month-valid');
+      assert.strictEqual(bundle.formatPattern(msg.value, {arg}, errors), expectedMonthLong);
       assert.strictEqual(errors.length, 0);
     });
 


### PR DESCRIPTION
The FluentType opts are not compatible between dates and numbers, don't pass one to the formatter of the other.

As I mentioned in #526, this is compatible with what gecko does for fluent-rs, AFAICT.