### PR TITLE
Cancel the `requestAnimationFrame` when all roots are disconnected

### DIFF
--- a/fluent-dom/src/dom_localization.js
+++ b/fluent-dom/src/dom_localization.js
@@ -168,6 +168,9 @@ export default class DOMLocalization extends Localization {
 
     if (this.roots.size === 0) {
       this.mutationObserver = null;
+      if (this.windowElement && this.pendingrAF) {
+        this.windowElement.cancelAnimationFrame(this.pendingrAF);
+      }
       this.windowElement = null;
       this.pendingrAF = null;
       this.pendingElements.clear();


### PR DESCRIPTION
Given that `pendingElements` was already being cleared, just below, there won't be anything to translate and as far as I can tell keeping the `requestAnimationFrame` running shouldn't be necessary.

Note that this was found in the PDF.js project, please refer to [this discussion](https://github.com/mozilla/pdf.js/pull/18313#discussion_r1649732857), where we're trying to shutdown various asynchronous operations when running tests and currently Fluent make this difficult.

/cc @calixteman, @timvandermeij