### PR TITLE
Fix typescript types in DOMLocalization

### DIFF
--- a/fluent-dom/src/dom_localization.js
+++ b/fluent-dom/src/dom_localization.js
@@ -120,7 +120,7 @@ export default class DOMLocalization extends Localization {
    * Additionally, if this `DOMLocalization` has an observer, start observing
    * `newRoot` in order to translate mutations in it.
    *
-   * @param {Element}      newRoot - Root to observe.
+   * @param {Element | DocumentFragment}      newRoot - Root to observe.
    */
   connectRoot(newRoot) {
     for (const root of this.roots) {
@@ -158,7 +158,7 @@ export default class DOMLocalization extends Localization {
    * Returns `true` if the root was the last one managed by this
    * `DOMLocalization`.
    *
-   * @param   {Element} root - Root to disconnect.
+   * @param   {Element | DocumentFragment} root - Root to disconnect.
    * @returns {boolean}
    */
   disconnectRoot(root) {
@@ -269,7 +269,7 @@ export default class DOMLocalization extends Localization {
    *
    * Returns a `Promise` that gets resolved once the translation is complete.
    *
-   * @param   {DOMFragment} frag - Element or DocumentFragment to be translated
+   * @param   {Element | DocumentFragment} frag - Element or DocumentFragment to be translated
    * @returns {Promise}
    */
   translateFragment(frag) {
@@ -321,7 +321,7 @@ export default class DOMLocalization extends Localization {
   /**
    * Collects all translatable child elements of the element.
    *
-   * @param {Element} element
+   * @param {Element | DocumentFragment} element
    * @returns {Array<Element>}
    * @private
    */


### PR DESCRIPTION
I noticed some types were not good enough when I started checking the types in firefox' lit-utils file, for example in these lines: https://searchfox.org/mozilla-central/rev/a9e77c69ed8a2b408bbe64553316c7849ec3d267/toolkit/content/widgets/lit-utils.mjs#160,179

Indeed in Lit we're dealing with DocumentFragments more. This works fine in Fluent, only the types aren't correct.