### PR TITLE
Add getFragment method to ReactLocalization

### DIFF
--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -213,11 +213,11 @@ export class ReactLocalization {
       return cloneElement(componentToRender, localizedProps, messageValue);
     }
 
-    let elemsLower: Record<string, ReactElement>;
+    let elemsLower: Map<string, ReactElement>;
     if (args?.elems) {
-      elemsLower = {};
+      elemsLower = new Map();
       for (let [name, elem] of Object.entries(args?.elems)) {
-        elemsLower[name.toLowerCase()] = elem;
+        elemsLower.set(name.toLowerCase(), elem);
       }
     }
 
@@ -239,7 +239,7 @@ export class ReactLocalization {
         return childNode.textContent;
       }
 
-      const sourceChild = elemsLower[childName];
+      const sourceChild = elemsLower.get(childName);
 
       // Ignore elems which are not valid React elements.
       if (!isValidElement(sourceChild)) {

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -44,7 +44,7 @@ export class ReactLocalization {
 
   getString(
     id: string,
-    args?: Record<string, FluentVariable> | null,
+    vars?: Record<string, FluentVariable> | null,
     fallback?: string
   ): string {
     const bundle = this.getBundle(id);
@@ -52,7 +52,7 @@ export class ReactLocalization {
       const msg = bundle.getMessage(id);
       if (msg && msg.value) {
         let errors: Array<Error> = [];
-        let value = bundle.formatPattern(msg.value, args, errors);
+        let value = bundle.formatPattern(msg.value, vars, errors);
         for (let error of errors) {
           this.reportError(error);
         }

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -234,7 +234,7 @@ export class ReactLocalization {
       // If the child is not expected just take its textContent.
       if (
         !elemsLower ||
-        !Object.prototype.hasOwnProperty.call(elemsLower, childName)
+        !elemsLower.has(childName)
       ) {
         return textContent;
       }

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -82,11 +82,11 @@ export class ReactLocalization {
   getElement(
     componentToRender: ReactElement,
     id: string,
-    args?: {
+    args: {
       vars?: Record<string, FluentVariable>,
       elems?: Record<string, ReactElement>,
       attrs?: Record<string, boolean>;
-    },
+    } = {},
   ): ReactElement {
     const bundle = this.getBundle(id);
     if (bundle === null) {
@@ -124,14 +124,14 @@ export class ReactLocalization {
     // The default is to forbid all message attributes. If the attrs prop exists
     // on the Localized instance, only set message attributes which have been
     // explicitly allowed by the developer.
-    if (args?.attrs && msg.attributes) {
+    if (args.attrs && msg.attributes) {
       localizedProps = {};
       errors = [];
-      for (const [name, allowed] of Object.entries(args?.attrs)) {
+      for (const [name, allowed] of Object.entries(args.attrs)) {
         if (allowed && name in msg.attributes) {
           localizedProps[name] = bundle.formatPattern(
             msg.attributes[name],
-            args?.vars,
+            args.vars,
             errors
           );
         }
@@ -157,7 +157,7 @@ export class ReactLocalization {
     }
 
     errors = [];
-    const messageValue = bundle.formatPattern(msg.value, args?.vars, errors);
+    const messageValue = bundle.formatPattern(msg.value, args.vars, errors);
     for (let error of errors) {
       this.reportError(error);
     }
@@ -169,9 +169,9 @@ export class ReactLocalization {
     }
 
     let elemsLower: Map<string, ReactElement>;
-    if (args?.elems) {
+    if (args.elems) {
       elemsLower = new Map();
-      for (let [name, elem] of Object.entries(args?.elems)) {
+      for (let [name, elem] of Object.entries(args.elems)) {
         // Ignore elems which are not valid React elements.
         if (!isValidElement(elem)) {
           continue;

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -123,23 +123,22 @@ export class ReactLocalization {
         this.reportError(
           new Error("No string id was provided when localizing a component.")
         );
+      } else if (this.areBundlesEmpty()) {
+        this.reportError(
+          new Error(
+            "Attempting to get a localized element when no localization bundles are " +
+              "present."
+          )
+        );
       } else {
-        if (this.areBundlesEmpty()) {
-          this.reportError(
-            new Error(
-              "Attempting to get a localized element when no localization bundles are " +
-                "present."
-            )
-          );
-        } else {
-          this.reportError(
-            new Error(
-              `The id "${id}" did not match any messages in the localization ` +
-                "bundles."
-            )
-          );
-        }
+        this.reportError(
+          new Error(
+            `The id "${id}" did not match any messages in the localization ` +
+              "bundles."
+          )
+        );
       }
+
       return createElement(Fragment, null, componentToRender);
     }
 

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -106,7 +106,7 @@ export class ReactLocalization {
     if (Array.isArray(component)) {
       if (component.length > 1) {
         throw new Error(
-          "<Localized/> expected to receive a single React node child"
+          "Expected to receive a single React node element to inject a localized string into."
         );
       }
 

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -80,7 +80,7 @@ export class ReactLocalization {
   }
 
   getElement(
-    componentToRender: ReactElement,
+    sourceElement: ReactElement,
     id: string,
     args: {
       vars?: Record<string, FluentVariable>,
@@ -110,7 +110,7 @@ export class ReactLocalization {
         );
       }
 
-      return createElement(Fragment, null, componentToRender);
+      return createElement(Fragment, null, sourceElement);
     }
 
     // this.getBundle makes the bundle.hasMessage check which ensures that
@@ -145,15 +145,15 @@ export class ReactLocalization {
     // message value and do not pass it to cloneElement in order to avoid the
     // "void element tags must neither have `children` nor use
     // `dangerouslySetInnerHTML`" error.
-    if (typeof componentToRender.type === "string" && componentToRender.type in voidElementTags) {
-      return cloneElement(componentToRender, localizedProps);
+    if (typeof sourceElement.type === "string" && sourceElement.type in voidElementTags) {
+      return cloneElement(sourceElement, localizedProps);
     }
 
     // If the message has a null value, we're only interested in its attributes.
     // Do not pass the null value to cloneElement as it would nuke all children
     // of the wrapped component.
     if (msg.value === null) {
-      return cloneElement(componentToRender, localizedProps);
+      return cloneElement(sourceElement, localizedProps);
     }
 
     errors = [];
@@ -165,7 +165,7 @@ export class ReactLocalization {
     // If the message value doesn't contain any markup nor any HTML entities,
     // insert it as the only child of the component to render.
     if (!reMarkup.test(messageValue) || this.parseMarkup === null) {
-      return cloneElement(componentToRender, localizedProps, messageValue);
+      return cloneElement(sourceElement, localizedProps, messageValue);
     }
 
     let elemsLower: Map<string, ReactElement>;
@@ -214,7 +214,7 @@ export class ReactLocalization {
       return cloneElement(sourceChild, undefined, textContent);
     });
 
-    return cloneElement(componentToRender, localizedProps, ...translatedChildren);
+    return cloneElement(sourceElement, localizedProps, ...translatedChildren);
   }
 
   // XXX Control this via a prop passed to the LocalizationProvider.

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -95,7 +95,7 @@ export class ReactLocalization {
     if (Array.isArray(component)) {
       if (component.length > 1) {
         throw new Error(
-          "Expected to receive a single React node element to inject a localized string into."
+          "Expected to receive a single React element to localize."
         );
       }
 

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -119,7 +119,7 @@ export class ReactLocalization {
 
     const bundle = this.getBundle(id);
     if (bundle === null) {
-      if (id === undefined) {
+      if (!id) {
         this.reportError(
           new Error("No string id was provided when localizing a component.")
         );

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -1,6 +1,6 @@
 import { FluentBundle, FluentVariable } from "@fluent/bundle";
 import { mapBundleSync } from "@fluent/sequence";
-import { Fragment, ReactElement, createElement, isValidElement, ReactFragment, cloneElement, ReactNode } from "react";
+import { Fragment, ReactElement, createElement, isValidElement, cloneElement, ReactNode } from "react";
 import { CachedSyncIterable } from "cached-iterable";
 import { createParseMarkup, MarkupParser } from "./markup.js";
 import voidElementTags from "../vendor/voidElementTags.js";
@@ -77,17 +77,6 @@ export class ReactLocalization {
     }
 
     return fallback || id;
-  }
-
-  getFragment(
-    id: string,
-    args?: {
-      vars?: Record<string, FluentVariable>,
-      elems?: Record<string, ReactElement>,
-    },
-    fallback?: string
-  ): ReactFragment {
-    return this.getElement(createElement(Fragment, null, fallback || id), id, args);
   }
 
   getElement(

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -1,7 +1,13 @@
 import { FluentBundle, FluentVariable } from "@fluent/bundle";
 import { mapBundleSync } from "@fluent/sequence";
+import { Fragment, ReactElement, createElement, isValidElement, ReactFragment, cloneElement } from "react";
 import { CachedSyncIterable } from "cached-iterable";
 import { createParseMarkup, MarkupParser } from "./markup.js";
+import voidElementTags from "../vendor/voidElementTags.js";
+
+// Match the opening angle bracket (<) in HTML tags, and HTML entities like
+// &amp;, &#0038;, &#x0026;.
+const reMarkup = /<|&#?\w+;/;
 
 /*
  * `ReactLocalization` handles translation formatting and fallback.
@@ -71,6 +77,101 @@ export class ReactLocalization {
     }
 
     return fallback || id;
+  }
+
+  getFragment(
+    id: string,
+    args?: {
+      vars?: Record<string, FluentVariable>,
+      elems?: Record<string, ReactElement>,
+    },
+    fallback?: string
+  ): ReactFragment {
+    const bundle = this.getBundle(id);
+    if (!bundle) {
+      if (this.areBundlesEmpty()) {
+        this.reportError(
+          new Error(
+            "Attempting to get a fragment when no localization bundles are " +
+              "present."
+          )
+        );
+      } else {
+        this.reportError(
+          new Error(
+            `The id "${id}" did not match any messages in the localization ` +
+              "bundles."
+          )
+        );
+      }
+      return createElement(Fragment, null, fallback || id);
+    }
+
+    const msg = bundle.getMessage(id);
+
+    if (!msg || !msg.value) {
+      return createElement(Fragment, null, fallback || id);
+    }
+
+    let errors: Array<Error> = [];
+    let value = bundle.formatPattern(msg.value, args && args.vars ? args.vars : {}, errors);
+    for (let error of errors) {
+      this.reportError(error);
+    }
+
+    let elemsLower: Record<string, ReactElement>;
+    if (args && args.elems) {
+      elemsLower = {};
+      for (let [name, elem] of Object.entries(args.elems)) {
+        elemsLower[name.toLowerCase()] = elem;
+      }
+    }
+
+    // If the message value doesn't contain any markup nor any HTML entities,
+    // return a fragment with the message directly.
+    if (!reMarkup.test(value) || this.parseMarkup === null) {
+      return createElement(Fragment, null, value);
+    }
+
+    // If the message contains markup, parse it and try to match the children
+    // found in the translation with the elems passed to this method.
+    const translationNodes = this.parseMarkup(value);
+    const translatedChildren = translationNodes.map(childNode => {
+      if (childNode.nodeName === "#text") {
+        return childNode.textContent;
+      }
+
+      const childName = childNode.nodeName.toLowerCase();
+
+      // If the child is not expected just take its textContent.
+      if (
+        !elemsLower ||
+        !Object.prototype.hasOwnProperty.call(elemsLower, childName)
+      ) {
+        return childNode.textContent;
+      }
+
+      const sourceChild = elemsLower[childName];
+
+      // Ignore elems which are not valid React elements.
+      if (!isValidElement(sourceChild)) {
+        return childNode.textContent;
+      }
+
+      // If the element passed in the elems prop is a known void element,
+      // explicitly dismiss any textContent which might have accidentally been
+      // defined in the translation to prevent the "void element tags must not
+      // have children" error.
+      if (
+        typeof sourceChild.type === "string" &&
+        sourceChild.type in voidElementTags
+      ) {
+        return sourceChild;
+      }
+
+      return cloneElement(sourceChild, undefined, childNode.textContent);
+    });
+    return createElement(Fragment, null, ...translatedChildren);
   }
 
   // XXX Control this via a prop passed to the LocalizationProvider.

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -206,6 +206,10 @@ export class ReactLocalization {
     if (args?.elems) {
       elemsLower = new Map();
       for (let [name, elem] of Object.entries(args?.elems)) {
+        // Ignore elems which are not valid React elements.
+        if (!isValidElement(elem)) {
+          continue;
+        }
         elemsLower.set(name.toLowerCase(), elem);
       }
     }
@@ -219,19 +223,10 @@ export class ReactLocalization {
       }
 
       const childName = nodeName.toLowerCase();
+      const sourceChild = elemsLower?.get(childName);
 
       // If the child is not expected just take its textContent.
-      if (
-        !elemsLower ||
-        !elemsLower.has(childName)
-      ) {
-        return textContent;
-      }
-
-      const sourceChild = elemsLower.get(childName);
-
-      // Ignore elems which are not valid React elements.
-      if (!isValidElement(sourceChild)) {
+      if (!sourceChild) {
         return textContent;
       }
 

--- a/fluent-react/src/localization.ts
+++ b/fluent-react/src/localization.ts
@@ -224,26 +224,26 @@ export class ReactLocalization {
     // If the message contains markup, parse it and try to match the children
     // found in the translation with the args passed to this function.
     const translationNodes = this.parseMarkup(messageValue);
-    const translatedChildren = translationNodes.map(childNode => {
-      if (childNode.nodeName === "#text") {
-        return childNode.textContent;
+    const translatedChildren = translationNodes.map(({ nodeName, textContent }) => {
+      if (nodeName === "#text") {
+        return textContent;
       }
 
-      const childName = childNode.nodeName.toLowerCase();
+      const childName = nodeName.toLowerCase();
 
       // If the child is not expected just take its textContent.
       if (
         !elemsLower ||
         !Object.prototype.hasOwnProperty.call(elemsLower, childName)
       ) {
-        return childNode.textContent;
+        return textContent;
       }
 
       const sourceChild = elemsLower.get(childName);
 
       // Ignore elems which are not valid React elements.
       if (!isValidElement(sourceChild)) {
-        return childNode.textContent;
+        return textContent;
       }
 
       // If the element passed in the elems prop is a known void element,
@@ -261,7 +261,7 @@ export class ReactLocalization {
       // https://github.com/projectfluent/fluent.js/issues/184
       // TODO  Control localizable attributes on elements passed as props
       // https://github.com/projectfluent/fluent.js/issues/185
-      return cloneElement(sourceChild, undefined, childNode.textContent);
+      return cloneElement(sourceChild, undefined, textContent);
     });
 
     return cloneElement(componentToRender, localizedProps, ...translatedChildren);

--- a/fluent-react/src/localized.ts
+++ b/fluent-react/src/localized.ts
@@ -1,4 +1,5 @@
 import React, {
+  Children,
   isValidElement,
   ReactElement,
   ReactNode,
@@ -48,20 +49,14 @@ export function Localized(props: LocalizedProps): ReactElement {
 
   let componentToRender: ReactNode | null;
 
-  // Validate that the child element isn't an array that contains multiple
-  // elements.
-  if (Array.isArray(children)) {
-    if (children.length > 1) {
-      throw new Error(
-        "Expected to receive a single React element to localize."
-      );
-    }
-
-    // If it's an array with zero or one element, we can directly get the first
-    // one.
+  if(typeof children === "string") {
+    componentToRender = children;
+  } else if (!children) {
+    componentToRender = null;
+  } else if (Array.isArray(children) && children.length === 1) {
     componentToRender = children[0];
   } else {
-    componentToRender = children ?? null;
+    componentToRender = Children.only(children);
   }
 
   // Check if the component to render is a valid element -- if not, then

--- a/fluent-react/src/localized.ts
+++ b/fluent-react/src/localized.ts
@@ -49,7 +49,7 @@ export function Localized(props: LocalizedProps): ReactElement {
 
   let componentToRender: ReactNode | null;
 
-  if(typeof children === "string") {
+  if (typeof children === "string") {
     componentToRender = children;
   } else if (!children) {
     componentToRender = null;
@@ -69,8 +69,8 @@ export function Localized(props: LocalizedProps): ReactElement {
       l10n.getString(
         id,
         vars,
-        typeof componentToRender === "string" ? componentToRender : undefined,
-      ),
+        typeof componentToRender === "string" ? componentToRender : undefined
+      )
     );
   }
 

--- a/fluent-react/src/localized.ts
+++ b/fluent-react/src/localized.ts
@@ -1,5 +1,4 @@
 import React, {
-  Children,
   isValidElement,
   ReactElement,
   ReactNode,
@@ -47,34 +46,30 @@ export function Localized(props: LocalizedProps): ReactElement {
     );
   }
 
-  let componentToRender: ReactNode | null;
+  let source: ReactNode | null;
 
-  if (typeof children === "string") {
-    componentToRender = children;
-  } else if (!children) {
-    componentToRender = null;
-  } else if (Array.isArray(children) && children.length === 1) {
-    componentToRender = children[0];
+  if (Array.isArray(children)) {
+    if (children.length > 1) {
+      throw new Error(
+        "Expected to receive a single React element to localize."
+      );
+    }
+    // If it's an array with zero or one element, we can directly get the first one.
+    source = children[0];
   } else {
-    componentToRender = Children.only(children);
+    source = children ?? null;
   }
 
   // Check if the component to render is a valid element -- if not, then
   // it's either null or a simple fallback string. No need to localize the
   // attributes or replace.
-  if (!isValidElement(componentToRender)) {
-    return React.createElement(
-      React.Fragment,
-      null,
-      l10n.getString(
-        id,
-        vars,
-        typeof componentToRender === "string" ? componentToRender : undefined
-      )
-    );
+  if (!isValidElement(source)) {
+    const fallback = typeof source === "string" ? source : undefined;
+    const string = l10n.getString(id, vars, fallback);
+    return React.createElement(React.Fragment, null, string);
   }
 
-  return l10n.getElement(componentToRender, id, { attrs, vars, elems });
+  return l10n.getElement(source, id, { attrs, vars, elems });
 }
 
 export default Localized;

--- a/fluent-react/src/localized.ts
+++ b/fluent-react/src/localized.ts
@@ -1,4 +1,5 @@
-import {
+import React, {
+  isValidElement,
   ReactElement,
   ReactNode,
   useContext,
@@ -45,7 +46,40 @@ export function Localized(props: LocalizedProps): ReactElement {
     );
   }
 
-  return l10n.getElement(children, id, { attrs, vars, elems });
+  let componentToRender: ReactNode | null;
+
+  // Validate that the child element isn't an array that contains multiple
+  // elements.
+  if (Array.isArray(children)) {
+    if (children.length > 1) {
+      throw new Error(
+        "Expected to receive a single React element to localize."
+      );
+    }
+
+    // If it's an array with zero or one element, we can directly get the first
+    // one.
+    componentToRender = children[0];
+  } else {
+    componentToRender = children ?? null;
+  }
+
+  // Check if the component to render is a valid element -- if not, then
+  // it's either null or a simple fallback string. No need to localize the
+  // attributes or replace.
+  if (!isValidElement(componentToRender)) {
+    return React.createElement(
+      React.Fragment,
+      null,
+      l10n.getString(
+        id,
+        vars,
+        typeof componentToRender === "string" ? componentToRender : undefined,
+      ),
+    );
+  }
+
+  return l10n.getElement(componentToRender, id, { attrs, vars, elems });
 }
 
 export default Localized;

--- a/fluent-react/src/localized.ts
+++ b/fluent-react/src/localized.ts
@@ -1,19 +1,10 @@
 import {
-  Fragment,
   ReactElement,
   ReactNode,
-  cloneElement,
-  createElement,
-  isValidElement,
   useContext,
 } from "react";
-import voidElementTags from "../vendor/voidElementTags.js";
 import { FluentContext } from "./context.js";
 import { FluentVariable } from "@fluent/bundle";
-
-// Match the opening angle bracket (<) in HTML tags, and HTML entities like
-// &amp;, &#0038;, &#x0026;.
-const reMarkup = /<|&#?\w+;/;
 
 export interface LocalizedProps {
   id: string;
@@ -47,23 +38,6 @@ export interface LocalizedProps {
 export function Localized(props: LocalizedProps): ReactElement {
   const { id, attrs, vars, elems, children } = props;
   const l10n = useContext(FluentContext);
-  let child: ReactNode | null;
-
-  // Validate that the child element isn't an array that contains multiple
-  // elements.
-  if (Array.isArray(children)) {
-    if (children.length > 1) {
-      throw new Error(
-        "<Localized/> expected to receive a single React node child"
-      );
-    }
-
-    // If it's an array with zero or one element, we can directly get the first
-    // one.
-    child = children[0];
-  } else {
-    child = children ?? null;
-  }
 
   if (!l10n) {
     throw new Error(
@@ -71,155 +45,7 @@ export function Localized(props: LocalizedProps): ReactElement {
     );
   }
 
-  const bundle = l10n.getBundle(id);
-
-  if (bundle === null) {
-    if (id === undefined) {
-      l10n.reportError(
-        new Error("No id was provided for a <Localized /> component.")
-      );
-    } else {
-      if (l10n.areBundlesEmpty()) {
-        l10n.reportError(
-          new Error(
-            "A <Localized /> component was rendered when no localization bundles are present."
-          )
-        );
-      } else {
-        l10n.reportError(
-          new Error(
-            `The id "${id}" did not match any messages in the localization bundles.`
-          )
-        );
-      }
-    }
-    // Use the wrapped component as fallback.
-    return createElement(Fragment, null, child);
-  }
-
-  // l10n.getBundle makes the bundle.hasMessage check which ensures that
-  // bundle.getMessage returns an existing message.
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const msg = bundle.getMessage(id)!;
-  let errors: Array<Error> = [];
-
-  // Check if the child inside <Localized> is a valid element -- if not, then
-  // it's either null or a simple fallback string. No need to localize the
-  // attributes.
-  if (!isValidElement(child)) {
-    if (msg.value) {
-      // Replace the fallback string with the message value;
-      let value = bundle.formatPattern(msg.value, vars, errors);
-      for (let error of errors) {
-        l10n.reportError(error);
-      }
-      return createElement(Fragment, null, value);
-    }
-
-    return createElement(Fragment, null, child);
-  }
-
-  let localizedProps: Record<string, string> | undefined;
-
-  // The default is to forbid all message attributes. If the attrs prop exists
-  // on the Localized instance, only set message attributes which have been
-  // explicitly allowed by the developer.
-  if (attrs && msg.attributes) {
-    localizedProps = {};
-    errors = [];
-    for (const [name, allowed] of Object.entries(attrs)) {
-      if (allowed && name in msg.attributes) {
-        localizedProps[name] = bundle.formatPattern(
-          msg.attributes[name],
-          vars,
-          errors
-        );
-      }
-    }
-    for (let error of errors) {
-      l10n.reportError(error);
-    }
-  }
-
-  // If the wrapped component is a known void element, explicitly dismiss the
-  // message value and do not pass it to cloneElement in order to avoid the
-  // "void element tags must neither have `children` nor use
-  // `dangerouslySetInnerHTML`" error.
-  if (typeof child.type === "string" && child.type in voidElementTags) {
-    return cloneElement(child, localizedProps);
-  }
-
-  // If the message has a null value, we're only interested in its attributes.
-  // Do not pass the null value to cloneElement as it would nuke all children
-  // of the wrapped component.
-  if (msg.value === null) {
-    return cloneElement(child, localizedProps);
-  }
-
-  errors = [];
-  const messageValue = bundle.formatPattern(msg.value, vars, errors);
-  for (let error of errors) {
-    l10n.reportError(error);
-  }
-
-  // If the message value doesn't contain any markup nor any HTML entities,
-  // insert it as the only child of the wrapped component.
-  if (!reMarkup.test(messageValue) || l10n.parseMarkup === null) {
-    return cloneElement(child, localizedProps, messageValue);
-  }
-
-  let elemsLower: Record<string, ReactElement>;
-  if (elems) {
-    elemsLower = {};
-    for (let [name, elem] of Object.entries(elems)) {
-      elemsLower[name.toLowerCase()] = elem;
-    }
-  }
-
-  // If the message contains markup, parse it and try to match the children
-  // found in the translation with the props passed to this Localized.
-  const translationNodes = l10n.parseMarkup(messageValue);
-  const translatedChildren = translationNodes.map(childNode => {
-    if (childNode.nodeName === "#text") {
-      return childNode.textContent;
-    }
-
-    const childName = childNode.nodeName.toLowerCase();
-
-    // If the child is not expected just take its textContent.
-    if (
-      !elemsLower ||
-      !Object.prototype.hasOwnProperty.call(elemsLower, childName)
-    ) {
-      return childNode.textContent;
-    }
-
-    const sourceChild = elemsLower[childName];
-
-    // Ignore elems which are not valid React elements.
-    if (!isValidElement(sourceChild)) {
-      return childNode.textContent;
-    }
-
-    // If the element passed in the elems prop is a known void element,
-    // explicitly dismiss any textContent which might have accidentally been
-    // defined in the translation to prevent the "void element tags must not
-    // have children" error.
-    if (
-      typeof sourceChild.type === "string" &&
-      sourceChild.type in voidElementTags
-    ) {
-      return sourceChild;
-    }
-
-    // TODO Protect contents of elements wrapped in <Localized>
-    // https://github.com/projectfluent/fluent.js/issues/184
-    // TODO  Control localizable attributes on elements passed as props
-    // https://github.com/projectfluent/fluent.js/issues/185
-    return cloneElement(sourceChild, undefined, childNode.textContent);
-  });
-
-  return cloneElement(child, localizedProps, ...translatedChildren);
+  return l10n.getElement(children, id, { attrs, vars, elems });
 }
 
 export default Localized;

--- a/fluent-react/test/localized_render.test.js
+++ b/fluent-react/test/localized_render.test.js
@@ -557,7 +557,7 @@ foo = Message
     expect(renderer.toJSON()).toMatchInlineSnapshot(`"Message"`);
   });
 
-  test("render without a fallback and no message returns nothing", () => {
+  test("render without a fallback and no message returns the message ID", () => {
     jest.spyOn(console, "warn").mockImplementation(() => {});
     const bundle = new FluentBundle();
 
@@ -567,7 +567,7 @@ foo = Message
       </LocalizationProvider>
     );
 
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`null`);
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`"foo"`);
     expect(console.warn.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [

--- a/fluent-react/test/localized_valid.test.js
+++ b/fluent-react/test/localized_valid.test.js
@@ -109,7 +109,7 @@ describe("Localized - validation", () => {
     expect(console.warn.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          "[@fluent/react] Error: No id was provided for a <Localized /> component.",
+          "[@fluent/react] Error: No string id was provided when localizing a component.",
         ],
       ]
     `);

--- a/fluent-react/test/use_localization.test.js
+++ b/fluent-react/test/use_localization.test.js
@@ -13,7 +13,7 @@ function DummyComponent() {
   return (
     <div>
       <p>{l10n.getString("foo")}</p>
-      <p>{l10n.getFragment("bar", { elems: { elem: <b/> } })}</p>
+      <p>{l10n.getElement(<></>, "bar", { elems: { elem: <b/> } })}</p>
       {l10n.getElement(<p/>, "bar", { elems: { elem: <i/> }, attrs: { "title": true } })}
     </div>
   );

--- a/fluent-react/test/use_localization.test.js
+++ b/fluent-react/test/use_localization.test.js
@@ -14,6 +14,7 @@ function DummyComponent() {
     <div>
       <p>{l10n.getString("foo")}</p>
       <p>{l10n.getFragment("bar", { elems: { elem: <b/> } })}</p>
+      {l10n.getElement(<p/>, "bar", { elems: { elem: <i/> }, attrs: { "title": true } })}
     </div>
   );
 }
@@ -21,7 +22,7 @@ function DummyComponent() {
 describe("useLocalization", () => {
   function createBundle() {
     const bundle = new FluentBundle("en");
-    bundle.addResource(new FluentResource("foo = FOO\nbar = BAR<elem>BAZ</elem>\n"));
+    bundle.addResource(new FluentResource("foo = FOO\nbar = BAR<elem>BAZ</elem>\n\t.title = QUX\n"));
     return bundle;
   }
 
@@ -41,6 +42,14 @@ describe("useLocalization", () => {
           <b>
             BAZ
           </b>
+        </p>
+        <p
+          title="QUX"
+        >
+          BAR
+          <i>
+            BAZ
+          </i>
         </p>
       </div>
     `);
@@ -76,6 +85,14 @@ describe("useLocalization", () => {
           <b>
             BAZ
           </b>
+        </p>
+        <p
+          title="QUX"
+        >
+          BAR
+          <i>
+            BAZ
+          </i>
         </p>
       </div>
     `);

--- a/fluent-react/test/use_localization.test.js
+++ b/fluent-react/test/use_localization.test.js
@@ -10,13 +10,18 @@ import {
 function DummyComponent() {
   const { l10n } = useLocalization();
 
-  return <p>{l10n.getString("foo")}</p>;
+  return (
+    <div>
+      <p>{l10n.getString("foo")}</p>
+      <p>{l10n.getFragment("bar", { elems: { elem: <b/> } })}</p>
+    </div>
+  );
 }
 
 describe("useLocalization", () => {
   function createBundle() {
-    const bundle = new FluentBundle("en", { useIsolating: false });
-    bundle.addResource(new FluentResource("foo = FOO\n"));
+    const bundle = new FluentBundle("en");
+    bundle.addResource(new FluentResource("foo = FOO\nbar = BAR<elem>BAZ</elem>\n"));
     return bundle;
   }
 
@@ -27,9 +32,17 @@ describe("useLocalization", () => {
       </LocalizationProvider>
     );
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      <p>
-        FOO
-      </p>
+      <div>
+        <p>
+          FOO
+        </p>
+        <p>
+          BAR
+          <b>
+            BAZ
+          </b>
+        </p>
+      </div>
     `);
   });
 
@@ -54,9 +67,17 @@ describe("useLocalization", () => {
     );
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      <p>
-        FOO
-      </p>
+      <div>
+        <p>
+          FOO
+        </p>
+        <p>
+          BAR
+          <b>
+            BAZ
+          </b>
+        </p>
+      </div>
     `);
   });
 });

--- a/fluent-react/test/use_localization.test.js
+++ b/fluent-react/test/use_localization.test.js
@@ -13,8 +13,11 @@ function DummyComponent() {
   return (
     <div>
       <p>{l10n.getString("foo")}</p>
-      <p>{l10n.getElement(<></>, "bar", { elems: { elem: <b/> } })}</p>
-      {l10n.getElement(<p/>, "bar", { elems: { elem: <i/> }, attrs: { "title": true } })}
+      <p>{l10n.getElement(<></>, "bar", { elems: { elem: <b /> } })}</p>
+      {l10n.getElement(<p />, "bar", {
+        elems: { elem: <i /> },
+        attrs: { title: true },
+      })}
     </div>
   );
 }
@@ -22,7 +25,11 @@ function DummyComponent() {
 describe("useLocalization", () => {
   function createBundle() {
     const bundle = new FluentBundle("en");
-    bundle.addResource(new FluentResource("foo = FOO\nbar = BAR<elem>BAZ</elem>\n\t.title = QUX\n"));
+    bundle.addResource(
+      new FluentResource(
+        "foo = FOO\nbar = BAR<elem>BAZ</elem>\n\t.title = QUX\n"
+      )
+    );
     return bundle;
   }
 


### PR DESCRIPTION
Fixes #544.

It's similar to `getString`, but returns a React Fragment instead
of a string. The main added benefit here is that it allows the
caller to pass in `elems` analogous to the similarly-named prop on
`<Localized>`.

We're mostly using `getString` in the Firefox Relay codebase, but have to switch to `<Localized>` every time we want to use an element in the translation string, which can be confusing to new contributors.

I do understand that generally it's best to be aligned on a new feature before submitting a PR, which I didn't do, so I want to emphasise that it's perfectly fine to let me know that this feature isn't desirable for one reason or another, or that I should redo everything if I want to get this in. It didn't seem like a feature that was too hard to implement, so I decided to just go ahead and give it a shot, with the worst case being a little wasted effort :)