### PR TITLE
Rename default branch from master to main

### DIFF
--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,9 +1,9 @@
 name: legacy
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 jobs:
   dist:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: test
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 jobs:
   dist:

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ natural languages like gender, plurals, conjugations, and others.
 Fluent.js consists of a set of packages which have different use-cases and can
 be installed independently of each other.
 
-- [@fluent/bundle](https://github.com/projectfluent/fluent.js/tree/master/fluent-bundle)
-- [@fluent/dedent](https://github.com/projectfluent/fluent.js/tree/master/fluent-dedent)
-- [@fluent/dom](https://github.com/projectfluent/fluent.js/tree/master/fluent-dom)
-- [@fluent/langneg](https://github.com/projectfluent/fluent.js/tree/master/fluent-langneg)
-- [@fluent/react](https://github.com/projectfluent/fluent.js/tree/master/fluent-react)
-- [@fluent/sequence](https://github.com/projectfluent/fluent.js/tree/master/fluent-sequence)
-- [@fluent/syntax](https://github.com/projectfluent/fluent.js/tree/master/fluent-syntax)
+- [@fluent/bundle](https://github.com/projectfluent/fluent.js/tree/main/fluent-bundle)
+- [@fluent/dedent](https://github.com/projectfluent/fluent.js/tree/main/fluent-dedent)
+- [@fluent/dom](https://github.com/projectfluent/fluent.js/tree/main/fluent-dom)
+- [@fluent/langneg](https://github.com/projectfluent/fluent.js/tree/main/fluent-langneg)
+- [@fluent/react](https://github.com/projectfluent/fluent.js/tree/main/fluent-react)
+- [@fluent/sequence](https://github.com/projectfluent/fluent.js/tree/main/fluent-sequence)
+- [@fluent/syntax](https://github.com/projectfluent/fluent.js/tree/main/fluent-syntax)
 
 You can install each of the above packages via `npm`, e.g. `npm install @fluent/react`.  
 See the end of this `README` for instructions on how to build `fluent.js` locally.


### PR DESCRIPTION
These changes should go together with the actual rename of the default branch, which should be pretty painless.