### PR TITLE
Provided better errors when components are mis-configured

### DIFF
--- a/fluent-react/src/context.ts
+++ b/fluent-react/src/context.ts
@@ -1,4 +1,5 @@
 import { createContext } from "react";
 import { ReactLocalization } from "./localization";
 
-export let FluentContext = createContext(new ReactLocalization([], null));
+export let FluentContext =
+  createContext(null) as React.Context<ReactLocalization | null>;

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -30,6 +30,11 @@ export class ReactLocalization {
     return mapBundleSync(this.bundles, id);
   }
 
+  areBundlesEmpty() {
+    // Create an iterator and only peek at the first value to see if it contains anything.
+    return this.bundles[Symbol.iterator]().next().done
+  }
+
   getString(
     id: string,
     args?: Record<string, FluentVariable> | null,
@@ -45,6 +50,12 @@ export class ReactLocalization {
           this.reportError(error);
         }
         return value;
+      }
+    } else {
+      if (this.areBundlesEmpty()) {
+        this.reportError(new Error(`Attempting to get a string when no localization bundles are present.`));
+      } else {
+        this.reportError(new Error(`The id "${id}" did not match any messages in the localization bundles.`));
       }
     }
 

--- a/fluent-react/src/localized.ts
+++ b/fluent-react/src/localized.ts
@@ -66,8 +66,9 @@ export function Localized(props: LocalizedProps): ReactElement {
   }
 
   if (!l10n) {
-    // Use the wrapped component as fallback.
-    return createElement(Fragment, null, child);
+    throw new Error(
+      "The <Localized /> component was not properly wrapped in a <LocalizationProvider />."
+    );
   }
 
   const bundle = l10n.getBundle(id);

--- a/fluent-react/src/localized.ts
+++ b/fluent-react/src/localized.ts
@@ -74,6 +74,17 @@ export function Localized(props: LocalizedProps): ReactElement {
   const bundle = l10n.getBundle(id);
 
   if (bundle === null) {
+    if (id === undefined) {
+      l10n.reportError(
+        new Error("No id was provided for a <Localized /> component.")
+      );
+    } else {
+      if (l10n.areBundlesEmpty()) {
+        l10n.reportError(new Error(`A <Localized /> component was rendered when no localization bundles are present.`));
+      } else {
+        l10n.reportError(new Error(`The id "${id}" did not match any messages in the localization bundles.`));
+      }
+    }
     // Use the wrapped component as fallback.
     return createElement(Fragment, null, child);
   }

--- a/fluent-react/src/use_localization.ts
+++ b/fluent-react/src/use_localization.ts
@@ -9,5 +9,12 @@ type useLocalization = () => { l10n: ReactLocalization }
 export const useLocalization: useLocalization = () => {
   const l10n = useContext(FluentContext);
 
+  if (!l10n) {
+    throw new Error(
+      "useLocalization was used without wrapping it in a "
+        + "<LocalizationProvider />."
+    );
+  }
+
   return { l10n };
 };

--- a/fluent-react/src/with_localization.ts
+++ b/fluent-react/src/with_localization.ts
@@ -17,6 +17,12 @@ export function withLocalization<P extends WithLocalizationProps>(
 ): ComponentType<WithoutLocalizationProps<P>> {
   function WithLocalization(props: WithoutLocalizationProps<P>): ReactElement {
     const l10n = useContext(FluentContext);
+    if (!l10n) {
+      throw new Error(
+        "withLocalization was used without wrapping it in a "
+          + "<LocalizationProvider />."
+      );
+    }
     // Re-bind getString to trigger a re-render of Inner.
     const getString = l10n.getString.bind(l10n);
     return createElement(Inner, { getString, ...props } as P);

--- a/fluent-react/test/localized_fallback.test.js
+++ b/fluent-react/test/localized_fallback.test.js
@@ -61,6 +61,8 @@ foo = FOO
 });
 
 test("falls back back for missing message", function() {
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+
   const bundle1 = new FluentBundle();
   bundle1.addResource(
     new FluentResource(`
@@ -80,5 +82,13 @@ not-foo = NOT FOO
     <div>
       Bar
     </div>
+  `);
+
+  expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "[@fluent/react] Error: The id \\"foo\\" did not match any messages in the localization bundles.",
+      ],
+    ]
   `);
 });

--- a/fluent-react/test/localized_render.test.js
+++ b/fluent-react/test/localized_render.test.js
@@ -336,11 +336,11 @@ foo = { $arg }
   });
 
   test("render with a fragment and no message preserves the fragment", () => {
-    const bundle = new FluentBundle();
+    jest.spyOn(console, "warn").mockImplementation(() => {});
 
     const renderer = TestRenderer.create(
-      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
-        <Localized id="foo">
+      <LocalizationProvider l10n={new ReactLocalization([])}>
+        <Localized id="non-matching-id">
           <React.Fragment>
             <div>Fragment content</div>
           </React.Fragment>
@@ -349,10 +349,11 @@ foo = { $arg }
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-                  <div>
-                    Fragment content
-                  </div>
-            `);
+      <div>
+        Fragment content
+      </div>
+    `);
+    expect(console.warn).toHaveBeenCalled();
   });
 
   test("A missing $arg does not break rendering", () => {
@@ -442,6 +443,7 @@ foo = Test message
 
   test("render with an empty fragment and no message preserves the fragment", () => {
     const bundle = new FluentBundle();
+    jest.spyOn(console, "warn").mockImplementation(() => {});
 
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([bundle])}>
@@ -452,6 +454,13 @@ foo = Test message
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`null`);
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] Error: The id \\"foo\\" did not match any messages in the localization bundles.",
+        ],
+      ]
+    `);
   });
 
   test("render with an empty fragment and no message value preserves the fragment", () => {
@@ -494,6 +503,7 @@ foo = Test message
   });
 
   test("render with a string fallback and no message returns the fallback", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
     const bundle = new FluentBundle();
 
     const renderer = TestRenderer.create(
@@ -503,6 +513,13 @@ foo = Test message
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`"String fallback"`);
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] Error: The id \\"foo\\" did not match any messages in the localization bundles.",
+        ],
+      ]
+    `);
   });
 
   test("render with a string fallback returns the message", () => {
@@ -541,6 +558,7 @@ foo = Message
   });
 
   test("render without a fallback and no message returns nothing", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
     const bundle = new FluentBundle();
 
     const renderer = TestRenderer.create(
@@ -550,5 +568,12 @@ foo = Message
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`null`);
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] Error: The id \\"foo\\" did not match any messages in the localization bundles.",
+        ],
+      ]
+    `);
   });
 });

--- a/fluent-react/test/localized_valid.test.js
+++ b/fluent-react/test/localized_valid.test.js
@@ -5,18 +5,31 @@ import {
   LocalizationProvider,
   Localized
 } from "../esm/index";
+import { FluentBundle, FluentResource } from "@fluent/bundle";
 
 describe("Localized - validation", () => {
-  test("inside of a LocalizationProvider", () => {
+  function createValidBundle() {
+    const validBundle = new FluentBundle();
+    validBundle.addResource(
+      new FluentResource("example-id = Example localized text\n")
+    );
+    return validBundle;
+  }
+
+  test("renders with no errors or warnings when correctly created inside of a LocalizationProvider", () => {
     const renderer = TestRenderer.create(
-      <LocalizationProvider l10n={new ReactLocalization([])}>
-        <Localized>
+      <LocalizationProvider l10n={new ReactLocalization([createValidBundle()])}>
+        <Localized id="example-id">
           <div />
         </Localized>
       </LocalizationProvider>
     );
 
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      <div>
+        Example localized text
+      </div>
+    `);
   });
 
   test("throws an error when placed outside of a LocalizationProvider", () => {
@@ -36,24 +49,26 @@ describe("Localized - validation", () => {
     expect(console.error).toHaveBeenCalled();
   });
 
-  test("without a child", () => {
+  test("renders the localized text when no child is provided", () => {
     const renderer = TestRenderer.create(
-      <LocalizationProvider l10n={new ReactLocalization([])}>
-        <Localized />
+      <LocalizationProvider l10n={new ReactLocalization([createValidBundle()])}>
+        <Localized id="example-id" />
       </LocalizationProvider>
     );
 
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`null`);
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`"Example localized text"`);
   });
 
-  test("with multiple children", () => {
+  test("throws when multiple children are provided", () => {
     // React also does a console.error, ignore that here.
     jest.spyOn(console, "error").mockImplementation(() => {});
 
     expect(() => {
       TestRenderer.create(
-        <LocalizationProvider l10n={new ReactLocalization([])}>
-          <Localized>
+        <LocalizationProvider
+          l10n={new ReactLocalization([createValidBundle()])}
+        >
+          <Localized id="example-id">
             <div />
             <div />
           </Localized>
@@ -64,17 +79,23 @@ describe("Localized - validation", () => {
     expect(console.error).toHaveBeenCalled();
   });
 
-  test("with single children inside an array", () => {
+  test("is valid to have a children array with a single element inside", () => {
     const renderer = TestRenderer.create(
-      <LocalizationProvider l10n={new ReactLocalization([])}>
-        <Localized children={[<div />]} />
+      <LocalizationProvider l10n={new ReactLocalization([createValidBundle()])}>
+        <Localized id="example-id" children={[<div />]} />
       </LocalizationProvider>
     );
 
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      <div>
+        Example localized text
+      </div>
+    `);
   });
 
-  test("without id", () => {
+  test("has a warning when no id is provided", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
     const renderer = TestRenderer.create(
       <LocalizationProvider l10n={new ReactLocalization([])}>
         <Localized>
@@ -84,5 +105,13 @@ describe("Localized - validation", () => {
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
+
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] Error: No id was provided for a <Localized /> component.",
+        ],
+      ]
+    `);
   });
 });

--- a/fluent-react/test/localized_valid.test.js
+++ b/fluent-react/test/localized_valid.test.js
@@ -19,14 +19,21 @@ describe("Localized - validation", () => {
     expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
   });
 
-  test("outside of a LocalizationProvider", () => {
-    const renderer = TestRenderer.create(
-      <Localized>
-        <div />
-      </Localized>
+  test("throws an error when placed outside of a LocalizationProvider", () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => {
+      TestRenderer.create(
+        <Localized id="example-id">
+          <div />
+        </Localized>
+      );
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"The <Localized /> component was not properly wrapped in a <LocalizationProvider />."`
     );
 
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
+    // React also does a console.error.
+    expect(console.error).toHaveBeenCalled();
   });
 
   test("without a child", () => {

--- a/fluent-react/test/use_localization.test.js
+++ b/fluent-react/test/use_localization.test.js
@@ -14,15 +14,22 @@ function DummyComponent() {
 }
 
 describe("useLocalization", () => {
+  function createBundle() {
+    const bundle = new FluentBundle("en", { useIsolating: false });
+    bundle.addResource(new FluentResource("foo = FOO\n"));
+    return bundle;
+  }
+
   test("render inside of a LocalizationProvider", () => {
+
     const renderer = TestRenderer.create(
-      <LocalizationProvider l10n={new ReactLocalization([])}>
+      <LocalizationProvider l10n={new ReactLocalization([createBundle()])}>
         <DummyComponent />
       </LocalizationProvider>
     );
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
       <p>
-        foo
+        FOO
       </p>
     `);
   });
@@ -41,15 +48,8 @@ describe("useLocalization", () => {
   });
 
   test("useLocalization exposes getString from ReactLocalization", () => {
-    const bundle = new FluentBundle("en", { useIsolating: false });
-    bundle.addResource(
-      new FluentResource(`
-foo = FOO
-`)
-    );
-
     const renderer = TestRenderer.create(
-      <LocalizationProvider l10n={new ReactLocalization([bundle])}>
+      <LocalizationProvider l10n={new ReactLocalization([createBundle()])}>
         <DummyComponent />
       </LocalizationProvider>
     );

--- a/fluent-react/test/use_localization.test.js
+++ b/fluent-react/test/use_localization.test.js
@@ -27,13 +27,17 @@ describe("useLocalization", () => {
     `);
   });
 
-  test("render outside of a LocalizationProvider", () => {
-    const renderer = TestRenderer.create(<DummyComponent />);
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      <p>
-        foo
-      </p>
-    `);
+  test("throws an error when rendered outside of a LocalizationProvider", () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => {
+      TestRenderer.create(<DummyComponent />);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"useLocalization was used without wrapping it in a <LocalizationProvider />."`
+    );
+
+    // React also does a console.error.
+    expect(console.error).toHaveBeenCalled();
   });
 
   test("useLocalization exposes getString from ReactLocalization", () => {

--- a/fluent-react/test/with_localization.test.js
+++ b/fluent-react/test/with_localization.test.js
@@ -101,30 +101,59 @@ bar = BAR {$arg}
     expect(console.warn.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
+          "[@fluent/react] Error: The id \\"missing\\" did not match any messages in the localization bundles.",
+        ],
+        Array [
           "[@fluent/react] ReferenceError: Unknown variable: $arg",
         ],
       ]
     `);
   });
 
-  test.skip("getString without access to the l10n context", () => {
+  test("getString with an empty bundle list", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
     const EnhancedComponent = withLocalization(DummyComponent);
-    const renderer = TestRenderer.create(<EnhancedComponent />);
+    const renderer = TestRenderer.create(
+      <LocalizationProvider l10n={new ReactLocalization([])}>
+        <EnhancedComponent />
+      </LocalizationProvider>
+    );
 
     const { getString } = renderer.root.findByType(DummyComponent).props;
     // Returns the id if no fallback.
     expect(getString("foo", { arg: 1 })).toBe("foo");
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] Error: Attempting to get a string when no localization bundles are present.",
+        ],
+      ]
+    `);
   });
 
-  test.skip("getString without access to the l10n context, with fallback value", () => {
+  test("getString with an empty bundle list, with fallback value", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
     const EnhancedComponent = withLocalization(DummyComponent);
-    const renderer = TestRenderer.create(<EnhancedComponent />);
+    const renderer = TestRenderer.create(
+      <LocalizationProvider l10n={new ReactLocalization([])}>
+        <EnhancedComponent />
+      </LocalizationProvider>
+    );
 
     const { getString } = renderer.root.findByType(DummyComponent).props;
     // Returns the fallback if provided.
     expect(getString("foo", { arg: 1 }, "fallback message")).toBe(
       "fallback message"
     );
+
+    expect(console.warn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "[@fluent/react] Error: Attempting to get a string when no localization bundles are present.",
+        ],
+      ]
+    `);
   });
 
   test("getString with access to the l10n context, with message changes", () => {

--- a/fluent-react/test/with_localization.test.js
+++ b/fluent-react/test/with_localization.test.js
@@ -23,11 +23,18 @@ describe("withLocalization", () => {
     expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
   });
 
-  test("render outside of a LocalizationProvider", () => {
+  test("thows an error when rendered outside of a LocalizationProvider", () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
     const EnhancedComponent = withLocalization(DummyComponent);
 
-    const renderer = TestRenderer.create(<EnhancedComponent />);
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`<div />`);
+    expect(() => {
+      TestRenderer.create(<EnhancedComponent />);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"withLocalization was used without wrapping it in a <LocalizationProvider />."`
+    );
+
+    // React also does a console.error.
+    expect(console.error).toHaveBeenCalled();
   });
 
   test("getString with access to the l10n context", () => {
@@ -100,7 +107,7 @@ bar = BAR {$arg}
     `);
   });
 
-  test("getString without access to the l10n context", () => {
+  test.skip("getString without access to the l10n context", () => {
     const EnhancedComponent = withLocalization(DummyComponent);
     const renderer = TestRenderer.create(<EnhancedComponent />);
 
@@ -109,7 +116,7 @@ bar = BAR {$arg}
     expect(getString("foo", { arg: 1 })).toBe("foo");
   });
 
-  test("getString without access to the l10n context, with fallback value", () => {
+  test.skip("getString without access to the l10n context, with fallback value", () => {
     const EnhancedComponent = withLocalization(DummyComponent);
     const renderer = TestRenderer.create(<EnhancedComponent />);
 


### PR DESCRIPTION
Each commit here is well-ordered and can be considered separately.

Resolves #519.

The second commit isn't particularly risky, but the first introduces a new `throw` for misconfigured systems. See the commit message for more information.

dminor: As we discussed in Slack it would be great if you could look over the code. It's using TypeScript.

zibi: I also added you on here as a reviewer, as Dan wanted someone with JS experience to also look over it. Feel free to redirect if you know someone better to look at it.
