### PR TITLE
Treat tab as text, not whitespace

### DIFF
--- a/fluent-bundle/test/fixtures_reference/tab.json
+++ b/fluent-bundle/test/fixtures_reference/tab.json
@@ -11,6 +11,18 @@
                 "This line is indented by 4 spaces,"
             ],
             "attributes": {}
+        },
+        {
+            "id": "key05",
+            "value": "\t",
+            "attributes": {}
+        },
+        {
+            "id": "key06",
+            "value": null,
+            "attributes": {
+                "attr": "\t\t"
+            }
         }
     ]
 }

--- a/fluent-syntax/src/parser.ts
+++ b/fluent-syntax/src/parser.ts
@@ -6,7 +6,7 @@ import type { Resource, Entry } from "./ast.js";
 import { EOF, EOL, FluentParserStream } from "./stream.js";
 import { ParseError } from "./errors.js";
 
-const trailingWSRe = /[ \t\n\r]+$/;
+const trailingWSRe = /[ \n\r]+$/;
 
 type ParseFn<T> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/fluent-syntax/test/fixtures_reference/tab.ftl
+++ b/fluent-syntax/test/fixtures_reference/tab.ftl
@@ -12,3 +12,10 @@ key03 =
 key04 =
     This line is indented by 4 spaces,
 	whereas this line by 1 tab.
+
+# OK (value is a single tab)
+key05 = 	
+
+# OK (attribute value is two tabs)
+key06 =
+  .attr = 		

--- a/fluent-syntax/test/fixtures_reference/tab.json
+++ b/fluent-syntax/test/fixtures_reference/tab.json
@@ -64,7 +64,58 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "\twhereas this line by 1 tab.\n"
+            "content": "\twhereas this line by 1 tab.\n\n"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key05"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "\t"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "OK (value is a single tab)"
+            }
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key06"
+            },
+            "value": null,
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "\t\t"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": {
+                "type": "Comment",
+                "content": "OK (attribute value is two tabs)"
+            }
         }
     ]
 }


### PR DESCRIPTION
See projectfluent/python-fluent#173

Tabs were defined to be text, not whitespace, in projectfluent/fluent#167, but this change was not reflected in the trailing whitespace trimming that was added in #247.