### PR TITLE
Remove "type": "commonjs" from package.json

### DIFF
--- a/fluent-bundle/package.json
+++ b/fluent-bundle/package.json
@@ -15,7 +15,6 @@
       "email": "stas@mozilla.com"
     }
   ],
-  "type": "commonjs",
   "main": "./index.js",
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",

--- a/fluent-dedent/package.json
+++ b/fluent-dedent/package.json
@@ -11,7 +11,6 @@
       "email": "stas@mozilla.com"
     }
   ],
-  "type": "commonjs",
   "main": "./index.js",
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",

--- a/fluent-dom/package.json
+++ b/fluent-dom/package.json
@@ -18,7 +18,6 @@
       "email": "stas@mozilla.com"
     }
   ],
-  "type": "commonjs",
   "main": "./index.js",
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",

--- a/fluent-langneg/package.json
+++ b/fluent-langneg/package.json
@@ -15,7 +15,6 @@
       "email": "stas@mozilla.com"
     }
   ],
-  "type": "commonjs",
   "main": "./index.js",
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",

--- a/fluent-react/package.json
+++ b/fluent-react/package.json
@@ -15,7 +15,6 @@
       "email": "stas@mozilla.com"
     }
   ],
-  "type": "commonjs",
   "main": "./index.js",
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",

--- a/fluent-sequence/package.json
+++ b/fluent-sequence/package.json
@@ -15,7 +15,6 @@
       "email": "stas@mozilla.com"
     }
   ],
-  "type": "commonjs",
   "main": "./index.js",
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",

--- a/fluent-syntax/package.json
+++ b/fluent-syntax/package.json
@@ -15,7 +15,6 @@
       "email": "stas@mozilla.com"
     }
   ],
-  "type": "commonjs",
   "main": "./index.js",
   "module": "./esm/index.js",
   "types": "./esm/index.d.ts",


### PR DESCRIPTION
Setting "type" field in package.json forces Webpack to treat all files in the package as either CommonJS or EcmaScript. 
Without it Webpack correctly uses "main" and "module" fields.
Fixes #517