### PR TITLE
refactor: allow resolution of variables in the proto chain

### DIFF
--- a/fluent-bundle/src/resolver.ts
+++ b/fluent-bundle/src/resolver.ts
@@ -156,14 +156,14 @@ function resolveVariableReference(
   let arg: FluentVariable;
   if (scope.params) {
     // We're inside a TermReference. It's OK to reference undefined parameters.
-    if (Object.prototype.hasOwnProperty.call(scope.params, name)) {
+    if (Reflect.has(scope.params, name)) {
       arg = scope.params[name];
     } else {
       return new FluentNone(`$${name}`);
     }
   } else if (
     scope.args
-    && Object.prototype.hasOwnProperty.call(scope.args, name)
+    && Reflect.has(scope.args, name)
   ) {
     // We're in the top-level Pattern or inside a MessageReference. Missing
     // variables references produce ReferenceErrors.


### PR DESCRIPTION
`resolveVariableReference` enforces variables names to be own properties. This seems to be very restrictive, and instead, Reflect.has() or `in` operator is probably better. In our case, the args structure provided to messages might be optimized in various ways (very likely be immutable structures) that does not necessary have a flatten structure, and instead it might rely on the `__proto__` chain.

## Perf Considerations

I believe this change will not necessary introduce a significant chante in terms of performance. Yes, missing variable names lookups will take one more step (most likely a look up on `Object.prototype` which is probably optimized by engines already), but that should not move the needle IMO.

## Security Implications

The interpolation is already very secure (by doing the escaping), with this change, poisoning of the Object.prototype is possible, but again, you can only attack message if the consumer is not providing the variable name, in which case Object.prototype lookup will occur. There are other different ways to do a similar attack, including patching `Object.prototype.hasOwnProperty` on itself :), so I will consider this to not be an issue.

## TODO

* [ ] update tests