### PR TITLE
Add ".js" extension to imports in fluent-dom and fluent-langneg

### DIFF
--- a/fluent-dom/src/index.js
+++ b/fluent-dom/src/index.js
@@ -1,2 +1,2 @@
-export { default as DOMLocalization } from "./dom_localization";
-export { default as Localization } from "./localization";
+export { default as DOMLocalization } from "./dom_localization.js";
+export { default as Localization } from "./localization.js";

--- a/fluent-langneg/src/index.ts
+++ b/fluent-langneg/src/index.ts
@@ -8,7 +8,8 @@
  */
 
 export {
-  negotiateLanguages, NegotiateLanguagesOptions
-} from "./negotiate_languages";
-export {acceptedLanguages} from "./accepted_languages";
-export {filterMatches} from "./matches";
+  negotiateLanguages,
+  NegotiateLanguagesOptions,
+} from "./negotiate_languages.js";
+export { acceptedLanguages } from "./accepted_languages.js";
+export { filterMatches } from "./matches.js";


### PR DESCRIPTION
Fixes #579 by adding the missing `.js` extensions to fluent-dom and fluent-langneg.