### PR TITLE
Make temporal tests locale independent

### DIFF
--- a/fluent-bundle/test/temporal_test.js
+++ b/fluent-bundle/test/temporal_test.js
@@ -47,11 +47,11 @@ suite("Temporal support", function () {
     });
 
     test("direct interpolation", function () {
-      assert.strictEqual(msg("direct"), arg.toLocaleString());
+      assert.strictEqual(msg("direct"), arg.toLocaleString("en-US"));
     });
 
     test("run through DATETIME()", function () {
-      assert.strictEqual(msg("dt"), arg.toLocaleString());
+      assert.strictEqual(msg("dt"), arg.toLocaleString("en-US"));
     });
 
     test("run through DATETIME() with month option", function () {


### PR DESCRIPTION
Currently, the temporal tests assume that the system language is set to `en_US` and break otherwise:

``` console
$ LANG=en_US.UTF-8 npm run test
...
338 passing (64ms)
  2 pending
```

With a different locale

``` console
$ LANG=de npm run test
...
  336 passing (67ms)
  2 pending
  2 failing

  1) Temporal support
       Temporal.Instant
         direct interpolation:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
actual expected

'1/.1/.1970, 01:00:00 AM'

      + expected - actual

      -1/1/1970, 1:00:00 AM
      +1.1.1970, 01:00:00

      at Context.<anonymous> (file:///Users/konstantin/Workspace/rkh/fluent.js/fluent-bundle/test/temporal_test.js:50:14)
      at process.processImmediate (node:internal/timers:511:21)

  2) Temporal support
       Temporal.Instant
         run through DATETIME():

      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
actual expected

'1/.1/.1970, 01:00:00 AM'

      + expected - actual

      -1/1/1970, 1:00:00 AM
      +1.1.1970, 01:00:00

      at Context.<anonymous> (file:///Users/konstantin/Workspace/rkh/fluent.js/fluent-bundle/test/temporal_test.js:54:14)
      at process.processImmediate (node:internal/timers:511:21)
```

This PR fixes the issue by explicitly setting the locale in the tests.