### PR TITLE
test(bundle): Use different Date constructor to get a local date

### DIFF
--- a/fluent-bundle/test/arguments_test.js
+++ b/fluent-bundle/test/arguments_test.js
@@ -215,7 +215,8 @@ suite('Variables', function() {
     });
 
     test('can be a FluentDateTime', function(){
-      const arg = new FluentDateTime(new Date('2016-09-29'), {weekday: "long"});
+      const localDate = new Date(2016, 8, 29, 12);
+      const arg = new FluentDateTime(localDate, {weekday: "long"});
       const msg = bundle.getMessage('foo');
       const val = bundle.formatPattern(msg.value, {arg}, errs);
       assert.strictEqual(val, 'Thursday');


### PR DESCRIPTION
Fixes #572 by using a different form of `new Date()`. The constructor parses string input as a UTC date, while numeric input uses the local timezone.