### PR TITLE
Update likely subtags

### DIFF
--- a/fluent-langneg/src/locale.ts
+++ b/fluent-langneg/src/locale.ts
@@ -137,6 +137,8 @@ const likelySubtagsMin: Record<string, string> = {
   "zh": "zh-hans-cn",
   "zh-hant": "zh-hant-tw",
   "zh-hk": "zh-hant-hk",
+  "zh-mo": "zh-hant-mo",
+  "zh-tw": "zh-hant-tw",
   "zh-gb": "zh-hant-gb",
   "zh-us": "zh-hant-us",
 };


### PR DESCRIPTION
Macau and Taiwan uses traditional Chinese.