### PR TITLE
Add Temporal support

### DIFF
--- a/fluent-bundle/package.json
+++ b/fluent-bundle/package.json
@@ -49,6 +49,7 @@
     "npm": ">=7.0.0"
   },
   "devDependencies": {
-    "@fluent/dedent": "^0.5.0"
+    "@fluent/dedent": "^0.5.0",
+    "temporal-polyfill": "^0.2.5"
   }
 }

--- a/fluent-bundle/src/builtins.ts
+++ b/fluent-bundle/src/builtins.ts
@@ -88,7 +88,7 @@ export function NUMBER(
   }
 
   if (arg instanceof FluentDateTime) {
-    return new FluentNumber(arg.valueOf(), {
+    return new FluentNumber(arg.toNumber(), {
       ...values(opts, NUMBER_ALLOWED),
     });
   }
@@ -157,17 +157,8 @@ export function DATETIME(
     return new FluentNone(`DATETIME(${arg.valueOf()})`);
   }
 
-  if (arg instanceof FluentDateTime) {
-    return new FluentDateTime(arg.valueOf(), {
-      ...arg.opts,
-      ...values(opts, DATETIME_ALLOWED),
-    });
-  }
-
-  if (arg instanceof FluentNumber) {
-    return new FluentDateTime(arg.valueOf(), {
-      ...values(opts, DATETIME_ALLOWED),
-    });
+  if (arg instanceof FluentDateTime || arg instanceof FluentNumber) {
+    return new FluentDateTime(arg, values(opts, DATETIME_ALLOWED));
   }
 
   throw new TypeError("Invalid argument to DATETIME");

--- a/fluent-bundle/src/bundle.ts
+++ b/fluent-bundle/src/bundle.ts
@@ -1,13 +1,12 @@
 import { resolveComplexPattern } from "./resolver.js";
 import { Scope } from "./scope.js";
 import { FluentResource } from "./resource.js";
-import { FluentValue, FluentNone, FluentFunction } from "./types.js";
+import { FluentVariable, FluentNone, FluentFunction } from "./types.js";
 import { Message, Term, Pattern } from "./ast.js";
 import { NUMBER, DATETIME } from "./builtins.js";
 import { getMemoizerForLocale, IntlCache } from "./memoizer.js";
 
 export type TextTransform = (text: string) => string;
-export type FluentVariable = FluentValue | string | number | Date;
 
 /**
  * Message bundles are single-language stores of translation resources. They are

--- a/fluent-bundle/src/index.ts
+++ b/fluent-bundle/src/index.ts
@@ -8,11 +8,12 @@
  */
 
 export type { Message } from "./ast.js";
-export { FluentBundle, FluentVariable, TextTransform } from "./bundle.js";
+export { FluentBundle, TextTransform } from "./bundle.js";
 export { FluentResource } from "./resource.js";
 export type { Scope } from "./scope.js";
 export {
   FluentValue,
+  FluentVariable,
   FluentType,
   FluentFunction,
   FluentNone,

--- a/fluent-bundle/src/resolver.ts
+++ b/fluent-bundle/src/resolver.ts
@@ -30,6 +30,7 @@ import {
   FluentNone,
   FluentNumber,
   FluentDateTime,
+  FluentVariable,
 } from "./types.js";
 import { Scope } from "./scope.js";
 import {
@@ -44,7 +45,6 @@ import {
   ComplexPattern,
   Pattern,
 } from "./ast.js";
-import { FluentVariable } from "./bundle.js";
 
 /**
  * The maximum number of placeables which can be expanded in a single call to
@@ -187,8 +187,8 @@ function resolveVariableReference(
     case "number":
       return new FluentNumber(arg);
     case "object":
-      if (arg instanceof Date) {
-        return new FluentDateTime(arg.getTime());
+      if (FluentDateTime.supportsValue(arg)) {
+        return new FluentDateTime(arg);
       }
     // eslint-disable-next-line no-fallthrough
     default:

--- a/fluent-bundle/src/scope.ts
+++ b/fluent-bundle/src/scope.ts
@@ -1,5 +1,6 @@
-import { FluentBundle, FluentVariable } from "./bundle.js";
+import { FluentBundle } from "./bundle.js";
 import { ComplexPattern } from "./ast.js";
+import { FluentVariable } from "./types.js";
 
 export class Scope {
   /** The bundle for which the given resolution is happening. */

--- a/fluent-bundle/src/types.ts
+++ b/fluent-bundle/src/types.ts
@@ -11,7 +11,6 @@ export type FluentVariable =
   | Temporal.PlainTime
   | Temporal.PlainYearMonth
   | Temporal.PlainMonthDay
-  | Temporal.ZonedDateTime
   | string
   | number
   | Date;
@@ -132,7 +131,6 @@ export class FluentDateTime extends FluentType<
   | Temporal.PlainMonthDay
   | Temporal.PlainTime
   | Temporal.PlainYearMonth
-  | Temporal.ZonedDateTime
 > {
   /** Options passed to `Intl.DateTimeFormat`. */
   public opts: Intl.DateTimeFormatOptions;
@@ -150,8 +148,7 @@ export class FluentDateTime extends FluentType<
         value instanceof Temporal.PlainDate      || // @ts-ignore
         value instanceof Temporal.PlainMonthDay  || // @ts-ignore
         value instanceof Temporal.PlainTime      || // @ts-ignore
-        value instanceof Temporal.PlainYearMonth || // @ts-ignore
-        value instanceof Temporal.ZonedDateTime
+        value instanceof Temporal.PlainYearMonth
       ) {
         return true;
       }
@@ -176,7 +173,6 @@ export class FluentDateTime extends FluentType<
       | Temporal.PlainMonthDay
       | Temporal.PlainTime
       | Temporal.PlainYearMonth
-      | Temporal.ZonedDateTime
       | FluentDateTime
       | FluentType<number>,
     opts: Intl.DateTimeFormatOptions = {}
@@ -189,29 +185,9 @@ export class FluentDateTime extends FluentType<
       value = value.valueOf();
     }
 
-    if (typeof value === "object") {
-      // Intl.DateTimeFormat defaults to gregorian calendar, but Temporal defaults to iso8601
-      if ('calendarId' in value) {
-        if (opts.calendar === undefined) {
-          opts = { ...opts, calendar: value.calendarId };
-        } else if (opts.calendar !== value.calendarId && 'withCalendar' in value) {
-          value = value.withCalendar(opts.calendar);
-        }
-      }
-
-      // Temporal.ZonedDateTime is timezone aware
-      if ('timeZoneId' in value) {
-        if (opts.timeZone === undefined) {
-          opts = { ...opts, timeZone: value.timeZoneId };
-        } else if (opts.timeZone !== value.timeZoneId && 'withTimeZone' in value) {
-          value = value.withTimeZone(opts.timeZone);
-        }
-      }
-
-      // Temporal.ZonedDateTime cannot be formatted directly
-      if ('toInstant' in value) {
-        value = value.toInstant();
-      }
+    // Intl.DateTimeFormat defaults to gregorian calendar, but Temporal defaults to iso8601
+    if (typeof value === "object" && 'calendarId' in value && opts.calendar === undefined) {
+      opts = { ...opts, calendar: value.calendarId };
     }
 
     super(value);

--- a/fluent-bundle/src/types.ts
+++ b/fluent-bundle/src/types.ts
@@ -1,6 +1,19 @@
 import { Scope } from "./scope.js";
+import type { Temporal } from "temporal-polyfill";
 
 export type FluentValue = FluentType<unknown> | string;
+
+export type FluentVariable =
+  | FluentValue
+  | Temporal.Instant
+  | Temporal.PlainDateTime
+  | Temporal.PlainDate
+  | Temporal.PlainTime
+  | Temporal.PlainYearMonth
+  | Temporal.PlainMonthDay
+  | Temporal.ZonedDateTime
+  | string
+  | number;
 
 export type FluentFunction = (
   positional: Array<FluentValue>,
@@ -104,14 +117,46 @@ export class FluentNumber extends FluentType<number> {
 /**
  * A `FluentType` representing a date and time.
  *
- * A `FluentDateTime` instance stores the number value of the date it
- * represents, as a numerical timestamp in milliseconds. It may also store an
+ * A `FluentDateTime` instance stores a Date object, Temporal object, or a number
+ * as a numerical timestamp in milliseconds. It may also store an
  * option bag of options which will be passed to `Intl.DateTimeFormat` when the
  * `FluentDateTime` is formatted to a string.
  */
-export class FluentDateTime extends FluentType<number> {
+export class FluentDateTime extends FluentType<
+  | number
+  | Date
+  | Temporal.Instant
+  | Temporal.PlainDateTime
+  | Temporal.PlainDate
+  | Temporal.PlainMonthDay
+  | Temporal.PlainTime
+  | Temporal.PlainYearMonth
+  | Temporal.ZonedDateTime
+> {
   /** Options passed to `Intl.DateTimeFormat`. */
   public opts: Intl.DateTimeFormatOptions;
+
+  static supportsValue(value: any): value is ConstructorParameters<typeof Temporal.Instant>[0] {
+    if (typeof value === "number") return true;
+    if (value instanceof Date) return true;
+    if (value instanceof FluentType) return FluentDateTime.supportsValue(value.valueOf());
+    // Temporary workaround to support environments without Temporal
+    if ('Temporal' in globalThis) {
+      if (
+        // @ts-ignore
+        value instanceof Temporal.Instant        || // @ts-ignore
+        value instanceof Temporal.PlainDateTime  || // @ts-ignore
+        value instanceof Temporal.PlainDate      || // @ts-ignore
+        value instanceof Temporal.PlainMonthDay  || // @ts-ignore
+        value instanceof Temporal.PlainTime      || // @ts-ignore
+        value instanceof Temporal.PlainYearMonth || // @ts-ignore
+        value instanceof Temporal.ZonedDateTime
+      ) {
+        return true;
+      }
+    }
+    return false
+  }
 
   /**
    * Create an instance of `FluentDateTime` with options to the
@@ -120,9 +165,70 @@ export class FluentDateTime extends FluentType<number> {
    * @param value The number value of this `FluentDateTime`, in milliseconds.
    * @param opts Options which will be passed to `Intl.DateTimeFormat`.
    */
-  constructor(value: number, opts: Intl.DateTimeFormatOptions = {}) {
+  constructor(
+    value:
+      | number
+      | Date
+      | Temporal.Instant
+      | Temporal.PlainDateTime
+      | Temporal.PlainDate
+      | Temporal.PlainMonthDay
+      | Temporal.PlainTime
+      | Temporal.PlainYearMonth
+      | Temporal.ZonedDateTime
+      | FluentDateTime
+      | FluentType<number>,
+    opts: Intl.DateTimeFormatOptions = {}
+  ) {
+    // unwrap any FluentType value, but only retain the opts from FluentDateTime
+    if (value instanceof FluentDateTime) {
+      opts = { ...value.opts, ...opts };
+      value = value.value;
+    } else if (value instanceof FluentType) {
+      value = value.valueOf();
+    }
+
+    if (typeof value === "object") {
+      // Intl.DateTimeFormat defaults to gregorian calendar, but Temporal defaults to iso8601
+      if ('calendarId' in value) {
+        if (opts.calendar === undefined) {
+          opts = { ...opts, calendar: value.calendarId };
+        } else if (opts.calendar !== value.calendarId && 'withCalendar' in value) {
+          value = value.withCalendar(opts.calendar);
+        }
+      }
+
+      // Temporal.ZonedDateTime is timezone aware
+      if ('timeZoneId' in value) {
+        if (opts.timeZone === undefined) {
+          opts = { ...opts, timeZone: value.timeZoneId };
+        } else if (opts.timeZone !== value.timeZoneId && 'withTimeZone' in value) {
+          value = value.withTimeZone(opts.timeZone);
+        }
+      }
+
+      // Temporal.ZonedDateTime cannot be formatted directly
+      if ('toInstant' in value) {
+        value = value.toInstant();
+      }
+    }
+
     super(value);
     this.opts = opts;
+  }
+
+  /**
+   * Convert this `FluentDateTime` to a number.
+   * Note that this isn't always possible due to the nature of Temporal objects.
+   * In such cases, a TypeError will be thrown.
+   */
+  toNumber(): number {
+    const value = this.value;
+    if (typeof value === "number") return value;
+    if (value instanceof Date) return value.getTime();
+    if ('epochMilliseconds' in value) return value.epochMilliseconds;
+    if ('toZonedDateTime' in value) return (value as Temporal.PlainDateTime).toZonedDateTime("UTC").epochMilliseconds;
+    throw new TypeError("Unwrapping a non-number value as a number");
   }
 
   /**
@@ -131,10 +237,14 @@ export class FluentDateTime extends FluentType<number> {
   toString(scope: Scope): string {
     try {
       const dtf = scope.memoizeIntlObject(Intl.DateTimeFormat, this.opts);
-      return dtf.format(this.value);
+      return dtf.format(this.value as Parameters<Intl.DateTimeFormat["format"]>[0]);
     } catch (err) {
       scope.reportError(err);
-      return new Date(this.value).toISOString();
+      if (typeof this.value === "number" || this.value instanceof Date) {
+        return new Date(this.value).toISOString();
+      } else {
+        return this.value.toString();
+      }
     }
   }
 }

--- a/fluent-bundle/src/types.ts
+++ b/fluent-bundle/src/types.ts
@@ -135,7 +135,7 @@ export class FluentDateTime extends FluentType<
   /** Options passed to `Intl.DateTimeFormat`. */
   public opts: Intl.DateTimeFormatOptions;
 
-  static supportsValue(value: any): value is ConstructorParameters<typeof Temporal.Instant>[0] {
+  static supportsValue(value: unknown): value is ConstructorParameters<typeof FluentDateTime>[0] {
     if (typeof value === "number") return true;
     if (value instanceof Date) return true;
     if (value instanceof FluentType) return FluentDateTime.supportsValue(value.valueOf());

--- a/fluent-bundle/src/types.ts
+++ b/fluent-bundle/src/types.ts
@@ -13,7 +13,8 @@ export type FluentVariable =
   | Temporal.PlainMonthDay
   | Temporal.ZonedDateTime
   | string
-  | number;
+  | number
+  | Date;
 
 export type FluentFunction = (
   positional: Array<FluentValue>,

--- a/fluent-bundle/src/types.ts
+++ b/fluent-bundle/src/types.ts
@@ -219,9 +219,8 @@ export class FluentDateTime extends FluentType<
       scope.reportError(err);
       if (typeof this.value === "number" || this.value instanceof Date) {
         return new Date(this.value).toISOString();
-      } else {
-        return this.value.toString();
       }
+      return this.value.toString();
     }
   }
 }

--- a/fluent-bundle/test/temporal_test.js
+++ b/fluent-bundle/test/temporal_test.js
@@ -40,11 +40,11 @@ suite("Temporal support", function () {
     });
 
     test("direct interpolation", function () {
-      assert.strictEqual(msg("direct"), "1/1/1970, 1:00:00 AM");
+      assert.strictEqual(msg("direct"), arg.toLocaleString());
     });
 
     test("run through DATETIME()", function () {
-      assert.strictEqual(msg("dt"), "1/1/1970, 1:00:00 AM");
+      assert.strictEqual(msg("dt"), arg.toLocaleString());
     });
 
     test("run through DATETIME() with month option", function () {

--- a/fluent-bundle/test/temporal_test.js
+++ b/fluent-bundle/test/temporal_test.js
@@ -1,0 +1,269 @@
+"use strict";
+
+import assert from "assert";
+import ftl from "@fluent/dedent";
+
+import { FluentBundle } from "../esm/bundle.js";
+import { FluentResource } from "../esm/resource.js";
+import { FluentDateTime } from "../esm/types.js";
+
+suite("Temporal support", function () {
+  let bundle, arg;
+
+  function msg(id, errors = undefined) {
+    const errs = [];
+    const msg = bundle.getMessage(id);
+    const res = bundle.formatPattern(msg.value, { arg }, errors || errs);
+    if (errs.length > 0) { assert.fail(errs[0].message); }
+    return res;
+  }
+
+  suiteSetup(async function () {
+    if (typeof Temporal === "undefined") {
+      await import("temporal-polyfill/global");
+    }
+
+    bundle = new FluentBundle("en-US", { useIsolating: false });
+    bundle.addResource(
+      new FluentResource(ftl`
+      direct = { $arg }
+      dt = { DATETIME($arg) }
+      month = { DATETIME($arg, month: "long", year: "numeric") }
+      timezone = { DATETIME($arg, timeZoneName: "shortGeneric") }
+      `)
+    );
+  });
+
+  suite("Temporal.Instant", function () {
+    setup(function () {
+      arg = Temporal.Instant.from("1970-01-01T00:00:00Z");
+    });
+
+    test("direct interpolation", function () {
+      assert.strictEqual(msg("direct"), "1/1/1970, 1:00:00 AM");
+    });
+
+    test("run through DATETIME()", function () {
+      assert.strictEqual(msg("dt"), "1/1/1970, 1:00:00 AM");
+    });
+
+    test("run through DATETIME() with month option", function () {
+      assert.strictEqual(msg("month"), "January 1970");
+    });
+
+    test("wrapped in FluentDateTime", function () {
+      arg = new FluentDateTime(arg, { timeZone: "America/New_York" });
+      assert.strictEqual(msg("dt"), "12/31/1969, 7:00:00 PM");
+      assert.strictEqual(msg("timezone"), "12/31/1969, 7:00:00 PM ET");
+    });
+
+    test("can be converted to a number", function () {
+      arg = new FluentDateTime(arg);
+      assert.strictEqual(arg.toNumber(), 0);
+    });
+  });
+
+  suite("Temporal.PlainDate (gregory)", function () {
+    setup(function () {
+      arg = Temporal.PlainDate.from("1970-01-01[u-ca=gregory]");
+    });
+
+    test("direct interpolation", function () {
+      assert.strictEqual(msg("direct"), "1/1/1970");
+    });
+
+    test("run through DATETIME()", function () {
+      assert.strictEqual(msg("dt"), "1/1/1970");
+    });
+
+    test("run through DATETIME() with month option", function () {
+      assert.strictEqual(msg("month"), "January 1970");
+    });
+
+    test("wrapped in FluentDateTime", function () {
+      arg = new FluentDateTime(arg, { calendar: "iso8601" });
+      assert.strictEqual(msg("dt"), "1970-01-01");
+    });
+
+    test("can be converted to a number", function () {
+      arg = new FluentDateTime(arg);
+      assert.strictEqual(arg.toNumber(), 0);
+    });
+  });
+
+  suite("Temporal.PlainDate (iso8601)", function () {
+    setup(function () {
+      arg = Temporal.PlainDate.from("1970-01-01[u-ca=iso8601]");
+    });
+
+    test("direct interpolation", function () {
+      assert.strictEqual(msg("direct"), "1970-01-01");
+    });
+
+    test("run through DATETIME()", function () {
+      assert.strictEqual(msg("dt"), "1970-01-01");
+    });
+
+    test("run through DATETIME() with month option", function () {
+      assert.strictEqual(msg("month"), "1970 January");
+    });
+
+    test("wrapped in FluentDateTime", function () {
+      arg = new FluentDateTime(arg, { calendar: "gregory" });
+      assert.strictEqual(msg("dt"), "1/1/1970");
+    });
+
+    test("can be converted to a number", function () {
+      arg = new FluentDateTime(arg);
+      assert.strictEqual(arg.toNumber(), 0);
+    });
+  });
+
+  suite("Temporal.PlainDateTime", function () {
+    setup(function () {
+      arg = Temporal.PlainDateTime.from("1970-01-01T00:00:00[u-ca=gregory]");
+    });
+
+    test("direct interpolation", function () {
+      assert.strictEqual(msg("direct"), "1/1/1970, 12:00:00 AM");
+    });
+
+    test("run through DATETIME()", function () {
+      assert.strictEqual(msg("dt"), "1/1/1970, 12:00:00 AM");
+    });
+
+    test("run through DATETIME() with month option", function () {
+      assert.strictEqual(msg("month"), "January 1970");
+    });
+
+    test("wrapped in FluentDateTime", function () {
+      arg = new FluentDateTime(arg, { timeZone: "America/New_York" });
+      assert.strictEqual(msg("dt"), "1/1/1970, 12:00:00 AM");
+    });
+  });
+
+  suite("Temporal.PlainTime", function () {
+    setup(function () {
+      arg = Temporal.PlainTime.from("00:00:00");
+    });
+
+    test("direct interpolation", function () {
+      assert.strictEqual(msg("direct"), "12:00:00 AM");
+    });
+
+    test("run through DATETIME()", function () {
+      assert.strictEqual(msg("dt"), "12:00:00 AM");
+    });
+
+    test("run through DATETIME() with month option", function () {
+      assert.strictEqual(msg("month"), "12:00:00 AM");
+    });
+
+    test("wrapped in FluentDateTime", function () {
+      arg = new FluentDateTime(arg, { timeZone: "America/New_York" });
+      assert.strictEqual(msg("dt"), "12:00:00 AM");
+    });
+
+    test("cannot be converted to a number", function () {
+      arg = new FluentDateTime(arg);
+      assert.throws(() => arg.toNumber(), TypeError);
+    });
+  });
+
+  suite("PlainYearMonth (gregory)", function () {
+    setup(function () {
+      arg = Temporal.PlainYearMonth.from({
+        year: 1970,
+        month: 1,
+        calendar: "gregory"
+      });
+    });
+
+    test("direct interpolation", function () {
+      assert.strictEqual(msg("direct"), "1/1970");
+    });
+
+    test("run through DATETIME()", function () {
+      assert.strictEqual(msg("dt"), "1/1970");
+    });
+
+    test("run through DATETIME() with month option", function () {
+      assert.strictEqual(msg("month"), "January 1970");
+    });
+
+    test("wrapped in FluentDateTime", function () {
+      arg = new FluentDateTime(arg, { timeZone: "America/New_York" });
+      assert.strictEqual(msg("dt"), "1/1970");
+    });
+
+    test("cannot be converted to a number", function () {
+      arg = new FluentDateTime(arg);
+      assert.throws(() => arg.toNumber(), TypeError);
+    });
+  });
+
+  suite("Temporal.ZonedDateTime (gregory)", function () {
+    setup(function () {
+      arg = Temporal.ZonedDateTime.from("1970-01-01T00:00:00Z[UTC][u-ca=gregory]");
+    });
+
+    test("direct interpolation", function () {
+      assert.strictEqual(msg("direct"), "1/1/1970, 12:00:00 AM");
+    });
+
+    test("run through DATETIME()", function () {
+      assert.strictEqual(msg("dt"), "1/1/1970, 12:00:00 AM");
+    });
+
+    test("run through DATETIME() with month option", function () {
+      assert.strictEqual(msg("month"), "January 1970");
+    });
+
+    test("wrapped in FluentDateTime", function () {
+      arg = new FluentDateTime(arg, { timeZone: "America/New_York" });
+      assert.strictEqual(msg("dt"), "12/31/1969, 7:00:00 PM");
+      assert.strictEqual(msg("timezone"), "12/31/1969, 7:00:00 PM ET");
+    });
+
+    test("respects timeZoneId", function () {
+      assert.strictEqual(msg("timezone"), "1/1/1970, 12:00:00 AM GMT");
+      arg = arg.withTimeZone("America/New_York");
+      assert.strictEqual(msg("timezone"), "12/31/1969, 7:00:00 PM ET");
+    });
+
+    test("can be converted to a number", function () {
+      arg = new FluentDateTime(arg);
+      assert.strictEqual(arg.toNumber(), 0);
+    });
+  });
+
+  suite("Temporal.ZonedDateTime (iso8601)", function () {
+    setup(function () {
+      arg = Temporal.ZonedDateTime.from("1970-01-01T00:00:00Z[UTC][u-ca=iso8601]");
+    });
+
+    test("direct interpolation", function () {
+      assert.strictEqual(msg("direct"), "1970-01-01, 12:00:00 AM");
+    });
+
+    test("run through DATETIME()", function () {
+      assert.strictEqual(msg("dt"), "1970-01-01, 12:00:00 AM");
+    });
+
+    test("run through DATETIME() with month option", function () {
+      assert.strictEqual(msg("month"), "1970 January");
+    });
+
+    test("wrapped in FluentDateTime", function () {
+      arg = new FluentDateTime(arg, { timeZone: "America/New_York" });
+      assert.strictEqual(msg("dt"), "1969-12-31, 7:00:00 PM");
+      assert.strictEqual(msg("timezone"), "1969-12-31, 7:00:00 PM ET");
+    });
+
+    test("respects timeZoneId", function () {
+      assert.strictEqual(msg("timezone"), "1970-01-01, 12:00:00 AM GMT");
+      arg = arg.withTimeZone("America/New_York");
+      assert.strictEqual(msg("timezone"), "1969-12-31, 7:00:00 PM ET");
+    });
+  });
+});

--- a/fluent-bundle/test/temporal_test.js
+++ b/fluent-bundle/test/temporal_test.js
@@ -10,6 +10,9 @@ import { FluentDateTime } from "../esm/types.js";
 suite("Temporal support", function () {
   let bundle, arg;
 
+  // Node.js prior to v20 does not support the iso8601 calendar
+  const supportIso8601 = new Intl.DateTimeFormat("en-US", { calendar: "iso8601" }).format(0) === "1970-01-01";
+
   function msg(id, errors = undefined) {
     const errs = [];
     const msg = bundle.getMessage(id);
@@ -91,33 +94,35 @@ suite("Temporal support", function () {
     });
   });
 
-  suite("Temporal.PlainDate (iso8601)", function () {
-    setup(function () {
-      arg = Temporal.PlainDate.from("1970-01-01[u-ca=iso8601]");
-    });
+  if (supportIso8601) {
+    suite("Temporal.PlainDate (iso8601)", function () {
+      setup(function () {
+        arg = Temporal.PlainDate.from("1970-01-01[u-ca=iso8601]");
+      });
 
-    test("direct interpolation", function () {
-      assert.strictEqual(msg("direct"), "1970-01-01");
-    });
+      test("direct interpolation", function () {
+        assert.strictEqual(msg("direct"), "1970-01-01");
+      });
 
-    test("run through DATETIME()", function () {
-      assert.strictEqual(msg("dt"), "1970-01-01");
-    });
+      test("run through DATETIME()", function () {
+        assert.strictEqual(msg("dt"), "1970-01-01");
+      });
 
-    test("run through DATETIME() with month option", function () {
-      assert.strictEqual(msg("month"), "1970 January");
-    });
+      test("run through DATETIME() with month option", function () {
+        assert.strictEqual(msg("month"), "1970 January");
+      });
 
-    test("wrapped in FluentDateTime", function () {
-      arg = new FluentDateTime(arg, { month: "long" });
-      assert.strictEqual(msg("dt"), "January");
-    });
+      test("wrapped in FluentDateTime", function () {
+        arg = new FluentDateTime(arg, { month: "long" });
+        assert.strictEqual(msg("dt"), "January");
+      });
 
-    test("can be converted to a number", function () {
-      arg = new FluentDateTime(arg);
-      assert.strictEqual(arg.toNumber(), 0);
+      test("can be converted to a number", function () {
+        arg = new FluentDateTime(arg);
+        assert.strictEqual(arg.toNumber(), 0);
+      });
     });
-  });
+  }
 
   suite("Temporal.PlainDateTime", function () {
     setup(function () {
@@ -153,10 +158,6 @@ suite("Temporal support", function () {
 
     test("run through DATETIME()", function () {
       assert.strictEqual(msg("dt"), "12:00:00 AM");
-    });
-
-    test("run through DATETIME() with month option", function () {
-      assert.strictEqual(msg("month"), "12:00:00 AM");
     });
 
     test("wrapped in FluentDateTime", function () {

--- a/fluent-bundle/test/temporal_test.js
+++ b/fluent-bundle/test/temporal_test.js
@@ -81,8 +81,8 @@ suite("Temporal support", function () {
     });
 
     test("wrapped in FluentDateTime", function () {
-      arg = new FluentDateTime(arg, { calendar: "iso8601" });
-      assert.strictEqual(msg("dt"), "1970-01-01");
+      arg = new FluentDateTime(arg, { month: "long" });
+      assert.strictEqual(msg("dt"), "January");
     });
 
     test("can be converted to a number", function () {
@@ -109,8 +109,8 @@ suite("Temporal support", function () {
     });
 
     test("wrapped in FluentDateTime", function () {
-      arg = new FluentDateTime(arg, { calendar: "gregory" });
-      assert.strictEqual(msg("dt"), "1/1/1970");
+      arg = new FluentDateTime(arg, { month: "long" });
+      assert.strictEqual(msg("dt"), "January");
     });
 
     test("can be converted to a number", function () {
@@ -199,71 +199,6 @@ suite("Temporal support", function () {
     test("cannot be converted to a number", function () {
       arg = new FluentDateTime(arg);
       assert.throws(() => arg.toNumber(), TypeError);
-    });
-  });
-
-  suite("Temporal.ZonedDateTime (gregory)", function () {
-    setup(function () {
-      arg = Temporal.ZonedDateTime.from("1970-01-01T00:00:00Z[UTC][u-ca=gregory]");
-    });
-
-    test("direct interpolation", function () {
-      assert.strictEqual(msg("direct"), "1/1/1970, 12:00:00 AM");
-    });
-
-    test("run through DATETIME()", function () {
-      assert.strictEqual(msg("dt"), "1/1/1970, 12:00:00 AM");
-    });
-
-    test("run through DATETIME() with month option", function () {
-      assert.strictEqual(msg("month"), "January 1970");
-    });
-
-    test("wrapped in FluentDateTime", function () {
-      arg = new FluentDateTime(arg, { timeZone: "America/New_York" });
-      assert.strictEqual(msg("dt"), "12/31/1969, 7:00:00 PM");
-      assert.strictEqual(msg("timezone"), "12/31/1969, 7:00:00 PM ET");
-    });
-
-    test("respects timeZoneId", function () {
-      assert.strictEqual(msg("timezone"), "1/1/1970, 12:00:00 AM GMT");
-      arg = arg.withTimeZone("America/New_York");
-      assert.strictEqual(msg("timezone"), "12/31/1969, 7:00:00 PM ET");
-    });
-
-    test("can be converted to a number", function () {
-      arg = new FluentDateTime(arg);
-      assert.strictEqual(arg.toNumber(), 0);
-    });
-  });
-
-  suite("Temporal.ZonedDateTime (iso8601)", function () {
-    setup(function () {
-      arg = Temporal.ZonedDateTime.from("1970-01-01T00:00:00Z[UTC][u-ca=iso8601]");
-    });
-
-    test("direct interpolation", function () {
-      assert.strictEqual(msg("direct"), "1970-01-01, 12:00:00 AM");
-    });
-
-    test("run through DATETIME()", function () {
-      assert.strictEqual(msg("dt"), "1970-01-01, 12:00:00 AM");
-    });
-
-    test("run through DATETIME() with month option", function () {
-      assert.strictEqual(msg("month"), "1970 January");
-    });
-
-    test("wrapped in FluentDateTime", function () {
-      arg = new FluentDateTime(arg, { timeZone: "America/New_York" });
-      assert.strictEqual(msg("dt"), "1969-12-31, 7:00:00 PM");
-      assert.strictEqual(msg("timezone"), "1969-12-31, 7:00:00 PM ET");
-    });
-
-    test("respects timeZoneId", function () {
-      assert.strictEqual(msg("timezone"), "1970-01-01, 12:00:00 AM GMT");
-      arg = arg.withTimeZone("America/New_York");
-      assert.strictEqual(msg("timezone"), "1969-12-31, 7:00:00 PM ET");
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,8 @@
       "version": "0.18.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@fluent/dedent": "^0.5.0"
+        "@fluent/dedent": "^0.5.0",
+        "temporal-polyfill": "^0.2.5"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -8303,6 +8304,23 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
+      "integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "^0.2.4"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
+      "integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",


### PR DESCRIPTION
This is an alternative to #635, adding only support for Temporal time objects without implementing a public variable caster API.

It still has some special handling to work fine in environments without Temporal. It also avoids running any such checks at load time, to allow loading a Temporal polyfill after loading fluent-bundle.

## Duration

It does not implement `Temporal.Duration` support yet, which would require:
* Augmenting built-in TypeScript `Intl` namespace to support `Intl.DurationFormat` and `Intl.DurationFormatOptions`
* Add signature for `Intl.DurationFormat` to `scope.memoizeIntlObject`
* Add `FluentDuration` wrapper for `Temporal.Duration`
* Optional: Add `DURATION` builtin

Happy to work on that as well, but can also create a separate PR for that.

## FluentVariable

I've taken the liberty to move `FluentVariable` to `types.js` – that made more sense to me, especially with the expanded list.